### PR TITLE
Project/solution conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the code converter will be documented here.
 
+## 5.6 - 27/02/2018
+
+### Visual studio extension
+* Works reliably in VS2017
+* Instead of copy to clipboard, opens result as Visual Studio window for quick viewing
+* Opens conversion summary window to explain what's happened
+* Project context used for all conversions
+
+### VB -> C# specific
+* Query expression syntax converted in simple cases
+* Anonymous object creation converted
+* Object initializer syntax converted
+* Converts comments in the majority of cases (though with some formatting oddities)
+* Now works on sub-method snippets
+* Names now fully qualified where necessary
+* Out parameters correctly converted
+
 ## 5.5 - 12/29/2017
 
 * Move from Refactoring Essentials to a repository of its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the code converter will be documented here.
 ### Visual studio extension
 * Works reliably in VS2017
 * Instead of copy to clipboard, opens result as Visual Studio window for quick viewing
-* Opens conversion summary window to explain what's happened
+* Writes summary to output window to explain what's happened
 * Project context used for all conversions
 
 ### VB -> C# specific

--- a/ICSharpCode.CodeConverter/CSharp/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommentConvertingMethodBodyVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;

--- a/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,16 +16,16 @@ namespace ICSharpCode.CodeConverter.CSharp
     public class CommentConvertingNodesVisitor : VisualBasicSyntaxVisitor<CSharpSyntaxNode>
     {
         public TriviaConverter TriviaConverter { get; }
-        private readonly VisualBasicSyntaxVisitor<CSharpSyntaxNode> wrappedVisitor;
+        private readonly VisualBasicSyntaxVisitor<CSharpSyntaxNode> _wrappedVisitor;
 
         public CommentConvertingNodesVisitor(VisualBasicSyntaxVisitor<CSharpSyntaxNode> wrappedVisitor)
         {
             TriviaConverter = new TriviaConverter();
-            this.wrappedVisitor = wrappedVisitor;
+            this._wrappedVisitor = wrappedVisitor;
         }
         public override CSharpSyntaxNode DefaultVisit(SyntaxNode node)
         {
-            return TriviaConverter.PortConvertedTrivia(node, wrappedVisitor.Visit(node));
+            return TriviaConverter.PortConvertedTrivia(node, _wrappedVisitor.Visit(node));
         }
 
         public override CSharpSyntaxNode VisitModuleBlock(VbSyntax.ModuleBlockSyntax node)
@@ -60,7 +61,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         private TDest WithPortedTrivia<TSource, TDest>(SyntaxNode node, Func<TSource, TDest, TDest> portExtraTrivia) where TSource : SyntaxNode where TDest : CSharpSyntaxNode
         {
-            var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)wrappedVisitor.Visit(node));
+            var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)_wrappedVisitor.Visit(node));
             return TriviaConverter.PortConvertedTrivia(node, cSharpSyntaxNode);
         }
 

--- a/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
@@ -39,10 +39,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var refOrOutKeyword = GetRefKeyword(methodSymbol.Parameters[index]);
                     var currentSyntaxKind = nodeToReturn.Arguments[index].Kind();
                     if (!refOrOutKeyword.IsKind(currentSyntaxKind)) {
-                        nodeToReturn = nodeToReturn.ReplaceNode(argument,
-                            SyntaxFactory.Argument(argument.NameColon, refOrOutKeyword, argument.Expression)
-                                .WithLeadingTrivia(argument.GetLeadingTrivia())
-                                .WithTrailingTrivia(argument.GetTrailingTrivia()));
+                        nodeToReturn = nodeToReturn.ReplaceNode(argument, argument.WithRefOrOutKeyword(refOrOutKeyword));
                     }
                 }
             }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -5,15 +5,6 @@ using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using ArgumentListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax;
-using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
-using ExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax;
-using IdentifierNameSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax;
-using LocalDeclarationStatementSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.LocalDeclarationStatementSyntax;
-using StatementSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax;
-using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using SyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
-using TypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax;
 using VBasic = Microsoft.CodeAnalysis.VisualBasic;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
@@ -35,7 +26,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 this.semanticModel = semanticModel;
                 this.nodesVisitor = nodesVisitor;
                 this.withBlockTempVariableNames = withBlockTempVariableNames;
-                this.CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter);
+                CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter);
             }
 
             public override SyntaxList<StatementSyntax> DefaultVisit(SyntaxNode node)
@@ -56,7 +47,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     case VBasic.SyntaxKind.EndKeyword:
                         return "System.Environment.Exit(0);";
                     default:
-                        throw new NotImplementedException(CSharpExtensions.Kind(node.StopOrEndKeyword) + " not implemented!");
+                        throw new NotImplementedException(node.StopOrEndKeyword.Kind() + " not implemented!");
                 }
             }
 
@@ -135,7 +126,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         VBasic.VisualBasicSyntaxNode typeContainer = (VBasic.VisualBasicSyntaxNode)node.Ancestors().OfType<VBSyntax.LambdaExpressionSyntax>().FirstOrDefault()
                             ?? node.Ancestors().OfType<VBSyntax.MethodBlockSyntax>().FirstOrDefault();
                         var info = typeContainer.TypeSwitch(
-                            (VBSyntax.LambdaExpressionSyntax e) => ModelExtensions.GetTypeInfo(semanticModel, e).Type.GetReturnType(),
+                            (VBSyntax.LambdaExpressionSyntax e) => semanticModel.GetTypeInfo(e).Type.GetReturnType(),
                             (VBSyntax.MethodBlockSyntax e) => {
                                 var type = (TypeSyntax)e.SubOrFunctionStatement.AsClause?.Type.Accept(nodesVisitor) ?? SyntaxFactory.ParseTypeName("object");
                                 return semanticModel.GetSymbolInfo(type).Symbol.GetReturnType();
@@ -369,10 +360,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                         foreach (var declaration in SplitVariableDeclarations(v, nodesVisitor, semanticModel).Values.Reverse())
                             stmt = SyntaxFactory.UsingStatement(declaration, null, stmt);
                     return SingleStatement(stmt);
-                } else {
-                    var expr = (ExpressionSyntax)node.UsingStatement.Expression.Accept(nodesVisitor);
-                    return SingleStatement(SyntaxFactory.UsingStatement(null, expr, SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock()));
                 }
+
+                var expr = (ExpressionSyntax)node.UsingStatement.Expression.Accept(nodesVisitor);
+                return SingleStatement(SyntaxFactory.UsingStatement(null, expr, SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock()));
             }
 
             public override SyntaxList<StatementSyntax> VisitWhileBlock(VBSyntax.WhileBlockSyntax node)
@@ -392,11 +383,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                             (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor),
                             SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock()
                         ));
-                    else
-                        return SingleStatement(SyntaxFactory.WhileStatement(
-                            SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor)),
-                            SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock()
-                        ));
+                    return SingleStatement(SyntaxFactory.WhileStatement(
+                        SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor)),
+                        SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock()
+                    ));
                 }
                 if (node.LoopStatement.WhileOrUntilClause != null) {
                     var stmt = node.LoopStatement.WhileOrUntilClause;
@@ -405,11 +395,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                             SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock(),
                             (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor)
                         ));
-                    else
-                        return SingleStatement(SyntaxFactory.DoStatement(
-                            SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock(),
-                            SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor))
-                        ));
+                    return SingleStatement(SyntaxFactory.DoStatement(
+                        SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CommentConvertingVisitor))).UnpackBlock(),
+                        SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, (ExpressionSyntax)stmt.Condition.Accept(nodesVisitor))
+                    ));
                 }
                 throw new NotSupportedException();
             }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -2,33 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using ICSharpCode.CodeConverter.Util;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using ArgumentListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax;
-using ArgumentSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax;
-using ArrayRankSpecifierSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax;
-using ArrayTypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayTypeSyntax;
-using AttributeListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax;
-using CatchFilterClauseSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.CatchFilterClauseSyntax;
-using EnumMemberDeclarationSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.EnumMemberDeclarationSyntax;
-using ExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax;
-using IdentifierNameSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.IdentifierNameSyntax;
-using InterpolatedStringContentSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.InterpolatedStringContentSyntax;
-using NameSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax;
-using ParameterListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax;
-using ParameterSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ParameterSyntax;
-using SimpleNameSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.SimpleNameSyntax;
-using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using SyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
-using SyntaxNodeExtensions = ICSharpCode.CodeConverter.Util.SyntaxNodeExtensions;
-using TypeArgumentListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeArgumentListSyntax;
-using TypeParameterConstraintClauseSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeParameterConstraintClauseSyntax;
-using TypeParameterListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeParameterListSyntax;
-using TypeParameterSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeParameterSyntax;
-using TypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using VBasic = Microsoft.CodeAnalysis.VisualBasic;
 
@@ -48,9 +24,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             public NodesVisitor(SemanticModel semanticModel)
             {
                 this.semanticModel = semanticModel;
-                this.TriviaConvertingVisitor = new CommentConvertingNodesVisitor(this);
+                TriviaConvertingVisitor = new CommentConvertingNodesVisitor(this);
                 importedNamespaces = new Dictionary<string, string> {{VBasic.VisualBasicExtensions.RootNamespace(semanticModel.Compilation).ToString(), ""}};
-                this.createConvertMethodsLookupByReturnType = CreateConvertMethodsLookupByReturnType(semanticModel);
+                createConvertMethodsLookupByReturnType = CreateConvertMethodsLookupByReturnType(semanticModel);
             }
 
             private static Dictionary<ITypeSymbol, string> CreateConvertMethodsLookupByReturnType(SemanticModel semanticModel)
@@ -58,7 +34,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var systemDotConvert = typeof(Convert).FullName;
                 var convertMethods = semanticModel.Compilation.GetTypeByMetadataName(systemDotConvert).GetMembers().Where(m =>
                     m.Name.StartsWith("To", StringComparison.Ordinal) && m.GetParameters().Length == 1);
-                var methodsByType = convertMethods.Where(m => m.Name != nameof(System.Convert.ToBase64String))
+                var methodsByType = convertMethods.Where(m => m.Name != nameof(Convert.ToBase64String))
                     .GroupBy(m => new { ReturnType = m.GetReturnType(), Name = $"{systemDotConvert}.{m.Name}" })
                     .ToDictionary(m => m.Key.ReturnType, m => m.Key.Name);
                 return methodsByType;
@@ -172,8 +148,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var convertedIdentifier = ConvertIdentifier(classStatement.Identifier);
 
                 return SyntaxFactory.ClassDeclaration(
-                    attributes,
-                    ConvertModifiers(classStatement.Modifiers),
+                    attributes, ConvertModifiers(classStatement.Modifiers),
                     convertedIdentifier,
                     parameters,
                     ConvertInheritsAndImplements(node.Inherits, node.Implements),
@@ -351,7 +326,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                             unConvertableModifiers.Any()
                                 ? baseFieldDeclarationSyntax.WithAppendedTrailingTrivia(
                                     SyntaxFactory.Comment(
-                                        $"/* TODO ERROR didn't convert: {string.Join(",", unConvertableModifiers)} */"))
+                                        $"/* TODO ERROR didn't convert: {String.Join(",", unConvertableModifiers)} */"))
                                 : baseFieldDeclarationSyntax);
                     }
                 }
@@ -382,9 +357,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 AccessorListSyntax accessors = null;
                 if (!hasBody) {
-                    var accessorList = new List<AccessorDeclarationSyntax>
-                    {
-                        SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)),
+                    var accessorList = new List<AccessorDeclarationSyntax> {
+                        SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken))
                     };
                     if (!isReadonly) {
                         accessorList.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)));
@@ -574,14 +548,14 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                     additionalDeclarations.Add(node, new MemberDeclarationSyntax[] { delegateDecl });
                     return eventDecl;
-                } else {
-                    return SyntaxFactory.EventFieldDeclaration(
-                        SyntaxFactory.List(attributes),
-                        modifiers,
-                        SyntaxFactory.VariableDeclaration((TypeSyntax)node.AsClause.Type.Accept(TriviaConvertingVisitor),
-                        SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(id)))
-                    );
                 }
+
+                return SyntaxFactory.EventFieldDeclaration(
+                    SyntaxFactory.List(attributes),
+                    modifiers,
+                    SyntaxFactory.VariableDeclaration((TypeSyntax)node.AsClause.Type.Accept(TriviaConvertingVisitor),
+                        SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(id)))
+                );
                 throw new NotSupportedException();
             }
 
@@ -593,8 +567,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return SyntaxFactory.OperatorDeclaration(
                     SyntaxFactory.List(attributes),
                     modifiers,
-                    (TypeSyntax)block.AsClause?.Type.Accept(TriviaConvertingVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
-                    ConvertToken(block.OperatorToken),
+                    (TypeSyntax)block.AsClause?.Type.Accept(TriviaConvertingVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), ConvertToken(block.OperatorToken),
                     (ParameterListSyntax)block.ParameterList.Accept(TriviaConvertingVisitor),
                     SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CreateMethodBodyVisitor()))),
                     null
@@ -867,15 +840,15 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 if (node.Expression.IsKind(VBasic.SyntaxKind.GlobalName)) {
                     return SyntaxFactory.AliasQualifiedName((IdentifierNameSyntax)left, simpleNameSyntax);
-                } else {
-                    var memberAccessExpressionSyntax = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, QualifyNode(node.Expression, left), simpleNameSyntax);
-                    if (semanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol methodSymbol && methodSymbol.ReturnType.Equals(semanticModel.GetTypeInfo(node).ConvertedType)) {
-                        var visitMemberAccessExpression = SyntaxFactory.InvocationExpression(memberAccessExpressionSyntax, SyntaxFactory.ArgumentList());
-                        return visitMemberAccessExpression;
-                    } else {
-                        return memberAccessExpressionSyntax;
-                    }
                 }
+
+                var memberAccessExpressionSyntax = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, QualifyNode(node.Expression, left), simpleNameSyntax);
+                if (semanticModel.GetSymbolInfo(node).Symbol is IMethodSymbol methodSymbol && methodSymbol.ReturnType.Equals(semanticModel.GetTypeInfo(node).ConvertedType)) {
+                    var visitMemberAccessExpression = SyntaxFactory.InvocationExpression(memberAccessExpressionSyntax, SyntaxFactory.ArgumentList());
+                    return visitMemberAccessExpression;
+                }
+
+                return memberAccessExpressionSyntax;
             }
 
             public override CSharpSyntaxNode VisitConditionalAccessExpression(VBSyntax.ConditionalAccessExpressionSyntax node)
@@ -1207,8 +1180,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 );
                 if (node.IsKind(VBasic.SyntaxKind.TypeOfIsNotExpression))
                     return SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, expr);
-                else
-                    return expr;
+                return expr;
             }
 
             public override CSharpSyntaxNode VisitUnaryExpression(VBSyntax.UnaryExpressionSyntax node)

--- a/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
@@ -42,9 +42,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public static async Task<ConversionResult> ConvertSingle(Compilation compilation, SyntaxTree syntaxTree, TextSpan selected)
         {
-            var root = await syntaxTree.GetRootAsync();
             if (selected.Length > 0) {
-                var annotatedSyntaxTree = GetSyntaxTreeWithAnnotatedSelection(root, selected);
+                var annotatedSyntaxTree = await GetSyntaxTreeWithAnnotatedSelection(syntaxTree, selected);
                 compilation = compilation.ReplaceSyntaxTree(syntaxTree, annotatedSyntaxTree);
                 syntaxTree = annotatedSyntaxTree;
             }
@@ -126,11 +125,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             Convert();
         }
 
-        private static SyntaxTree GetSyntaxTreeWithAnnotatedSelection(SyntaxNode root, TextSpan selected)
+        private static async Task<SyntaxTree> GetSyntaxTreeWithAnnotatedSelection(SyntaxTree syntaxTree, TextSpan selected)
         {
+            var root = await syntaxTree.GetRootAsync();
             var selectedNode = root.FindNode(selected);
             var annotatatedNode = selectedNode.WithAdditionalAnnotations(new SyntaxAnnotation(TriviaConverter.SelectedNodeAnnotationKind));
-            return root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree;
+            return root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree.WithFilePath(syntaxTree.FilePath);
         }
 
         private static SyntaxNode GetSelectedNode(SyntaxNode resultNode)

--- a/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,123 +9,147 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.Isam.Esent.Interop;
+using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
     public class ProjectConversion
     {
+        private bool _methodBodyOnly;
+        private VisualBasicCompilation _compilation;
+        private IEnumerable<VisualBasicSyntaxTree> _syntaxTreesToConvert;
         private static readonly AdhocWorkspace AdhocWorkspace = new AdhocWorkspace();
+        private readonly ConcurrentDictionary<string, Exception> _errors = new ConcurrentDictionary<string, Exception>();
+        private readonly Dictionary<string, SyntaxTree> _firstPassResults = new Dictionary<string, SyntaxTree>();
+        private CSharpCompilation _cSharpCompilation;
 
+        private ProjectConversion(VisualBasicCompilation compilation) :this(compilation, compilation.SyntaxTrees.OfType<VisualBasicSyntaxTree>())
+        {
+        }
 
-        public static async Task<ConversionResult> ConvertSingle(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree syntaxTree, TextSpan selected)
+        private ProjectConversion(VisualBasicCompilation compilation, IEnumerable<VisualBasicSyntaxTree> syntaxTreesToConvert)
+        {
+            _compilation = compilation;
+            _syntaxTreesToConvert = syntaxTreesToConvert;
+        }
+
+        public static ConversionResult ConvertText(string text, IReadOnlyCollection<MetadataReference> references)
+        {
+            var visualBasicSyntaxTree = CreateTree(text);
+            var compilation = CreateCompilationFromTree(visualBasicSyntaxTree, references);
+            return ConvertSingle(compilation, visualBasicSyntaxTree, new TextSpan(0, 0)).GetAwaiter().GetResult();
+        }
+
+        public static async Task<ConversionResult> ConvertSingle(VisualBasicCompilation compilation, VisualBasicSyntaxTree syntaxTree, TextSpan selected)
         {
             var root = await syntaxTree.GetRootAsync();
             if (selected.Length > 0) {
                 var annotatedSyntaxTree = GetSyntaxTreeWithAnnotatedSelection(selected, root);
                 compilation = compilation.ReplaceSyntaxTree(syntaxTree, annotatedSyntaxTree);
-                syntaxTree = (Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree) annotatedSyntaxTree;
             }
 
-            try {
-                var cSharpSyntaxNode = ConvertSingleUnhandled(compilation, syntaxTree);
-                var annotatedNode = cSharpSyntaxNode.GetAnnotatedNodes(TriviaConverter.SelectedNodeAnnotationKind).SingleOrDefault();
-                if (annotatedNode != null) cSharpSyntaxNode = (CSharpSyntaxNode) annotatedNode;
-                var formattedNode = Formatter.Format(cSharpSyntaxNode, AdhocWorkspace);
-                return new ConversionResult(formattedNode.ToFullString());
-            } catch (Exception ex) {
-                return new ConversionResult(ex);
-            }
+            var projectConversion = new ProjectConversion(compilation);
+            var resultNode = projectConversion.Convert().Select(r => r.Value).SingleOrDefault();
+            if (resultNode == default(SyntaxNode)) return new ConversionResult(projectConversion._errors.Single().Value);
+
+            var annotatedNode = resultNode.GetAnnotatedNodes(TriviaConverter.SelectedNodeAnnotationKind).SingleOrDefault();
+            if (annotatedNode != null) resultNode = Formatter.Format(annotatedNode, AdhocWorkspace);
+
+            return new ConversionResult(resultNode.ToFullString());
         }
 
         public static async Task ConvertProjects(IEnumerable<Project> projects)
         {
             foreach (var project in projects) {
                 var compilation = await project.GetCompilationAsync();
-                var syntaxTrees = project.Documents
-                    .Where(d => Path.GetExtension(d.FilePath).Equals(".vb", StringComparison.OrdinalIgnoreCase))
-                    .Select(d => d.GetSyntaxTreeAsync().GetAwaiter().GetResult())
-                    .OfType<Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree>();
-                foreach (var pathNodePair in ConvertMultiple((Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation)compilation, syntaxTrees)) {
-                    var formattedNode = Formatter.Format(pathNodePair.Value, AdhocWorkspace);
+                foreach (var pathNodePair in new ProjectConversion((VisualBasicCompilation)compilation).Convert()) {
                     var path = Path.ChangeExtension(pathNodePair.Key, ".cs");
-                    File.WriteAllText(path, formattedNode.ToFullString());
+                    File.WriteAllText(path, pathNodePair.Value.ToFullString());
                 }
             }
         }
 
-        public static ConversionResult ConvertText(string text, IReadOnlyCollection<MetadataReference> references)
+        private Dictionary<string, SyntaxNode> Convert()
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
-            if (references == null)
-                throw new ArgumentNullException(nameof(references));
-            
-            try {
-                var cSharpSyntaxNode = ConvertTextUnhandled(references, text);
-                var formattedNode = Formatter.Format(cSharpSyntaxNode, AdhocWorkspace);
-                return new ConversionResult(formattedNode.ToFullString());
-            } catch (Exception ex) {
-                return new ConversionResult(ex);
+            FirstPass();
+            _cSharpCompilation = CSharpCompilation.Create("Conversion", _firstPassResults.Values, _compilation.References);
+            var secondPassByFilePath = _firstPassResults.ToDictionary(cs => cs.Key, SingleSecondPass);
+            return secondPassByFilePath;
+        }
+
+        private void FirstPass()
+        {
+            foreach (var tree in _syntaxTreesToConvert)
+            {
+                var treeFilePath = tree.FilePath ?? "unknown";
+                try
+                {
+                    SingleFirstPass(tree, treeFilePath);
+                }
+                catch (NotImplementedOrRequiresSurroundingMethodDeclaration)
+                    when (!_methodBodyOnly && _compilation.SyntaxTrees.Length == 1)
+                {
+                    SingleFirstPassSurroundedByClassAndMethod(tree);
+                }
+                catch (Exception e)
+                {
+                    _errors.TryAdd(treeFilePath, e);
+                }
             }
         }
 
-        public static Dictionary<string, CSharpSyntaxNode> ConvertMultiple(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, IEnumerable<Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree> syntaxTrees)
+        private SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
         {
-            var cSharpFirstPass = syntaxTrees.ToDictionary(tree => tree.FilePath ?? "unknown",
-                tree => VisualBasicConverter.ConvertCompilationTree(compilation, tree));
-            var cSharpCompilation = CSharpCompilation.Create("Conversion", cSharpFirstPass.Values, compilation.References);
-            return cSharpFirstPass.ToDictionary(cs => cs.Key, cs => new CompilationErrorFixer(cSharpCompilation, cs.Value).Fix());
+            var secondPassNode = new CompilationErrorFixer(_cSharpCompilation, (CSharpSyntaxTree) cs.Value).Fix();
+            if (_methodBodyOnly) secondPassNode = secondPassNode.DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
+            return Formatter.Format(secondPassNode, AdhocWorkspace);
+        }
+
+        private void SingleFirstPass(VisualBasicSyntaxTree tree, string treeFilePath)
+        {
+            var converted = VisualBasicConverter.ConvertCompilationTree((VisualBasicCompilation) _compilation, tree);
+            _firstPassResults.Add(treeFilePath, SyntaxFactory.SyntaxTree(converted));
+        }
+
+        private void SingleFirstPassSurroundedByClassAndMethod(SyntaxTree tree)
+        {
+            var newTree = CreateTree(WithSurroundingClassAndMethod(tree.GetText().ToString()));
+            _methodBodyOnly = true;
+            _compilation = _compilation.AddSyntaxTrees(newTree);
+            _syntaxTreesToConvert = new[] {newTree};
+            Convert();
+        }
+
+        private static string WithSurroundingClassAndMethod(string text)
+        {
+            return $@"Class SurroundingClass
+Sub SurroundingSub()
+{text}
+End Sub
+End Class";
         }
 
         private static SyntaxTree GetSyntaxTreeWithAnnotatedSelection(TextSpan selected, SyntaxNode root)
         {
             var selectedNode = root.FindNode(selected);
             var annotatatedNode = selectedNode.WithAdditionalAnnotations(new SyntaxAnnotation(TriviaConverter.SelectedNodeAnnotationKind));
-            var syntaxTree = root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree;
-            return syntaxTree;
+            return root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree;
         }
 
-        private static CSharpSyntaxNode ConvertSingleUnhandled(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree syntaxTree)
+        private static VisualBasicSyntaxTree CreateTree(string text)
         {
-            return ConvertMultiple(compilation, new[] {syntaxTree}).Values.Single();
+            return (VisualBasicSyntaxTree) Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
         }
 
-        private static SyntaxNode ConvertTextUnhandled(IReadOnlyCollection<MetadataReference> references, string text)
+        private static VisualBasicCompilation CreateCompilationFromTree(VisualBasicSyntaxTree tree, IEnumerable<MetadataReference> references)
         {
-            try
-            {
-                return ConvertFullTree(references, text);
-            }
-            catch (NotImplementedOrRequiresSurroundingMethodDeclaration) {
-                text =
-                    $@"Class SurroundingClass
-Sub SurroundingSub()
-{text}
-End Sub
-End Class";
-                return ConvertFullTree(references, text).DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
-            }
-        }
-
-        private static SyntaxNode ConvertFullTree(IReadOnlyCollection<MetadataReference> references, string fullTreeText)
-        {
-            var tree = CreateTree(fullTreeText);
-            var compilation = CreateCompilationFromTree(tree, references);
-            return ConvertSingleUnhandled(compilation, tree);
-        }
-
-        private static Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree CreateTree(string text)
-        {
-            return (Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree) Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
-        }
-
-        private static Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation CreateCompilationFromTree(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree tree, IEnumerable<MetadataReference> references)
-        {
-            var compilationOptions = new Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithRootNamespace("TestProject")
-                .WithGlobalImports(Microsoft.CodeAnalysis.VisualBasic.GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
+                .WithGlobalImports(GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
                     "Microsoft.VisualBasic"));
-            var compilation = Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
+            var compilation = VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
                 .WithOptions(compilationOptions);
             return compilation;
         }

--- a/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
@@ -17,38 +17,38 @@ namespace ICSharpCode.CodeConverter.CSharp
     public class ProjectConversion
     {
         private bool _methodBodyOnly;
-        private VisualBasicCompilation _compilation;
-        private IEnumerable<VisualBasicSyntaxTree> _syntaxTreesToConvert;
+        private Compilation _sourceCompilation;
+        private IEnumerable<SyntaxTree> _syntaxTreesToConvert;
         private static readonly AdhocWorkspace AdhocWorkspace = new AdhocWorkspace();
         private readonly ConcurrentDictionary<string, Exception> _errors = new ConcurrentDictionary<string, Exception>();
         private readonly Dictionary<string, SyntaxTree> _firstPassResults = new Dictionary<string, SyntaxTree>();
-        private CSharpCompilation _cSharpCompilation;
+        private Compilation _targetCompilation;
 
-        private ProjectConversion(VisualBasicCompilation compilation, string solutionDir)
-            : this(compilation, compilation.SyntaxTrees.OfType<VisualBasicSyntaxTree>().Where(t => t.FilePath.StartsWith(solutionDir)))
+        private ProjectConversion(Compilation sourceCompilation, string solutionDir)
+            : this(sourceCompilation, sourceCompilation.SyntaxTrees.Where(t => t.FilePath.StartsWith(solutionDir)))
         {
         }
 
-        private ProjectConversion(VisualBasicCompilation compilation, IEnumerable<VisualBasicSyntaxTree> syntaxTreesToConvert)
+        private ProjectConversion(Compilation sourceCompilation, IEnumerable<SyntaxTree> syntaxTreesToConvert)
         {
-            _compilation = compilation;
+            _sourceCompilation = sourceCompilation;
             _syntaxTreesToConvert = syntaxTreesToConvert;
         }
 
         public static ConversionResult ConvertText(string text, IReadOnlyCollection<MetadataReference> references)
         {
-            var visualBasicSyntaxTree = CreateTree(text);
-            var compilation = CreateCompilationFromTree(visualBasicSyntaxTree, references);
-            return ConvertSingle(compilation, visualBasicSyntaxTree, new TextSpan(0, 0)).GetAwaiter().GetResult();
+            var syntaxTree = CreateTree(text);
+            var compilation = CreateCompilationFromTree(syntaxTree, references);
+            return ConvertSingle(compilation, syntaxTree, new TextSpan(0, 0)).GetAwaiter().GetResult();
         }
 
-        public static async Task<ConversionResult> ConvertSingle(VisualBasicCompilation compilation, VisualBasicSyntaxTree syntaxTree, TextSpan selected)
+        public static async Task<ConversionResult> ConvertSingle(Compilation compilation, SyntaxTree syntaxTree, TextSpan selected)
         {
             var root = await syntaxTree.GetRootAsync();
             if (selected.Length > 0) {
                 var annotatedSyntaxTree = GetSyntaxTreeWithAnnotatedSelection(selected, root);
                 compilation = compilation.ReplaceSyntaxTree(syntaxTree, annotatedSyntaxTree);
-                syntaxTree = (VisualBasicSyntaxTree) annotatedSyntaxTree;
+                syntaxTree = annotatedSyntaxTree;
             }
 
             var conversion = new ProjectConversion(compilation, new [] {syntaxTree});
@@ -68,7 +68,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var solutionDir = Path.GetDirectoryName(projects.First().Solution.FilePath);
             foreach (var project in projects) {
                 var compilation = project.GetCompilationAsync().GetAwaiter().GetResult();
-                var projectConversion = new ProjectConversion((VisualBasicCompilation)compilation, solutionDir);
+                var projectConversion = new ProjectConversion(compilation, solutionDir);
                 foreach (var pathNodePair in projectConversion.Convert()) {
                     yield return new ConversionResult(pathNodePair.Value.ToFullString()) {SourcePathOrNull = pathNodePair.Key};
                 }
@@ -84,7 +84,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         private Dictionary<string, SyntaxNode> Convert()
         {
             FirstPass();
-            _cSharpCompilation = CSharpCompilation.Create("Conversion", _firstPassResults.Values, _compilation.References);
+            _targetCompilation = CSharpCompilation.Create("Conversion", _firstPassResults.Values, _sourceCompilation.References);
             var secondPassByFilePath = _firstPassResults.ToDictionary(cs => cs.Key, SingleSecondPass);
             return secondPassByFilePath;
         }
@@ -99,7 +99,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     SingleFirstPass(tree, treeFilePath);
                 }
                 catch (NotImplementedOrRequiresSurroundingMethodDeclaration)
-                    when (!_methodBodyOnly && _compilation.SyntaxTrees.Length == 1)
+                    when (!_methodBodyOnly && _sourceCompilation.SyntaxTrees.Count() == 1)
                 {
                     SingleFirstPassSurroundedByClassAndMethod(tree);
                 }
@@ -110,35 +110,13 @@ namespace ICSharpCode.CodeConverter.CSharp
             }
         }
 
-        private SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
-        {
-            var secondPassNode = new CompilationErrorFixer(_cSharpCompilation, (CSharpSyntaxTree) cs.Value).Fix();
-            if (_methodBodyOnly) secondPassNode = secondPassNode.DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
-            return Formatter.Format(secondPassNode, AdhocWorkspace);
-        }
-
-        private void SingleFirstPass(VisualBasicSyntaxTree tree, string treeFilePath)
-        {
-            var converted = VisualBasicConverter.ConvertCompilationTree(_compilation, tree);
-            _firstPassResults.Add(treeFilePath, SyntaxFactory.SyntaxTree(converted));
-        }
-
         private void SingleFirstPassSurroundedByClassAndMethod(SyntaxTree tree)
         {
             var newTree = CreateTree(WithSurroundingClassAndMethod(tree.GetText().ToString()));
             _methodBodyOnly = true;
-            _compilation = _compilation.AddSyntaxTrees(newTree);
+            _sourceCompilation = _sourceCompilation.AddSyntaxTrees(newTree);
             _syntaxTreesToConvert = new[] {newTree};
             Convert();
-        }
-
-        private static string WithSurroundingClassAndMethod(string text)
-        {
-            return $@"Class SurroundingClass
-Sub SurroundingSub()
-{text}
-End Sub
-End Class";
         }
 
         private static SyntaxTree GetSyntaxTreeWithAnnotatedSelection(TextSpan selected, SyntaxNode root)
@@ -154,12 +132,34 @@ End Class";
             return annotatedNode == null ? resultNode : Formatter.Format(annotatedNode, AdhocWorkspace);
         }
 
-        private static VisualBasicSyntaxTree CreateTree(string text)
+        private void SingleFirstPass(SyntaxTree tree, string treeFilePath)
         {
-            return (VisualBasicSyntaxTree) Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+            var converted = VisualBasicConverter.ConvertCompilationTree((VisualBasicCompilation)_sourceCompilation, (VisualBasicSyntaxTree)tree);
+            _firstPassResults.Add(treeFilePath, SyntaxFactory.SyntaxTree(converted));
         }
 
-        private static VisualBasicCompilation CreateCompilationFromTree(VisualBasicSyntaxTree tree, IEnumerable<MetadataReference> references)
+        private SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
+        {
+            var secondPassNode = new CompilationErrorFixer((CSharpCompilation)_targetCompilation, (CSharpSyntaxTree)cs.Value).Fix();
+            if (_methodBodyOnly) secondPassNode = secondPassNode.DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
+            return Formatter.Format(secondPassNode, AdhocWorkspace);
+        }
+
+        private static string WithSurroundingClassAndMethod(string text)
+        {
+            return $@"Class SurroundingClass
+Sub SurroundingSub()
+{text}
+End Sub
+End Class";
+        }
+
+        private static SyntaxTree CreateTree(string text)
+        {
+            return Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+        }
+
+        private static Compilation CreateCompilationFromTree(SyntaxTree tree, IEnumerable<MetadataReference> references)
         {
             var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithRootNamespace("TestProject")

--- a/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ProjectConversion.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public class ProjectConversion
+    {
+        private static readonly AdhocWorkspace AdhocWorkspace = new AdhocWorkspace();
+
+
+        public static async Task<ConversionResult> ConvertSingle(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree syntaxTree, TextSpan selected)
+        {
+            var root = await syntaxTree.GetRootAsync();
+            if (selected.Length > 0) {
+                var annotatedSyntaxTree = GetSyntaxTreeWithAnnotatedSelection(selected, root);
+                compilation = compilation.ReplaceSyntaxTree(syntaxTree, annotatedSyntaxTree);
+                syntaxTree = (Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree) annotatedSyntaxTree;
+            }
+
+            try {
+                var cSharpSyntaxNode = ConvertSingleUnhandled(compilation, syntaxTree);
+                var annotatedNode = cSharpSyntaxNode.GetAnnotatedNodes(TriviaConverter.SelectedNodeAnnotationKind).SingleOrDefault();
+                if (annotatedNode != null) cSharpSyntaxNode = (CSharpSyntaxNode) annotatedNode;
+                var formattedNode = Formatter.Format(cSharpSyntaxNode, AdhocWorkspace);
+                return new ConversionResult(formattedNode.ToFullString());
+            } catch (Exception ex) {
+                return new ConversionResult(ex);
+            }
+        }
+
+        public static async Task ConvertProjects(IEnumerable<Project> projects)
+        {
+            foreach (var project in projects) {
+                var compilation = await project.GetCompilationAsync();
+                var syntaxTrees = project.Documents
+                    .Where(d => Path.GetExtension(d.FilePath).Equals(".vb", StringComparison.OrdinalIgnoreCase))
+                    .Select(d => d.GetSyntaxTreeAsync().GetAwaiter().GetResult())
+                    .OfType<Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree>();
+                foreach (var pathNodePair in ConvertMultiple((Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation)compilation, syntaxTrees)) {
+                    var formattedNode = Formatter.Format(pathNodePair.Value, AdhocWorkspace);
+                    var path = Path.ChangeExtension(pathNodePair.Key, ".cs");
+                    File.WriteAllText(path, formattedNode.ToFullString());
+                }
+            }
+        }
+
+        public static ConversionResult ConvertText(string text, IReadOnlyCollection<MetadataReference> references)
+        {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+            if (references == null)
+                throw new ArgumentNullException(nameof(references));
+            
+            try {
+                var cSharpSyntaxNode = ConvertTextUnhandled(references, text);
+                var formattedNode = Formatter.Format(cSharpSyntaxNode, AdhocWorkspace);
+                return new ConversionResult(formattedNode.ToFullString());
+            } catch (Exception ex) {
+                return new ConversionResult(ex);
+            }
+        }
+
+        public static Dictionary<string, CSharpSyntaxNode> ConvertMultiple(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, IEnumerable<Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree> syntaxTrees)
+        {
+            var cSharpFirstPass = syntaxTrees.ToDictionary(tree => tree.FilePath ?? "unknown",
+                tree => VisualBasicConverter.ConvertCompilationTree(compilation, tree));
+            var cSharpCompilation = CSharpCompilation.Create("Conversion", cSharpFirstPass.Values, compilation.References);
+            return cSharpFirstPass.ToDictionary(cs => cs.Key, cs => new CompilationErrorFixer(cSharpCompilation, cs.Value).Fix());
+        }
+
+        private static SyntaxTree GetSyntaxTreeWithAnnotatedSelection(TextSpan selected, SyntaxNode root)
+        {
+            var selectedNode = root.FindNode(selected);
+            var annotatatedNode = selectedNode.WithAdditionalAnnotations(new SyntaxAnnotation(TriviaConverter.SelectedNodeAnnotationKind));
+            var syntaxTree = root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree;
+            return syntaxTree;
+        }
+
+        private static CSharpSyntaxNode ConvertSingleUnhandled(Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation compilation, Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree syntaxTree)
+        {
+            return ConvertMultiple(compilation, new[] {syntaxTree}).Values.Single();
+        }
+
+        private static SyntaxNode ConvertTextUnhandled(IReadOnlyCollection<MetadataReference> references, string text)
+        {
+            try
+            {
+                return ConvertFullTree(references, text);
+            }
+            catch (NotImplementedOrRequiresSurroundingMethodDeclaration) {
+                text =
+                    $@"Class SurroundingClass
+Sub SurroundingSub()
+{text}
+End Sub
+End Class";
+                return ConvertFullTree(references, text).DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
+            }
+        }
+
+        private static SyntaxNode ConvertFullTree(IReadOnlyCollection<MetadataReference> references, string fullTreeText)
+        {
+            var tree = CreateTree(fullTreeText);
+            var compilation = CreateCompilationFromTree(tree, references);
+            return ConvertSingleUnhandled(compilation, tree);
+        }
+
+        private static Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree CreateTree(string text)
+        {
+            return (Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree) Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+        }
+
+        private static Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation CreateCompilationFromTree(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTree tree, IEnumerable<MetadataReference> references)
+        {
+            var compilationOptions = new Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithRootNamespace("TestProject")
+                .WithGlobalImports(Microsoft.CodeAnalysis.VisualBasic.GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
+                    "Microsoft.VisualBasic"));
+            var compilation = Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
+                .WithOptions(compilationOptions);
+            return compilation;
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public class VBToCSConversion : ILanguageConversion
+    {
+        private Compilation _sourceCompilation;
+        private readonly List<SyntaxTree> _firstPassResults = new List<SyntaxTree>();
+        private readonly Lazy<CSharpCompilation> _targetCompilation;
+
+        public VBToCSConversion()
+        {
+            _targetCompilation = new Lazy<CSharpCompilation>(() => CSharpCompilation.Create("Conversion", _firstPassResults, _sourceCompilation.References));
+        }
+
+        public SyntaxTree SingleFirstPass(Compilation sourceCompilation, SyntaxTree tree)
+        {
+            _sourceCompilation = sourceCompilation;
+            var converted = VisualBasicConverter.ConvertCompilationTree((VisualBasicCompilation)sourceCompilation, (VisualBasicSyntaxTree)tree);
+            var convertedTree = SyntaxFactory.SyntaxTree(converted);
+            _firstPassResults.Add(convertedTree);
+            return convertedTree;
+        }
+
+        public SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
+        {
+            return new CompilationErrorFixer(_targetCompilation.Value, (CSharpSyntaxTree)cs.Value).Fix();
+        }
+
+        public string WithSurroundingClassAndMethod(string text)
+        {
+            return $@"Class SurroundingClass
+Sub SurroundingSub()
+{text}
+End Sub
+End Class";
+        }
+
+        public SyntaxNode RemoveSurroundingClassAndMethod(SyntaxNode secondPassNode)
+        {
+            return secondPassNode.DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
+        }
+
+        public SyntaxTree CreateTree(string text)
+        {
+            return Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+        }
+
+        public Compilation CreateCompilationFromTree(SyntaxTree tree, IEnumerable<MetadataReference> references)
+        {
+            var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithRootNamespace("TestProject")
+                .WithGlobalImports(GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
+                    "Microsoft.VisualBasic"));
+            var compilation = VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
+                .WithOptions(compilationOptions);
+            return compilation;
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
@@ -24,11 +24,10 @@ namespace ICSharpCode.CodeConverter.CSharp
 {
     public partial class VisualBasicConverter
     {
-        public static CSharpSyntaxTree ConvertCompilationTree(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree tree)
+        public static CSharpSyntaxNode ConvertCompilationTree(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree tree)
         {
             var visualBasicSyntaxVisitor = new VisualBasicConverter.NodesVisitor(compilation.GetSemanticModel(tree, true));
-            return (CSharpSyntaxTree)SyntaxFactory.SyntaxTree(tree.GetRoot()
-                .Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor));
+            return tree.GetRoot().Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
         }
 
         enum TokenContext

--- a/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
@@ -24,6 +24,13 @@ namespace ICSharpCode.CodeConverter.CSharp
 {
     public partial class VisualBasicConverter
     {
+        public static CSharpSyntaxTree ConvertCompilationTree(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree tree)
+        {
+            var visualBasicSyntaxVisitor = new VisualBasicConverter.NodesVisitor(compilation.GetSemanticModel(tree, true));
+            return (CSharpSyntaxTree)SyntaxFactory.SyntaxTree(tree.GetRoot()
+                .Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor));
+        }
+
         enum TokenContext
         {
             Global,
@@ -35,126 +42,6 @@ namespace ICSharpCode.CodeConverter.CSharp
             MemberInClass,
             MemberInStruct,
             MemberInInterface
-        }
-
-        public static async Task<ConversionResult> ConvertSingle(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree syntaxTree, TextSpan selected)
-        {
-            var root = await syntaxTree.GetRootAsync();
-            if (selected.Length > 0) {
-                var annotatedSyntaxTree = GetSyntaxTreeWithAnnotatedSelection(selected, root);
-                compilation = compilation.ReplaceSyntaxTree(syntaxTree, annotatedSyntaxTree);
-                syntaxTree = (VBasic.VisualBasicSyntaxTree) annotatedSyntaxTree;
-            }
-
-            try {
-                var cSharpSyntaxNode = ConvertSingleUnhandled(compilation, syntaxTree);
-                var annotatedNode = cSharpSyntaxNode.GetAnnotatedNodes(TriviaConverter.SelectedNodeAnnotationKind).SingleOrDefault();
-                if (annotatedNode != null) cSharpSyntaxNode = (CSharpSyntaxNode) annotatedNode;
-                var formattedNode = Formatter.Format(cSharpSyntaxNode, new AdhocWorkspace());
-                return new ConversionResult(formattedNode.ToFullString());
-            } catch (Exception ex) {
-                return new ConversionResult(ex);
-            }
-        }
-
-        private static SyntaxTree GetSyntaxTreeWithAnnotatedSelection(TextSpan selected, SyntaxNode root)
-        {
-            var selectedNode = root.FindNode(selected);
-            var annotatatedNode = selectedNode.WithAdditionalAnnotations(new SyntaxAnnotation(TriviaConverter.SelectedNodeAnnotationKind));
-            var syntaxTree = root.ReplaceNode(selectedNode, annotatatedNode).SyntaxTree;
-            return syntaxTree;
-        }
-
-        public static async Task ConvertProjects(IEnumerable<Project> projects)
-        {
-            foreach (var project in projects) {
-                var compilation = await project.GetCompilationAsync();
-                var syntaxTrees = project.Documents
-                    .Where(d => Path.GetExtension(d.FilePath).Equals(".vb", StringComparison.OrdinalIgnoreCase))
-                    .Select(d => d.GetSyntaxTreeAsync().GetAwaiter().GetResult())
-                    .OfType<VBasic.VisualBasicSyntaxTree>();
-                foreach (var pathNodePair in ConvertMultiple((VBasic.VisualBasicCompilation)compilation, syntaxTrees)) {
-                    var formattedNode = Formatter.Format(pathNodePair.Value, new AdhocWorkspace());
-                    var path = Path.ChangeExtension(pathNodePair.Key, ".cs");
-                    File.WriteAllText(path, formattedNode.ToFullString());
-                }
-            }
-        }
-
-        public static Dictionary<string, CSharpSyntaxNode> ConvertMultiple(VBasic.VisualBasicCompilation compilation, IEnumerable<VBasic.VisualBasicSyntaxTree> syntaxTrees)
-        {
-            var cSharpFirstPass = syntaxTrees.ToDictionary(tree => tree.FilePath ?? "unknown",
-                tree => ConvertCompilationTree(compilation, tree));
-            var cSharpCompilation = CSharpCompilation.Create("Conversion", cSharpFirstPass.Values, compilation.References);
-            return cSharpFirstPass.ToDictionary(cs => cs.Key, cs => new CompilationErrorFixer(cSharpCompilation, cs.Value).Fix());
-        }
-
-        private static CSharpSyntaxNode ConvertSingleUnhandled(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree syntaxTree)
-        {
-            return ConvertMultiple(compilation, new[] {syntaxTree}).Values.Single();
-        }
-
-        private static CSharpSyntaxTree ConvertCompilationTree(VBasic.VisualBasicCompilation compilation, VBasic.VisualBasicSyntaxTree tree)
-        {
-            var visualBasicSyntaxVisitor = new NodesVisitor(compilation.GetSemanticModel(tree, true));
-            return (CSharpSyntaxTree) SyntaxFactory.SyntaxTree(tree.GetRoot()
-                .Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor));
-        }
-
-        public static ConversionResult ConvertText(string text, IReadOnlyCollection<MetadataReference> references)
-        {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
-            if (references == null)
-                throw new ArgumentNullException(nameof(references));
-
-            try {
-                var cSharpSyntaxNode = ConvertTextUnhandled(references, text);
-                var formattedNode = Formatter.Format(cSharpSyntaxNode, new AdhocWorkspace());
-                return new ConversionResult(formattedNode.ToFullString());
-            } catch (Exception ex) {
-                return new ConversionResult(ex);
-            }
-        }
-
-        private static SyntaxNode ConvertTextUnhandled(IReadOnlyCollection<MetadataReference> references, string text)
-        {
-            try
-            {
-                return ConvertFullTree(references, text);
-            }
-            catch (NotImplementedOrRequiresSurroundingMethodDeclaration) {
-                text =
-$@"Class SurroundingClass
-Sub SurroundingSub()
-{text}
-End Sub
-End Class";
-                return ConvertFullTree(references, text).DescendantNodes().OfType<MethodDeclarationSyntax>().First().Body;
-            }
-        }
-
-        private static SyntaxNode ConvertFullTree(IReadOnlyCollection<MetadataReference> references, string fullTreeText)
-        {
-            var tree = CreateTree(fullTreeText);
-            var compilation = CreateCompilationFromTree(tree, references);
-            return ConvertSingleUnhandled(compilation, tree);
-        }
-
-        private static VBasic.VisualBasicSyntaxTree CreateTree(string text)
-        {
-            return (VBasic.VisualBasicSyntaxTree) VBasic.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
-        }
-
-        private static VBasic.VisualBasicCompilation CreateCompilationFromTree(VBasic.VisualBasicSyntaxTree tree, IEnumerable<MetadataReference> references)
-        {
-            var compilationOptions = new VBasic.VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithRootNamespace("TestProject")
-                .WithGlobalImports(VBasic.GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
-                    "Microsoft.VisualBasic"));
-            var compilation = VBasic.VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
-                .WithOptions(compilationOptions);
-            return compilation;
         }
 
         static Dictionary<string, VariableDeclarationSyntax> SplitVariableDeclarations(VBSyntax.VariableDeclaratorSyntax declarator, VBasic.VisualBasicSyntaxVisitor<CSharpSyntaxNode> nodesVisitor, SemanticModel semanticModel)
@@ -245,7 +132,7 @@ End Class";
                 return SyntaxFactory.Identifier("@" + text);
             if (id.SyntaxTree == semanticModel.SyntaxTree) {
                 var symbol = semanticModel.GetSymbolInfo(id.Parent).Symbol;
-                if (symbol != null && !string.IsNullOrWhiteSpace(symbol.Name)) {
+                if (symbol != null && !String.IsNullOrWhiteSpace(symbol.Name)) {
                     if (symbol.IsConstructor() && isAttribute) {
                         text = symbol.ContainingType.Name;
                         if (text.EndsWith("Attribute", StringComparison.Ordinal))

--- a/ICSharpCode.CodeConverter/CodeConverter.cs
+++ b/ICSharpCode.CodeConverter/CodeConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.VB;
 
 namespace ICSharpCode.CodeConverter

--- a/ICSharpCode.CodeConverter/CodeConverter.cs
+++ b/ICSharpCode.CodeConverter/CodeConverter.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.CodeConverter
                 case "Visual Basic":
                     switch (code.ToLanguage) {
                         case "C#":
-                            return VisualBasicConverter.ConvertText(code.Text, code.References);
+                            return ProjectConversion.ConvertText(code.Text, code.References);
                     }
                     break;
 

--- a/ICSharpCode.CodeConverter/CodeConverter.cs
+++ b/ICSharpCode.CodeConverter/CodeConverter.cs
@@ -20,7 +20,7 @@ namespace ICSharpCode.CodeConverter
                 case "C#":
                     switch (code.ToLanguage) {
                         case "Visual Basic":
-                            return CSharpConverter.ConvertText(code.Text, code.References);
+                            return ProjectConversion<CSToVBConversion>.ConvertText(code.Text, code.References);
                     }
                     break;
                 case "Visual Basic":

--- a/ICSharpCode.CodeConverter/CodeConverter.cs
+++ b/ICSharpCode.CodeConverter/CodeConverter.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.CodeConverter
                 case "Visual Basic":
                     switch (code.ToLanguage) {
                         case "C#":
-                            return ProjectConversion.ConvertText(code.Text, code.References);
+                            return ProjectConversion<VBToCSConversion>.ConvertText(code.Text, code.References);
                     }
                     break;
 

--- a/ICSharpCode.CodeConverter/CodeWithOptions.cs
+++ b/ICSharpCode.CodeConverter/CodeWithOptions.cs
@@ -8,15 +8,19 @@ namespace ICSharpCode.CodeConverter
 {
     public class CodeWithOptions
     {
+        public static readonly IReadOnlyCollection<MetadataReference> DefaultMetadataReferences = new List<MetadataReference>(new[] {
+            MetadataReference.CreateFromFile(typeof(Action).GetAssemblyLocation()),
+            MetadataReference.CreateFromFile(typeof(System.ComponentModel.EditorBrowsableAttribute).GetAssemblyLocation()),
+            MetadataReference.CreateFromFile(typeof(Enumerable).GetAssemblyLocation())
+        });
+
         public string Text { get; private set; }
         public string FromLanguage { get; private set; }
         public int FromLanguageVersion { get; private set; }
         public string ToLanguage { get; private set; }
         public int ToLanguageVersion { get; private set; }
 
-        List<MetadataReference> references;
-
-        public MetadataReference[] References => references.ToArray();
+        public IReadOnlyCollection<MetadataReference> References { get; set; } = new List<MetadataReference>();
 
         public CodeWithOptions(string text)
         {
@@ -25,7 +29,6 @@ namespace ICSharpCode.CodeConverter
             ToLanguage = LanguageNames.VisualBasic;
             FromLanguageVersion = 6;
             ToLanguageVersion = 14;
-            references = new List<MetadataReference>();
         }
 
         public CodeWithOptions SetFromLanguage(string name = LanguageNames.CSharp, int version = 6)
@@ -44,11 +47,7 @@ namespace ICSharpCode.CodeConverter
 
         public CodeWithOptions WithDefaultReferences()
         {
-            references = new List<MetadataReference>(new[] {
-                MetadataReference.CreateFromFile(typeof(Action).GetAssemblyLocation()),
-                MetadataReference.CreateFromFile(typeof(System.ComponentModel.EditorBrowsableAttribute).GetAssemblyLocation()),
-                MetadataReference.CreateFromFile(typeof(Enumerable).GetAssemblyLocation())
-            });
+            References = DefaultMetadataReferences;
             return this;
         }
     }

--- a/ICSharpCode.CodeConverter/CodeWithOptions.cs
+++ b/ICSharpCode.CodeConverter/CodeWithOptions.cs
@@ -20,7 +20,7 @@ namespace ICSharpCode.CodeConverter
 
         public CodeWithOptions(string text)
         {
-            Text = text;
+            Text = text ?? throw new ArgumentNullException(nameof(text));
             FromLanguage = LanguageNames.CSharp;
             ToLanguage = LanguageNames.VisualBasic;
             FromLanguageVersion = 6;

--- a/ICSharpCode.CodeConverter/ConversionResult.cs
+++ b/ICSharpCode.CodeConverter/ConversionResult.cs
@@ -18,7 +18,7 @@ namespace ICSharpCode.CodeConverter
 
         public ConversionResult(string convertedCode)
         {
-            Success = !String.IsNullOrWhiteSpace(convertedCode);
+            Success = true;
             ConvertedCode = convertedCode;
         }
 
@@ -34,12 +34,12 @@ namespace ICSharpCode.CodeConverter
                 return String.Empty;
 
             var builder = new StringBuilder();
+            if (SourcePathOrNull != null) {
+                builder.AppendLine($"In '{SourcePathOrNull}':");
+            }
             for (int i = 0; i < Exceptions.Count; i++) {
                 if (Exceptions.Count > 1) {
                     builder.AppendFormat("----- Exception {0} of {1} -----" + Environment.NewLine, i + 1, Exceptions.Count);
-                }
-                if (SourcePathOrNull != null) {
-                    builder.AppendLine($"In '{SourcePathOrNull}':");
                 }
                 builder.AppendLine(Exceptions[i].ToString());
             }

--- a/ICSharpCode.CodeConverter/ConversionResult.cs
+++ b/ICSharpCode.CodeConverter/ConversionResult.cs
@@ -6,14 +6,19 @@ namespace ICSharpCode.CodeConverter
 {
     public class ConversionResult
     {
+        private string _sourcePathOrNull;
         public bool Success { get; private set; }
         public string ConvertedCode { get; private set; }
         public IReadOnlyList<Exception> Exceptions { get; private set; }
-        public string SourcePathOrNull { get; set; }
+
+        public string SourcePathOrNull {
+            get => _sourcePathOrNull;
+            set => _sourcePathOrNull = string.IsNullOrWhiteSpace(value) ? null : value;
+        }
 
         public ConversionResult(string convertedCode)
         {
-            Success = !string.IsNullOrWhiteSpace(convertedCode);
+            Success = !String.IsNullOrWhiteSpace(convertedCode);
             ConvertedCode = convertedCode;
         }
 
@@ -26,11 +31,16 @@ namespace ICSharpCode.CodeConverter
         public string GetExceptionsAsString()
         {
             if (Exceptions == null || Exceptions.Count == 0)
-                return string.Empty;
+                return String.Empty;
 
             var builder = new StringBuilder();
             for (int i = 0; i < Exceptions.Count; i++) {
-                builder.AppendFormat("----- Exception {0} of {1} -----" + Environment.NewLine, i + 1, Exceptions.Count);
+                if (Exceptions.Count > 1) {
+                    builder.AppendFormat("----- Exception {0} of {1} -----" + Environment.NewLine, i + 1, Exceptions.Count);
+                }
+                if (SourcePathOrNull != null) {
+                    builder.AppendLine($"In '{SourcePathOrNull}':");
+                }
                 builder.AppendLine(Exceptions[i].ToString());
             }
             return builder.ToString();

--- a/ICSharpCode.CodeConverter/ConversionResult.cs
+++ b/ICSharpCode.CodeConverter/ConversionResult.cs
@@ -9,6 +9,7 @@ namespace ICSharpCode.CodeConverter
         public bool Success { get; private set; }
         public string ConvertedCode { get; private set; }
         public IReadOnlyList<Exception> Exceptions { get; private set; }
+        public string SourcePathOrNull { get; set; }
 
         public ConversionResult(string convertedCode)
         {

--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
@@ -35,4 +35,9 @@
   <ItemGroup Condition="'$(SignAssembly)'=='True'">
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Esent.Interop">
+      <HintPath>..\packages\ManagedEsent.1.9.4\lib\net40\Esent.Interop.dll</HintPath>
+    </Reference>
+  </ItemGroup>
 </Project>

--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
@@ -8,9 +8,9 @@
     <Description>This Roslyn-based code converter was previously part of Refactoring Essentials. It has been teased out to be able to evolve separately and faster than the analyzers/refactorings. Conversion from C# to VB.NET, as well as from VB.NET to C# are included.</Description>
     <Product>Code Converter for C# to/from VB.NET</Product>
     <Copyright>Copyright (c) 2014-2017 AlphaSierraPapa</Copyright>
-    <AssemblyVersion>5.5.0.0</AssemblyVersion>
-    <FileVersion>5.5.0.0</FileVersion>
-    <Version>5.5.0</Version>
+    <AssemblyVersion>5.6.0.0</AssemblyVersion>
+    <FileVersion>5.6.0.0</FileVersion>
+    <Version>5.6.0</Version>
     <PackageId>ICSharpCode.CodeConverter</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/icsharpcode/CodeConverter/blob/master/LICENSE</PackageLicenseUrl>

--- a/ICSharpCode.CodeConverter/ILanguageConversion.cs
+++ b/ICSharpCode.CodeConverter/ILanguageConversion.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public interface ILanguageConversion
+    {
+        SyntaxTree SingleFirstPass(Compilation sourceCompilation, SyntaxTree tree);
+        SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs);
+        string WithSurroundingClassAndMethod(string text);
+        SyntaxTree CreateTree(string text);
+        Compilation CreateCompilationFromTree(SyntaxTree tree, IEnumerable<MetadataReference> references);
+        SyntaxNode RemoveSurroundingClassAndMethod(SyntaxNode secondPassNode);
+    }
+}

--- a/ICSharpCode.CodeConverter/Shared/NotImplementedOrRequiresSurroundingMethodDeclaration.cs
+++ b/ICSharpCode.CodeConverter/Shared/NotImplementedOrRequiresSurroundingMethodDeclaration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace ICSharpCode.CodeConverter.CSharp
+namespace ICSharpCode.CodeConverter.Shared
 {
     internal class NotImplementedOrRequiresSurroundingMethodDeclaration : NotImplementedException
     {

--- a/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
@@ -4,11 +4,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.CSharp;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 
-namespace ICSharpCode.CodeConverter.CSharp
+namespace ICSharpCode.CodeConverter.Shared
 {
     public class ProjectConversion<TLanguageConversion> where TLanguageConversion : ILanguageConversion, new()
     {

--- a/ICSharpCode.CodeConverter/Shared/TriviaConverter.cs
+++ b/ICSharpCode.CodeConverter/Shared/TriviaConverter.cs
@@ -29,16 +29,19 @@ namespace ICSharpCode.CodeConverter.Shared
         {
             if (destination == null || sourceNode == null) return destination;
 
+            destination = WithAnnotations(sourceNode, destination);
+
+            if (sourceNode is CSharpSyntaxNode) return destination;
+
             destination = sourceNode.HasLeadingTrivia
                 ? destination.WithLeadingTrivia(sourceNode.GetLeadingTrivia().ConvertTrivia())
                 : destination;
-            
+
             if (sourceNode.HasTrailingTrivia) {
                 var lastDestToken = destination.GetLastToken();
                 destination = destination.ReplaceToken(lastDestToken, WithDelegateToParentAnnotation(sourceNode, lastDestToken));
             }
 
-            destination = WithAnnotations(sourceNode, destination);
 
             var firstLineOfBlockConstruct = sourceNode.ChildNodes().OfType<VBSyntax.StatementSyntax>().FirstOrDefault(IsFirstLineOfBlockConstruct);
             if (firstLineOfBlockConstruct != null) {

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -8,7 +8,9 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using VBSyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
 using VBSyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
+using CSSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -842,10 +844,10 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static IEnumerable<SyntaxTrivia> ConvertTrivia(this IReadOnlyCollection<SyntaxTrivia> triviaToConvert)
         {
-            return triviaToConvert.Select(ConvertTrivia).Where(x => x != default(SyntaxTrivia));
+            return triviaToConvert.Select(t => t.Language == "Visual Basic" ? ConvertVBTrivia(t) : ConvertCSTrivia(t)).Where(x => x != default(SyntaxTrivia));
         }
 
-        private static SyntaxTrivia ConvertTrivia(SyntaxTrivia t)
+        private static SyntaxTrivia ConvertVBTrivia(SyntaxTrivia t)
         {
             if (t.IsKind(VBSyntaxKind.CommentTrivia))
                 return SyntaxFactory.SyntaxTrivia(SyntaxKind.SingleLineCommentTrivia, $"// {t.GetCommentText()}");
@@ -872,29 +874,44 @@ namespace ICSharpCode.CodeConverter.Util
             }
 
             //Each of these would need its own method to recreate for C# with the right structure probably so let's just warn about them for now.
-            var syntaxKinds = new Dictionary<VBSyntaxKind, SyntaxKind> {
-                {VBSyntaxKind.SkippedTokensTrivia, SyntaxKind.SkippedTokensTrivia},
-                {VBSyntaxKind.DisabledTextTrivia, SyntaxKind.DisabledTextTrivia},
-                {VBSyntaxKind.ConstDirectiveTrivia, SyntaxKind.DefineDirectiveTrivia}, // Just a guess
-                {VBSyntaxKind.IfDirectiveTrivia, SyntaxKind.IfDirectiveTrivia},
-                {VBSyntaxKind.ElseIfDirectiveTrivia, SyntaxKind.ElifDirectiveTrivia},
-                {VBSyntaxKind.ElseDirectiveTrivia, SyntaxKind.ElseDirectiveTrivia},
-                {VBSyntaxKind.EndIfDirectiveTrivia, SyntaxKind.EndIfDirectiveTrivia},
-                //{VBSyntaxKind.RegionDirectiveTrivia, SyntaxKind.RegionDirectiveTrivia}, Oh no I accidentally disabled regions :O ;)
-                //{VBSyntaxKind.EndRegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia},
-                {VBSyntaxKind.EnableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
-                {VBSyntaxKind.DisableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
-                {VBSyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia},
-                {VBSyntaxKind.BadDirectiveTrivia, SyntaxKind.BadDirectiveTrivia},
-                {VBSyntaxKind.ConflictMarkerTrivia, SyntaxKind.ConflictMarkerTrivia},
-                {VBSyntaxKind.ExternalSourceDirectiveTrivia, SyntaxKind.LoadDirectiveTrivia}, //Just a guess
-                {VBSyntaxKind.ExternalChecksumDirectiveTrivia, SyntaxKind.LineDirectiveTrivia}, // Even more random guess
-            };
-            var convertedKind = syntaxKinds.FirstOrNullable(kvp => t.IsKind(kvp.Key));
+            var convertedKind = VBToCSSyntaxKinds.FirstOrNullable(kvp => t.IsKind(kvp.Key));
             return convertedKind.HasValue
                 ? SyntaxFactory.Comment($"/* TODO ERROR: Skipped {convertedKind.Value.Key} */")
                 : default(SyntaxTrivia);
         }
+
+        private static SyntaxTrivia ConvertCSTrivia(SyntaxTrivia t)
+        {
+            if (t.IsKind(CSSyntaxKind.SingleLineCommentTrivia))
+                return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.CommentTrivia, $"' {t.GetCommentText()}");
+            if (t.IsKind(CSSyntaxKind.SingleLineCommentTrivia)) {
+                var previousWhitespace = t.GetPreviousTrivia(t.SyntaxTree, CancellationToken.None).ToString();
+                var commentTextLines = t.GetCommentText().Replace("\r\n", "\r").Split('\r');
+                var multiLine = commentTextLines.Count() > 1;
+                var outputCommentText = multiLine
+                    ? "/// " + string.Join($"\r\n{previousWhitespace}/// ", commentTextLines)
+                    : $"// {commentTextLines.Single()}";
+                return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.DocumentationCommentTrivia,
+                    outputCommentText);
+            }
+
+            if (t.IsKind(CSSyntaxKind.WhitespaceTrivia)) {
+                return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.WhitespaceTrivia, t.ToString());
+            }
+
+            if (t.IsKind(CSSyntaxKind.EndOfLineTrivia)) {
+                // Mapping one to one here leads to newlines appearing where the natural line-end was in VB.
+                // e.g. ToString\r\n()
+                // Because C Sharp needs those brackets. Handling each possible case of this is far more effort than it's worth.
+                return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.EndOfLineTrivia, t.ToString());
+            }
+
+            var convertedKind = CSToVBSyntaxKinds.FirstOrNullable(kvp => t.IsKind(kvp.Key));
+            return convertedKind.HasValue
+                ? VBSyntaxFactory.CommentTrivia($"' TODO ERROR: Skipped {convertedKind.Value.Key}")
+                : default(SyntaxTrivia);
+        }
+
         public static T WithoutTrailingEndOfLineTrivia<T>(this T cSharpNode) where T : CSharpSyntaxNode
         {
             var lastDescendant = cSharpNode.DescendantNodesAndTokens().Last();
@@ -1232,6 +1249,30 @@ namespace ICSharpCode.CodeConverter.Util
         /// </summary>
         private static readonly Func<SyntaxTriviaList, int, SyntaxToken> s_findSkippedTokenBackward =
             (l, p) => FindTokenHelper.FindSkippedTokenBackward(GetSkippedTokens(l), p);
+
+        private static readonly Dictionary<VBSyntaxKind, SyntaxKind> VBToCSSyntaxKinds = new Dictionary<VBSyntaxKind, SyntaxKind> {
+            {VBSyntaxKind.SkippedTokensTrivia, SyntaxKind.SkippedTokensTrivia},
+            {VBSyntaxKind.DisabledTextTrivia, SyntaxKind.DisabledTextTrivia},
+            {VBSyntaxKind.ConstDirectiveTrivia, SyntaxKind.DefineDirectiveTrivia}, // Just a guess
+            {VBSyntaxKind.IfDirectiveTrivia, SyntaxKind.IfDirectiveTrivia},
+            {VBSyntaxKind.ElseIfDirectiveTrivia, SyntaxKind.ElifDirectiveTrivia},
+            {VBSyntaxKind.ElseDirectiveTrivia, SyntaxKind.ElseDirectiveTrivia},
+            {VBSyntaxKind.EndIfDirectiveTrivia, SyntaxKind.EndIfDirectiveTrivia},
+            //{VBSyntaxKind.RegionDirectiveTrivia, SyntaxKind.RegionDirectiveTrivia}, Oh no I accidentally disabled regions :O ;)
+            //{VBSyntaxKind.EndRegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia},
+            {VBSyntaxKind.EnableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
+            {VBSyntaxKind.DisableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
+            {VBSyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia},
+            {VBSyntaxKind.BadDirectiveTrivia, SyntaxKind.BadDirectiveTrivia},
+            {VBSyntaxKind.ConflictMarkerTrivia, SyntaxKind.ConflictMarkerTrivia},
+            {VBSyntaxKind.ExternalSourceDirectiveTrivia, SyntaxKind.LoadDirectiveTrivia}, //Just a guess
+            {VBSyntaxKind.ExternalChecksumDirectiveTrivia, SyntaxKind.LineDirectiveTrivia}, // Even more random guess
+        };
+
+        private static readonly Dictionary<SyntaxKind, VBSyntaxKind> CSToVBSyntaxKinds = 
+            VBToCSSyntaxKinds
+                .ToLookup(kvp => kvp.Value, kvp => kvp.Key)
+                .ToDictionary(g => g.Key, g => g.First());
 
         /// <summary>
         /// return only skipped tokens

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -834,7 +834,10 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static IEnumerable<SyntaxTrivia> ImportantTrailingTrivia(this SyntaxToken node)
         {
-            return node.TrailingTrivia.Where(x => !x.IsKind(SyntaxKind.WhitespaceTrivia) && !x.IsKind(SyntaxKind.EndOfLineTrivia));
+            return node.TrailingTrivia.Where(x => 
+                !x.IsKind(SyntaxKind.WhitespaceTrivia) && !x.IsKind(SyntaxKind.EndOfLineTrivia)
+                && !x.IsKind(CSSyntaxKind.WhitespaceTrivia) && !x.IsKind(CSSyntaxKind.EndOfLineTrivia)
+            );
         }
 
         public static bool ParentHasSameTrailingTrivia(this SyntaxNode otherNode)
@@ -889,8 +892,8 @@ namespace ICSharpCode.CodeConverter.Util
                 var commentTextLines = t.GetCommentText().Replace("\r\n", "\r").Split('\r');
                 var multiLine = commentTextLines.Count() > 1;
                 var outputCommentText = multiLine
-                    ? "/// " + string.Join($"\r\n{previousWhitespace}/// ", commentTextLines)
-                    : $"// {commentTextLines.Single()}";
+                    ? "''' " + string.Join($"\r\n{previousWhitespace}/// ", commentTextLines)
+                    : $"' {commentTextLines.Single()}";
                 return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.DocumentationCommentTrivia,
                     outputCommentText);
             }

--- a/ICSharpCode.CodeConverter/VB/CSToVBConversion.cs
+++ b/ICSharpCode.CodeConverter/VB/CSToVBConversion.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.CodeConverter.VB;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using VBSyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
+using CSSyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public class CSToVBConversion : ILanguageConversion
+    {
+        public SyntaxTree SingleFirstPass(Compilation sourceCompilation, SyntaxTree tree)
+        {
+            var converted = CSharpConverter.ConvertCompilationTree((CSharpCompilation)sourceCompilation, (CSharpSyntaxTree)tree);
+            var convertedTree = VBSyntaxFactory.SyntaxTree(converted);
+            return convertedTree;
+        }
+
+        public SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
+        {
+            return cs.Value.GetRoot();
+        }
+
+        public string WithSurroundingClassAndMethod(string text)
+        {
+            return $@"class SurroundingClass
+{{
+void SurroundingSub()
+{{
+{text}
+}}
+}}";
+        }
+
+        public SyntaxNode RemoveSurroundingClassAndMethod(SyntaxNode secondPassNode)
+        {
+            return secondPassNode.DescendantNodes().OfType<MethodBlockSyntax>().First();
+        }
+
+        public SyntaxTree CreateTree(string text)
+        {
+            return CSSyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+        }
+
+        public Compilation CreateCompilationFromTree(SyntaxTree tree, IEnumerable<MetadataReference> references)
+        {
+            return CSharpCompilation.Create("Conversion", new[] { tree }, references);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -37,7 +37,7 @@ namespace ICSharpCode.CodeConverter.VB
         public static VisualBasicSyntaxNode ConvertCompilationTree(CS.CSharpCompilation compilation, CS.CSharpSyntaxTree tree)
         {
             var visualBasicSyntaxVisitor = new NodesVisitor(compilation.GetSemanticModel(tree, true));
-            return tree.GetRoot().Accept(visualBasicSyntaxVisitor);
+            return tree.GetRoot().Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
         }
 
         public static ConversionResult ConvertText(string text, MetadataReference[] references)
@@ -128,7 +128,7 @@ namespace ICSharpCode.CodeConverter.VB
             return token == SyntaxKind.None ? null : new SyntaxToken?(SyntaxFactory.Token(token));
         }
 
-        static SeparatedSyntaxList<VariableDeclaratorSyntax> RemodelVariableDeclaration(CSS.VariableDeclarationSyntax declaration, NodesVisitor nodesVisitor)
+        static SeparatedSyntaxList<VariableDeclaratorSyntax> RemodelVariableDeclaration(CSS.VariableDeclarationSyntax declaration, CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor)
         {
             var type = (TypeSyntax)declaration.Type.Accept(nodesVisitor);
             var declaratorsWithoutInitializers = new List<CSS.VariableDeclaratorSyntax>();

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -29,34 +29,10 @@ namespace ICSharpCode.CodeConverter.VB
             Local
         }
 
-        public static VisualBasicSyntaxNode Convert(CS.CSharpSyntaxNode input, SemanticModel semanticModel)
-        {
-            return input.Accept(new NodesVisitor(semanticModel));
-        }
-
         public static VisualBasicSyntaxNode ConvertCompilationTree(CS.CSharpCompilation compilation, CS.CSharpSyntaxTree tree)
         {
             var visualBasicSyntaxVisitor = new NodesVisitor(compilation.GetSemanticModel(tree, true));
             return tree.GetRoot().Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
-        }
-
-        public static ConversionResult ConvertText(string text, MetadataReference[] references)
-        {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
-            if (references == null)
-                throw new ArgumentNullException(nameof(references));
-            var tree = CS.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
-            var compilation = CS.CSharpCompilation.Create("Conversion", new[] { tree }, references);
-            try {
-                var visualBasicSyntaxNode = Convert((CS.CSharpSyntaxNode)tree.GetRoot(), compilation.GetSemanticModel(tree, true));
-                var formatted = Formatter.Format(visualBasicSyntaxNode, new AdhocWorkspace());
-                return new ConversionResult(formatted.ToFullString());
-            }
-            catch (Exception ex)
-            {
-                return new ConversionResult(ex);
-            }
         }
 
         static IEnumerable<SyntaxToken> ConvertModifiersCore(IEnumerable<SyntaxToken> modifiers, TokenContext context)

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -29,9 +29,15 @@ namespace ICSharpCode.CodeConverter.VB
             Local
         }
 
-        public static VisualBasicSyntaxNode Convert(CS.CSharpSyntaxNode input, SemanticModel semanticModel, Document targetDocument)
+        public static VisualBasicSyntaxNode Convert(CS.CSharpSyntaxNode input, SemanticModel semanticModel)
         {
-            return input.Accept(new NodesVisitor(semanticModel, targetDocument));
+            return input.Accept(new NodesVisitor(semanticModel));
+        }
+
+        public static VisualBasicSyntaxNode ConvertCompilationTree(CS.CSharpCompilation compilation, CS.CSharpSyntaxTree tree)
+        {
+            var visualBasicSyntaxVisitor = new NodesVisitor(compilation.GetSemanticModel(tree, true));
+            return tree.GetRoot().Accept(visualBasicSyntaxVisitor);
         }
 
         public static ConversionResult ConvertText(string text, MetadataReference[] references)
@@ -43,7 +49,7 @@ namespace ICSharpCode.CodeConverter.VB
             var tree = CS.SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
             var compilation = CS.CSharpCompilation.Create("Conversion", new[] { tree }, references);
             try {
-                var visualBasicSyntaxNode = Convert((CS.CSharpSyntaxNode)tree.GetRoot(), compilation.GetSemanticModel(tree, true), null);
+                var visualBasicSyntaxNode = Convert((CS.CSharpSyntaxNode)tree.GetRoot(), compilation.GetSemanticModel(tree, true));
                 var formatted = Formatter.Format(visualBasicSyntaxNode, new AdhocWorkspace());
                 return new ConversionResult(formatted.ToFullString());
             }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
@@ -1,0 +1,28 @@
+﻿using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
+namespace ICSharpCode.CodeConverter.VB
+{
+    public class CommentConvertingMethodBodyVisitor : CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>>
+    {
+        private readonly CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor;
+        private readonly TriviaConverter triviaConverter;
+
+        public CommentConvertingMethodBodyVisitor(CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor, TriviaConverter triviaConverter)
+        {
+            this.wrappedVisitor = wrappedVisitor;
+            this.triviaConverter = triviaConverter;
+        }
+
+        public override SyntaxList<VBSyntax.StatementSyntax> DefaultVisit(SyntaxNode node)
+        {
+            var syntaxNodes = wrappedVisitor.Visit(node);
+            // Port trivia to the last statement in the list
+            var lastWithConvertedTrivia = triviaConverter.PortConvertedTrivia(node, syntaxNodes.LastOrDefault());
+            return syntaxNodes.Replace(syntaxNodes.LastOrDefault(), lastWithConvertedTrivia);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using VbSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using CsSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.VB
+{
+    public class CommentConvertingNodesVisitor : CSharpSyntaxVisitor<VisualBasicSyntaxNode>
+    {
+        public TriviaConverter TriviaConverter { get; }
+        private readonly CSharpSyntaxVisitor<VisualBasicSyntaxNode> _wrappedVisitor;
+
+        public CommentConvertingNodesVisitor(CSharpSyntaxVisitor<VisualBasicSyntaxNode> wrappedVisitor)
+        {
+            TriviaConverter = new TriviaConverter();
+            this._wrappedVisitor = wrappedVisitor;
+        }
+        public override VisualBasicSyntaxNode DefaultVisit(SyntaxNode node)
+        {
+            return TriviaConverter.PortConvertedTrivia(node, _wrappedVisitor.Visit(node));
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -96,10 +96,9 @@ End Function";
                 return true;
             }
 
-            public NodesVisitor(SemanticModel semanticModel, Document targetDocument)
+            public NodesVisitor(SemanticModel semanticModel)
             {
                 this.semanticModel = semanticModel;
-                this.targetDocument = targetDocument;
                 this.options = (VisualBasicCompilationOptions)targetDocument?.Project.CompilationOptions;
             }
 

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -64,7 +64,7 @@ using Microsoft.VisualBasic;
         public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode, bool addUsings = true, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
         {
             if (addUsings) expectedCsharpCode = AddUsings(expectedCsharpCode, false);
-            var outputNode = VisualBasicConverter.ConvertText(visualBasicCode, DiagnosticTestBase.DefaultMetadataReferences);
+            var outputNode = ProjectConversion.ConvertText(visualBasicCode, DiagnosticTestBase.DefaultMetadataReferences);
             var txt = Utils.HomogenizeEol(outputNode.ConvertedCode ?? outputNode.GetExceptionsAsString()).TrimEnd();
             expectedCsharpCode = Utils.HomogenizeEol(expectedCsharpCode).TrimEnd();
             AssertCodeEqual(visualBasicCode, expectedCsharpCode, txt);

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -29,7 +29,7 @@ namespace CodeConverter.Tests
 
         private static void TestConversionCSharpToVisualBasicWithoutComments(string csharpCode, string expectedVisualBasicCode)
         {
-            var outputNode = CSharpConverter.ConvertText(csharpCode, DiagnosticTestBase.DefaultMetadataReferences);
+            var outputNode = ProjectConversion<CSToVBConversion>.ConvertText(csharpCode, DiagnosticTestBase.DefaultMetadataReferences);
 
             var txt = outputNode.ConvertedCode ?? outputNode.GetExceptionsAsString();
             txt = Utils.HomogenizeEol(txt).TrimEnd();

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using ICSharpCode.CodeConverter.VB;
 using Microsoft.CodeAnalysis;

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -19,12 +19,12 @@ namespace CodeConverter.Tests
 {
     public class ConverterTestBase
     {
-        private bool testCommentsByDefault = true;
+        private bool testCSToVBCommentsByDefault = false;
 
         public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool standaloneStatements = false, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
         {
             TestConversionCSharpToVisualBasicWithoutComments(csharpCode, expectedVisualBasicCode);
-            if (testCommentsByDefault) TestConversionCSharpToVisualBasicWithoutComments(AddLineNumberComments(csharpCode, "// ", false), AddLineNumberComments(expectedVisualBasicCode, "' ", true));
+            if (testCSToVBCommentsByDefault) TestConversionCSharpToVisualBasicWithoutComments(AddLineNumberComments(csharpCode, "// ", false), AddLineNumberComments(expectedVisualBasicCode, "' ", true));
         }
 
         private static void TestConversionCSharpToVisualBasicWithoutComments(string csharpCode, string expectedVisualBasicCode)
@@ -41,7 +41,7 @@ namespace CodeConverter.Tests
         {
             expectedCsharpCode = AddCSUsings(expectedCsharpCode, standaloneStatements);
             TestConversionVisualBasicToCSharpWithoutComments(visualBasicCode, expectedCsharpCode, false);
-            if (testCommentsByDefault) TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true), false);
+            TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true), false);
         }
 
         private static string AddCSUsings(string expectedCsharpCode, bool standaloneStatements)

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -21,7 +21,13 @@ namespace CodeConverter.Tests
     {
         private bool testCommentsByDefault = true;
 
-        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
+        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool standaloneStatements = false, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
+        {
+            TestConversionCSharpToVisualBasicWithoutComments(csharpCode, expectedVisualBasicCode);
+            if (testCommentsByDefault) TestConversionCSharpToVisualBasicWithoutComments(AddLineNumberComments(csharpCode, "// ", false), AddLineNumberComments(expectedVisualBasicCode, "' ", true));
+        }
+
+        private static void TestConversionCSharpToVisualBasicWithoutComments(string csharpCode, string expectedVisualBasicCode)
         {
             var outputNode = CSharpConverter.ConvertText(csharpCode, DiagnosticTestBase.DefaultMetadataReferences);
 
@@ -33,12 +39,12 @@ namespace CodeConverter.Tests
 
         public void TestConversionVisualBasicToCSharp(string visualBasicCode, string expectedCsharpCode, bool standaloneStatements = false)
         {
-            expectedCsharpCode = AddUsings(expectedCsharpCode, standaloneStatements);
+            expectedCsharpCode = AddCSUsings(expectedCsharpCode, standaloneStatements);
             TestConversionVisualBasicToCSharpWithoutComments(visualBasicCode, expectedCsharpCode, false);
             if (testCommentsByDefault) TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true), false);
         }
 
-        private static string AddUsings(string expectedCsharpCode, bool standaloneStatements)
+        private static string AddCSUsings(string expectedCsharpCode, bool standaloneStatements)
         {
             if (standaloneStatements)
             {
@@ -64,7 +70,7 @@ using Microsoft.VisualBasic;
 
         public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode, bool addUsings = true, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
         {
-            if (addUsings) expectedCsharpCode = AddUsings(expectedCsharpCode, false);
+            if (addUsings) expectedCsharpCode = AddCSUsings(expectedCsharpCode, false);
             var outputNode = ProjectConversion<VBToCSConversion>.ConvertText(visualBasicCode, DiagnosticTestBase.DefaultMetadataReferences);
             var txt = Utils.HomogenizeEol(outputNode.ConvertedCode ?? outputNode.GetExceptionsAsString()).TrimEnd();
             expectedCsharpCode = Utils.HomogenizeEol(expectedCsharpCode).TrimEnd();

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -64,7 +64,7 @@ using Microsoft.VisualBasic;
         public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode, bool addUsings = true, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
         {
             if (addUsings) expectedCsharpCode = AddUsings(expectedCsharpCode, false);
-            var outputNode = ProjectConversion.ConvertText(visualBasicCode, DiagnosticTestBase.DefaultMetadataReferences);
+            var outputNode = ProjectConversion<VBToCSConversion>.ConvertText(visualBasicCode, DiagnosticTestBase.DefaultMetadataReferences);
             var txt = Utils.HomogenizeEol(outputNode.ConvertedCode ?? outputNode.GetExceptionsAsString()).TrimEnd();
             expectedCsharpCode = Utils.HomogenizeEol(expectedCsharpCode).TrimEnd();
             AssertCodeEqual(visualBasicCode, expectedCsharpCode, txt);

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -233,8 +233,8 @@ End Class");
                         If b > 0 Then Return a / b
                         Return 0
                     End Function
-        Dim test3 = Function(a, b) a Mod b
 
+        Dim test3 = Function(a, b) a Mod b
         test(3)
     End Sub
 End Class");
@@ -283,7 +283,6 @@ End Class");
 }",
 @"Private Shared Sub SimpleQuery()
     Dim numbers As Integer() = {7, 9, 5, 3, 6}
-
     Dim res = From n In numbers Where n > 5 Select n
 
     For Each n In res

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -7,8 +7,7 @@ namespace CodeConverter.Tests.VB
         [Fact]
         public void MultilineString()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -26,8 +25,7 @@ End Class");
         [Fact]
         public void ConditionalExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(string str)
     {
@@ -43,8 +41,7 @@ End Class");
         [Fact]
         public void NullCoalescingExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(string str)
     {
@@ -60,8 +57,7 @@ End Class");
         [Fact]
         public void MemberAccessAndInvocationExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(string str)
     {
@@ -83,8 +79,7 @@ End Class");
         [Fact]
         public void ElvisOperatorExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(string str)
     {
@@ -136,8 +131,7 @@ End Class");
         [Fact(Skip = "Not implemented!")]
         public void ObjectInitializerExpression2()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(string str)
     {
@@ -156,8 +150,7 @@ End Class");
         [Fact]
         public void ThisMemberAccessExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     private int member;
 
@@ -177,8 +170,7 @@ End Class");
         [Fact]
         public void BaseMemberAccessExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class BaseTestClass
+            TestConversionCSharpToVisualBasic(@"class BaseTestClass
 {
     public int member;
 }
@@ -205,8 +197,7 @@ End Class");
         [Fact]
         public void DelegateExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass 
+            TestConversionCSharpToVisualBasic(@"class TestClass 
 {
     void TestMethod()
     {
@@ -225,8 +216,7 @@ End Class");
         [Fact]
         public void LambdaBodyExpression()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass 
+            TestConversionCSharpToVisualBasic(@"class TestClass 
 {
     void TestMethod()
     {
@@ -243,8 +233,8 @@ class TestClass
                         If b > 0 Then Return a / b
                         Return 0
                     End Function
-
         Dim test3 = Function(a, b) a Mod b
+
         test(3)
     End Sub
 End Class");
@@ -253,8 +243,7 @@ End Class");
         [Fact]
         public void Await()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass 
+            TestConversionCSharpToVisualBasic(@"class TestClass 
 {
     Task<int> SomeAsyncMethod()
     {
@@ -294,6 +283,7 @@ End Class");
 }",
 @"Private Shared Sub SimpleQuery()
     Dim numbers As Integer() = {7, 9, 5, 3, 6}
+
     Dim res = From n In numbers Where n > 5 Select n
 
     For Each n In res

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -7,8 +7,7 @@ namespace CodeConverter.Tests.VB
         [Fact]
         public void EmptyStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -37,8 +36,7 @@ End Class");
         [Fact]
         public void AssignmentStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -56,8 +54,7 @@ End Class");
         [Fact]
         public void AssignmentStatementInDeclaration()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -73,8 +70,7 @@ End Class");
         [Fact]
         public void AssignmentStatementInVarDeclaration()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -90,8 +86,7 @@ End Class");
         [Fact]
         public void ObjectInitializationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -109,8 +104,7 @@ End Class");
         [Fact]
         public void ObjectInitializationStatementInDeclaration()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -126,8 +120,7 @@ End Class");
         [Fact]
         public void ObjectInitializationStatementInVarDeclaration()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -143,8 +136,7 @@ End Class");
         [Fact]
         public void ArrayDeclarationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -160,8 +152,7 @@ End Class");
         [Fact]
         public void ArrayInitializationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -177,8 +168,7 @@ End Class");
         [Fact]
         public void ArrayInitializationStatementInVarDeclaration()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -194,8 +184,7 @@ End Class");
         [Fact]
         public void ArrayInitializationStatementWithType()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -211,8 +200,7 @@ End Class");
         [Fact]
         public void ArrayInitializationStatementWithLength()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -228,8 +216,7 @@ End Class");
         [Fact]
         public void MultidimensionalArrayDeclarationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -245,8 +232,7 @@ End Class");
         [Fact(Skip = "Not implemented!")]
         public void MultidimensionalArrayInitializationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -262,8 +248,7 @@ End Class");
         [Fact(Skip = "Not implemented!")]
         public void MultidimensionalArrayInitializationStatementWithType()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -279,8 +264,7 @@ End Class");
         [Fact(Skip = "Not implemented!")]
         public void MultidimensionalArrayInitializationStatementWithLengths()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -296,8 +280,7 @@ End Class");
         [Fact]
         public void JaggedArrayDeclarationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -313,8 +296,7 @@ End Class");
         [Fact]
         public void JaggedArrayInitializationStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -330,8 +312,7 @@ End Class");
         [Fact]
         public void JaggedArrayInitializationStatementWithType()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -347,8 +328,7 @@ End Class");
         [Fact]
         public void JaggedArrayInitializationStatementWithLength()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -388,8 +368,7 @@ End Class");
         [Fact]
         public void IfStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod (int a)
     {
@@ -424,8 +403,7 @@ End Class");
         [Fact]
         public void WhileStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -457,8 +435,7 @@ End Class");
         [Fact]
         public void DoWhileStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -491,8 +468,7 @@ End Class");
         [Fact]
         public void ForEachStatementWithExplicitType()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(int[] values)
     {
@@ -517,8 +493,7 @@ End Class");
         [Fact]
         public void ForEachStatementWithVar()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(int[] values)
     {
@@ -543,8 +518,7 @@ End Class");
         [Fact]
         public void SyncLockStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(object nullObject)
     {
@@ -568,8 +542,7 @@ End Class");
         [Fact]
         public void ForWithUnknownConditionAndSingleStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -591,8 +564,7 @@ End Class");
         [Fact]
         public void ForWithUnknownConditionAndBlock()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -615,8 +587,7 @@ End Class");
         [Fact]
         public void ForWithSingleStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -634,8 +605,7 @@ End Class");
         [Fact]
         public void ForWithBlock()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod()
     {
@@ -655,8 +625,7 @@ End Class");
         [Fact]
         public void LabeledAndForStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class GotoTest1
+            TestConversionCSharpToVisualBasic(@"class GotoTest1
 {
     static void Main()
     {
@@ -738,8 +707,7 @@ End Class");
         [Fact]
         public void ThrowStatement()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(object nullObject)
     {
@@ -801,8 +769,7 @@ End Class");
         [Fact]
         public void SelectCase1()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     void TestMethod(int number)
     {
@@ -851,8 +818,7 @@ End Class");
         [Fact]
         public void TryCatch()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     static bool Log(string message)
     {
@@ -921,8 +887,7 @@ End Class");
         [Fact]
         public void Yield()
         {
-            TestConversionCSharpToVisualBasic(@"
-class TestClass
+            TestConversionCSharpToVisualBasic(@"class TestClass
 {
     IEnumerable<int> TestMethod(int number)
     {

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -84,7 +84,7 @@ namespace CodeConverter.VsExtension
         {
             var projectsByPath = visualStudioWorkspace.CurrentSolution.Projects.ToDictionary(p => p.FilePath, p => p);
             var projects = selectedProjects.Select(p => projectsByPath[p.FullName]);
-            await VisualBasicConverter.ConvertProjects(projects);
+            await ProjectConversion.ConvertProjects(projects);
 
 
             //var errors = new Dictionary<string, string>();
@@ -166,7 +166,7 @@ namespace CodeConverter.VsExtension
             var documentSyntaxTree = await document.GetSyntaxTreeAsync();
 
             var selectedTextSpan = new TextSpan(selected.Start, selected.Length);
-            return await VisualBasicConverter.ConvertSingle((VisualBasicCompilation)compilation, (VisualBasicSyntaxTree)documentSyntaxTree, selectedTextSpan);
+            return await ProjectConversion.ConvertSingle((VisualBasicCompilation)compilation, (VisualBasicSyntaxTree)documentSyntaxTree, selectedTextSpan);
         }
         void WriteStatusBarText(string text)
         {

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -85,8 +85,8 @@ namespace CodeConverter.VsExtension
             var projectsByPath = visualStudioWorkspace.CurrentSolution.Projects.ToDictionary(p => p.FilePath, p => p);
             var projects = selectedProjects.Select(p => projectsByPath[p.FullName]);
             var convertedFiles = ProjectConversion.ConvertProjects(projects);
-            foreach (var convertedFile in convertedFiles) {
-
+            var solutionDir = Path.GetDirectoryName(visualStudioWorkspace.CurrentSolution.FilePath);
+            foreach (var convertedFile in convertedFiles.Where(f => f.SourcePathOrNull == null || f.SourcePathOrNull.StartsWith(solutionDir))) {
                 if (convertedFile.Success) {
                     var path = Path.ChangeExtension(convertedFile.SourcePathOrNull, ".cs");
                     File.WriteAllText(path, convertedFile.ConvertedCode);

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter;
 using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -73,7 +73,7 @@ namespace CodeConverter.VsExtension
         {
             if (files.Any()) {
                 VisualStudioInteraction.OpenFile(new FileInfo(files.First()));
-                
+                files[0] = files[0] + " (opened in adjacent code window)";
             }
 
             VisualStudioInteraction.NewTextWindow("Conversion result summary", GetConversionSummary(files, errors));
@@ -82,7 +82,7 @@ namespace CodeConverter.VsExtension
         private string GetConversionSummary(IReadOnlyCollection<string> files, IReadOnlyCollection<string> errors)
         {
             var solutionDir = Path.GetDirectoryName(_visualStudioWorkspace.CurrentSolution.FilePath);
-            var relativeFilePaths = files.Select(fn => fn.Replace(solutionDir, "").Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            var relativeFilePaths = files.Select(fn => fn.Replace(solutionDir, "").Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)).OrderBy(s => s);
 
 
             var introSummary = "Code conversion failed";

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -72,12 +72,12 @@ namespace CodeConverter.VsExtension
 
         private void ShowFirstResultAndConversionSummary(List<string> files, List<string> errors)
         {
-            if (files.Any()) {
-                VisualStudioInteraction.OpenFile(new FileInfo(files.First()));
-                files[0] = files[0] + " (opened in adjacent code window)";
-            }
+            VisualStudioInteraction.OutputWindow.ShowMessageToUser(GetConversionSummary(files, errors));
 
-            VisualStudioInteraction.NewTextWindow("Conversion result summary", GetConversionSummary(files, errors));
+            if (files.Any()) {
+                VisualStudioInteraction.OpenFile(new FileInfo(files.First())).SelectAll();
+                files[0] = files[0] + " (opened in code window)";
+            }
         }
 
         private string GetConversionSummary(IReadOnlyCollection<string> files, IReadOnlyCollection<string> errors)
@@ -90,7 +90,7 @@ namespace CodeConverter.VsExtension
             var summaryOfSuccesses = "";
             if (files.Any()) {
                 introSummary = "Code conversion completed";
-                summaryOfSuccesses = "The following files have been written to disk (but are not part of the solution):"
+                summaryOfSuccesses = "The following files have been written to disk:"
                     + Environment.NewLine + "* " + string.Join(Environment.NewLine + "* ", relativeFilePaths);
             }
 
@@ -103,7 +103,7 @@ namespace CodeConverter.VsExtension
                        + Environment.NewLine
                        + string.Join(Environment.NewLine, errors);
             } else {
-                WriteStatusBarText(introSummary);
+                WriteStatusBarText(introSummary + " - see output window for details");
                 return introSummary
                        + Environment.NewLine
                        + summaryOfSuccesses;

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -165,45 +165,10 @@ namespace CodeConverter.VsExtension
             statusBar.SetText(text);
             statusBar.FreezeOutput(1);
         }
-
-        IWpfTextViewHost GetCurrentCSViewHost()
-        {
-            IWpfTextViewHost viewHost = VisualStudioInteraction.GetCurrentViewHost(_serviceProvider);
-            if (viewHost == null)
-                return null;
-
-            ITextDocument textDocument = viewHost.GetTextDocument();
-            if ((textDocument == null) || !IsCSFileName(textDocument.FilePath))
-                return null;
-
-            return viewHost;
-        }
-
+        
         public static bool IsCSFileName(string fileName)
         {
             return fileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
-        }
-
-        public ITextSelection GetCSSelectionInCurrentView()
-        {
-            IWpfTextViewHost viewHost = GetCurrentCSViewHost();
-            if (viewHost == null)
-                return null;
-
-            return viewHost.TextView.Selection;
-        }
-
-        public IWpfTextViewHost GetCurrentVBViewHost()
-        {
-            IWpfTextViewHost viewHost = VisualStudioInteraction.GetCurrentViewHost(_serviceProvider);
-            if (viewHost == null)
-                return null;
-
-            ITextDocument textDocument = viewHost.GetTextDocument();
-            if ((textDocument == null) || !IsVBFileName(textDocument.FilePath))
-                return null;
-
-            return viewHost;
         }
 
         public static bool IsVBFileName(string fileName)
@@ -211,13 +176,26 @@ namespace CodeConverter.VsExtension
             return fileName.EndsWith(".vb", StringComparison.OrdinalIgnoreCase);
         }
 
-        public ITextSelection GetVBSelectionInCurrentView()
+        public ITextSelection GetSelectionInCurrentView(Func<string, bool> predicate)
         {
-            IWpfTextViewHost viewHost = GetCurrentVBViewHost();
+            IWpfTextViewHost viewHost = GetCurrentViewHost(predicate);
             if (viewHost == null)
                 return null;
 
             return viewHost.TextView.Selection;
+        }
+
+        public IWpfTextViewHost GetCurrentViewHost(Func<string, bool> predicate)
+        {
+            IWpfTextViewHost viewHost = VisualStudioInteraction.GetCurrentViewHost(_serviceProvider);
+            if (viewHost == null)
+                return null;
+
+            ITextDocument textDocument = viewHost.GetTextDocument();
+            if (textDocument == null || !predicate(textDocument.FilePath))
+                return null;
+
+            return viewHost;
         }
     }
 }

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -129,6 +129,9 @@ namespace CodeConverter.VsExtension
             WriteStatusBarText("Copied converted C# code to clipboard.");
 
             Clipboard.SetText(convertedText);
+            var fi = new FileInfo(Path.ChangeExtension(documentFilePath, ".cs"));
+            File.WriteAllText(fi.FullName, convertedText);
+            VisualStudioInteraction.OpenFile(fi);
         }
 
         private void ShowNonFatalError(string error)

--- a/Vsix/ConvertCSToVBCommand.cs
+++ b/Vsix/ConvertCSToVBCommand.cs
@@ -13,6 +13,8 @@ namespace CodeConverter.VsExtension
         public const int MainMenuCommandId = 0x0100;
         public const int CtxMenuCommandId = 0x0101;
         public const int ProjectItemCtxMenuCommandId = 0x0102;
+        public const int ProjectCtxMenuCommandId = 0x0103;
+        public const int SolutionCtxMenuCommandId = 0x0104;
 
         /// <summary>
         /// Command menu group (command set GUID).
@@ -81,6 +83,18 @@ namespace CodeConverter.VsExtension
                 var projectItemCtxMenuItem = new OleMenuCommand(ProjectItemMenuItemCallback, projectItemCtxMenuCommandID);
                 projectItemCtxMenuItem.BeforeQueryStatus += ProjectItemMenuItem_BeforeQueryStatus;
                 commandService.AddCommand(projectItemCtxMenuItem);
+
+                // Command in project context menu
+                var projectCtxMenuCommandID = new CommandID(CommandSet, ProjectCtxMenuCommandId);
+                var projectCtxMenuItem = new OleMenuCommand(ProjectMenuItemCallback, projectCtxMenuCommandID);
+                projectCtxMenuItem.BeforeQueryStatus += ProjectMenuItem_BeforeQueryStatus;
+                commandService.AddCommand(projectCtxMenuItem);
+
+                // Command in solution context menu
+                var solutionCtxMenuCommandID = new CommandID(CommandSet, SolutionCtxMenuCommandId);
+                var solutionCtxMenuItem = new OleMenuCommand(SolutionMenuItemCallback, solutionCtxMenuCommandID);
+                solutionCtxMenuItem.BeforeQueryStatus += SolutionMenuItem_BeforeQueryStatus;
+                commandService.AddCommand(solutionCtxMenuItem);
             }
         }
 

--- a/Vsix/ConvertCSToVBCommand.cs
+++ b/Vsix/ConvertCSToVBCommand.cs
@@ -156,10 +156,10 @@ namespace CodeConverter.VsExtension
             }
         }
 
-        private async void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
+        private void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                await codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".csproj"));
+                codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".csproj"));
             } catch (Exception ex) {
                 VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
             }

--- a/Vsix/ConvertCSToVBCommand.cs
+++ b/Vsix/ConvertCSToVBCommand.cs
@@ -15,7 +15,6 @@ namespace CodeConverter.VsExtension
         public const int CtxMenuCommandId = 0x0101;
         public const int ProjectItemCtxMenuCommandId = 0x0102;
         public const int ProjectCtxMenuCommandId = 0x0103;
-        public const int SolutionCtxMenuCommandId = 0x0104;
 
         /// <summary>
         /// Command menu group (command set GUID).
@@ -90,12 +89,6 @@ namespace CodeConverter.VsExtension
                 var projectCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, projectCtxMenuCommandID);
                 projectCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
                 commandService.AddCommand(projectCtxMenuItem);
-
-                // Command in solution context menu
-                var solutionCtxMenuCommandID = new CommandID(CommandSet, SolutionCtxMenuCommandId);
-                var solutionCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, solutionCtxMenuCommandID);
-                solutionCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
-                commandService.AddCommand(solutionCtxMenuItem);
             }
         }
 

--- a/Vsix/ConvertCSToVBCommand.cs
+++ b/Vsix/ConvertCSToVBCommand.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
+using ICSharpCode.CodeConverter.CSharp;
 using Microsoft.VisualStudio.Shell;
 
 namespace CodeConverter.VsExtension
@@ -152,7 +153,7 @@ namespace CodeConverter.VsExtension
         private void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".csproj"));
+                codeConversion.ConvertProjects<CSToVBConversion>(VisualStudioInteraction.GetSelectedProjects(".csproj"));
             } catch (Exception ex) {
                 VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
             }

--- a/Vsix/ConvertCSToVBCommand.cs
+++ b/Vsix/ConvertCSToVBCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using ICSharpCode.CodeConverter.CSharp;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
 
 namespace CodeConverter.VsExtension
 {
@@ -127,10 +128,10 @@ namespace CodeConverter.VsExtension
             }
         }
 
-        void CodeEditorMenuItemCallback(object sender, EventArgs e)
+        async void CodeEditorMenuItemCallback(object sender, EventArgs e)
         {
             string selectedText = codeConversion.GetCSSelectionInCurrentView()?.StreamSelectionSpan.GetText();
-            codeConversion.PerformCSToVBConversion(selectedText);
+            await codeConversion.PerformDocumentConversion<CSToVBConversion>(selectedText, new Span());
         }
 
         async void ProjectItemMenuItemCallback(object sender, EventArgs e)
@@ -143,19 +144,19 @@ namespace CodeConverter.VsExtension
             try {
                 using (StreamReader reader = new StreamReader(itemPath)) {
                     string csCode = await reader.ReadToEndAsync();
-                    codeConversion.PerformCSToVBConversion(csCode);
+                    await codeConversion.PerformDocumentConversion<CSToVBConversion>(csCode, new Span());
                 }
             } catch (Exception ex) {
-                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.CSToVBConversionTitle, ex);
+                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.ConverterTitle, ex);
             }
         }
 
         private void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                codeConversion.ConvertProjects<CSToVBConversion>(VisualStudioInteraction.GetSelectedProjects(".csproj"));
+                codeConversion.PerformProjectConversion<CSToVBConversion>(VisualStudioInteraction.GetSelectedProjects(".csproj"));
             } catch (Exception ex) {
-                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
+                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.ConverterTitle, ex);
             }
         }
     }

--- a/Vsix/ConvertVBToCSCommand.cs
+++ b/Vsix/ConvertVBToCSCommand.cs
@@ -130,6 +130,7 @@ namespace CodeConverter.VsExtension
                 menuItem.Enabled = true;
             }
         }
+
         private void SolutionOrProjectMenuItem_BeforeQueryStatus(object sender, EventArgs e)
         {
             var menuItem = sender as OleMenuCommand;

--- a/Vsix/ConvertVBToCSCommand.cs
+++ b/Vsix/ConvertVBToCSCommand.cs
@@ -17,7 +17,7 @@ namespace CodeConverter.VsExtension
         public const int MainMenuCommandId = 0x0200;
         public const int CtxMenuCommandId = 0x0201;
         public const int ProjectItemCtxMenuCommandId = 0x0202;
-        public const int ProjectCtxMenuCommandId = 0x0203;
+        public const int SolutionOrProjectCtxMenuCommandId = 0x0203;
 
         /// <summary>
         /// Command menu group (command set GUID).
@@ -92,10 +92,10 @@ namespace CodeConverter.VsExtension
                 commandService.AddCommand(projectItemCtxMenuItem);
 
                 // Command in project context menu
-                var projectCtxMenuCommandID = new CommandID(CommandSet, ProjectCtxMenuCommandId);
-                var projectCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, projectCtxMenuCommandID);
-                projectCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
-                commandService.AddCommand(projectCtxMenuItem);
+                var solutionOrProjectCtxMenuCommandID = new CommandID(CommandSet, SolutionOrProjectCtxMenuCommandId);
+                var solutionOrProjectCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, solutionOrProjectCtxMenuCommandID);
+                solutionOrProjectCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
+                commandService.AddCommand(solutionOrProjectCtxMenuItem);
             }
         }
 
@@ -148,9 +148,9 @@ namespace CodeConverter.VsExtension
         private async void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                codeConversion.ConvertProjects<VBToCSConversion>(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
+                codeConversion.PerformProjectConversion<VBToCSConversion>(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
             } catch (Exception ex) {
-                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
+                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.ConverterTitle, ex);
             }
         }
 
@@ -161,10 +161,10 @@ namespace CodeConverter.VsExtension
                 return;
 
             try {
-                await codeConversion.PerformVBToCSConversion(documentPath, selected);
+                await codeConversion.PerformDocumentConversion<VBToCSConversion>(documentPath, selected);
             }
             catch (Exception ex) {
-                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
+                VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.ConverterTitle, ex);
             }
         }
     }

--- a/Vsix/ConvertVBToCSCommand.cs
+++ b/Vsix/ConvertVBToCSCommand.cs
@@ -17,7 +17,6 @@ namespace CodeConverter.VsExtension
         public const int CtxMenuCommandId = 0x0201;
         public const int ProjectItemCtxMenuCommandId = 0x0202;
         public const int ProjectCtxMenuCommandId = 0x0203;
-        public const int SolutionCtxMenuCommandId = 0x0204;
 
         /// <summary>
         /// Command menu group (command set GUID).
@@ -96,12 +95,6 @@ namespace CodeConverter.VsExtension
                 var projectCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, projectCtxMenuCommandID);
                 projectCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
                 commandService.AddCommand(projectCtxMenuItem);
-
-                // Command in solution context menu
-                var solutionCtxMenuCommandID = new CommandID(CommandSet, SolutionCtxMenuCommandId);
-                var solutionCtxMenuItem = new OleMenuCommand(SolutionOrProjectMenuItemCallback, solutionCtxMenuCommandID);
-                solutionCtxMenuItem.BeforeQueryStatus += SolutionOrProjectMenuItem_BeforeQueryStatus;
-                commandService.AddCommand(solutionCtxMenuItem);
             }
         }
 

--- a/Vsix/ConvertVBToCSCommand.cs
+++ b/Vsix/ConvertVBToCSCommand.cs
@@ -154,7 +154,7 @@ namespace CodeConverter.VsExtension
         private async void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                await codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
+                codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
             } catch (Exception ex) {
                 VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
             }

--- a/Vsix/ConvertVBToCSCommand.cs
+++ b/Vsix/ConvertVBToCSCommand.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
+using ICSharpCode.CodeConverter.CSharp;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Task = System.Threading.Tasks.Task;
@@ -147,7 +148,7 @@ namespace CodeConverter.VsExtension
         private async void SolutionOrProjectMenuItemCallback(object sender, EventArgs e)
         {
             try {
-                codeConversion.ConvertVBProjects(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
+                codeConversion.ConvertProjects<VBToCSConversion>(VisualStudioInteraction.GetSelectedProjects(".vbproj"));
             } catch (Exception ex) {
                 VisualStudioInteraction.ShowException(ServiceProvider, CodeConversion.VBToCSConversionTitle, ex);
             }

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -25,7 +25,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+          <ButtonText>Convert to VB</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBCtxCommandId" priority="0x0100" type="Button">
@@ -33,7 +33,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+          <ButtonText>Convert to VB</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" priority="0x0100" type="Button">
@@ -41,7 +41,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+          <ButtonText>Convert to VB</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionOrProjectCtxCommandId" priority="0x0100" type="Button">
@@ -49,7 +49,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to VB and write to adjacent files</ButtonText>
+          <ButtonText>Convert to VB</ButtonText>
         </Strings>
       </Button>
 
@@ -59,7 +59,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+          <ButtonText>Convert to C#</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCtxCommandId" priority="0x0100" type="Button">
@@ -67,7 +67,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+          <ButtonText>Convert to C#</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" priority="0x0100" type="Button">
@@ -75,7 +75,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+          <ButtonText>Convert to C#</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSSolutionOrProjectCtxCommandId" priority="0x0100" type="Button">
@@ -83,7 +83,7 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>Convert to C# and write to adjacent files</ButtonText>
+          <ButtonText>Convert to C#</ButtonText>
         </Strings>
       </Button>
     </Buttons>

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -15,12 +15,7 @@
       <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
       </Group>
-      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_XPROJ_MULTIPROJ"/>
-      </Group>
-      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE"/>
-      </Group>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" priority="0x0600" />
     </Groups>
 
     <Buttons>
@@ -51,14 +46,6 @@
       </Button>
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectCtxCommandId" priority="0x0100" type="Button">
         <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <ButtonText>Convert to VB and write to adjacent files</ButtonText>
-        </Strings>
-      </Button>
-      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionCtxCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
@@ -99,17 +86,19 @@
           <ButtonText>Convert to C# and write to adjacent files</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSSolutionCtxCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <Strings>
-          <ButtonText>Convert to C# and write to adjacent files</ButtonText>
-        </Strings>
-      </Button>
     </Buttons>
   </Commands>
-
+  <CommandPlacements>
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_XPROJ_MULTIPROJ"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE"/>
+    </CommandPlacement>
+  </CommandPlacements>
   <Symbols>
     <!-- This is the package guid. -->
     <GuidSymbol name="guidREConverterPackage" value="{60378c8b-d75c-4fb2-aa2b-58609d67f886}" />
@@ -120,17 +109,14 @@
       <IDSymbol name="REConverterCtxMenuGroup" value="0x1021" />
       <IDSymbol name="REConverterProjectItemCtxMenuGroup" value="0x1022" />
       <IDSymbol name="REConverterProjectCtxMenuGroup" value="0x1023" />
-      <IDSymbol name="REConverterSolutionCtxMenuGroup" value="0x1024" />
       <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
       <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
       <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
       <IDSymbol name="ConvertCSToVBProjectCtxCommandId" value="0x0103" />
-      <IDSymbol name="ConvertCSToVBSolutionCtxCommandId" value="0x0104" />
       <IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
       <IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
       <IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
       <IDSymbol name="ConvertVBToCSProjectCtxCommandId" value="0x0203" />
-      <IDSymbol name="ConvertVBToCSSolutionCtxCommandId" value="0x0204" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -1,92 +1,92 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-	<Extern href="stdidcmd.h"/>
-	<Extern href="vsshlids.h"/>
+  <Extern href="stdidcmd.h"/>
+  <Extern href="vsshlids.h"/>
 
-	<Commands package="guidREConverterPackage">
-		<Groups>
-			<Group guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" priority="0x0600">
-				<Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_EDIT"/>
-			</Group>
-			<Group guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" priority="0x0600">
-				<Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
-			</Group>
-			<Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" priority="0x0600">
-				<Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
-			</Group>
-		</Groups>
+  <Commands package="guidREConverterPackage">
+    <Groups>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_EDIT"/>
+      </Group>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_CODEWIN"/>
+      </Group>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+      </Group>
+    </Groups>
 
-		<Buttons>
-			<!-- C# to VB convertion commands -->
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to VB and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBCtxCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to VB and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to VB and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
+    <Buttons>
+      <!-- C# to VB convertion commands -->
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to VB and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
 
-			<!-- VB to C# conversion commands -->
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to C# and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCtxCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to C# and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
-			<Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" priority="0x0100" type="Button">
-				<Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
-				<CommandFlag>DefaultInvisible</CommandFlag>
-				<CommandFlag>DynamicVisibility</CommandFlag>
-				<Strings>
-					<ButtonText>Convert to C# and copy to clipboard</ButtonText>
-				</Strings>
-			</Button>
-		</Buttons>
-	</Commands>
+      <!-- VB to C# conversion commands -->
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to C# and copy to clipboard</ButtonText>
+        </Strings>
+      </Button>
+    </Buttons>
+  </Commands>
 
-	<Symbols>
-		<!-- This is the package guid. -->
-		<GuidSymbol name="guidREConverterPackage" value="{60378c8b-d75c-4fb2-aa2b-58609d67f886}" />
+  <Symbols>
+    <!-- This is the package guid. -->
+    <GuidSymbol name="guidREConverterPackage" value="{60378c8b-d75c-4fb2-aa2b-58609d67f886}" />
 
-		<!-- This is the guid used to group the menu commands together -->
-		<GuidSymbol name="guidREConverterCommandPackageCmdSet" value="{a3378a21-e939-40c9-9e4b-eb0cec7b7854}">
-			<IDSymbol name="REConverterMenuGroup" value="0x1020" />
-			<IDSymbol name="REConverterCtxMenuGroup" value="0x1021" />
-			<IDSymbol name="REConverterProjectItemCtxMenuGroup" value="0x1022" />
-			<IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
-			<IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
-			<IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
-			<IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
-			<IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
-			<IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
-		</GuidSymbol>
-	</Symbols>
+    <!-- This is the guid used to group the menu commands together -->
+    <GuidSymbol name="guidREConverterCommandPackageCmdSet" value="{a3378a21-e939-40c9-9e4b-eb0cec7b7854}">
+      <IDSymbol name="REConverterMenuGroup" value="0x1020" />
+      <IDSymbol name="REConverterCtxMenuGroup" value="0x1021" />
+      <IDSymbol name="REConverterProjectItemCtxMenuGroup" value="0x1022" />
+      <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
+      <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
+      <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
+      <IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
+      <IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
+      <IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
+    </GuidSymbol>
+  </Symbols>
 </CommandTable>

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -15,7 +15,7 @@
       <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
       </Group>
-      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" priority="0x0600" />
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup" priority="0x0600" />
     </Groups>
 
     <Buttons>
@@ -44,8 +44,8 @@
           <ButtonText>Convert to VB and copy to clipboard</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectCtxCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" />
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionOrProjectCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
@@ -78,8 +78,8 @@
           <ButtonText>Convert to C# and copy to clipboard</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectCtxCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" />
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSSolutionOrProjectCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
@@ -89,13 +89,13 @@
     </Buttons>
   </Commands>
   <CommandPlacements>
-    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_XPROJ_MULTIPROJ"/>
     </CommandPlacement>
-    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+    <CommandPlacement guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionOrProjectCtxMenuGroup">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE"/>
     </CommandPlacement>
   </CommandPlacements>
@@ -108,15 +108,15 @@
       <IDSymbol name="REConverterMenuGroup" value="0x1020" />
       <IDSymbol name="REConverterCtxMenuGroup" value="0x1021" />
       <IDSymbol name="REConverterProjectItemCtxMenuGroup" value="0x1022" />
-      <IDSymbol name="REConverterProjectCtxMenuGroup" value="0x1023" />
+      <IDSymbol name="REConverterSolutionOrProjectCtxMenuGroup" value="0x1023" />
       <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
       <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
       <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
-      <IDSymbol name="ConvertCSToVBProjectCtxCommandId" value="0x0103" />
+      <IDSymbol name="ConvertCSToVBSolutionOrProjectCtxCommandId" value="0x0103" />
       <IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
       <IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
       <IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
-      <IDSymbol name="ConvertVBToCSProjectCtxCommandId" value="0x0203" />
+      <IDSymbol name="ConvertVBToCSSolutionOrProjectCtxCommandId" value="0x0203" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -99,8 +99,8 @@
           <ButtonText>Convert to C# and write to adjacent files</ButtonText>
         </Strings>
       </Button>
-      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" priority="0x0100" type="Button">
-        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSSolutionCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup" />
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
@@ -119,6 +119,8 @@
       <IDSymbol name="REConverterMenuGroup" value="0x1020" />
       <IDSymbol name="REConverterCtxMenuGroup" value="0x1021" />
       <IDSymbol name="REConverterProjectItemCtxMenuGroup" value="0x1022" />
+      <IDSymbol name="REConverterProjectCtxMenuGroup" value="0x1023" />
+      <IDSymbol name="REConverterSolutionCtxMenuGroup" value="0x1024" />
       <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
       <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
       <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -15,6 +15,12 @@
       <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" priority="0x0600">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
       </Group>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_XPROJ_MULTIPROJ"/>
+      </Group>
+      <Group guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE"/>
+      </Group>
     </Groups>
 
     <Buttons>
@@ -43,6 +49,22 @@
           <ButtonText>Convert to VB and copy to clipboard</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBProjectCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to VB and write to adjacent files</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterSolutionCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to VB and write to adjacent files</ButtonText>
+        </Strings>
+      </Button>
 
       <!-- VB to C# conversion commands -->
       <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSCommandId" priority="0x0100" type="Button">
@@ -69,6 +91,22 @@
           <ButtonText>Convert to C# and copy to clipboard</ButtonText>
         </Strings>
       </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to C# and write to adjacent files</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidREConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" priority="0x0100" type="Button">
+        <Parent guid="guidREConverterCommandPackageCmdSet" id="REConverterProjectItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Convert to C# and write to adjacent files</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
   </Commands>
 
@@ -84,9 +122,13 @@
       <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
       <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
       <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
+      <IDSymbol name="ConvertCSToVBProjectCtxCommandId" value="0x0103" />
+      <IDSymbol name="ConvertCSToVBSolutionCtxCommandId" value="0x0104" />
       <IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
       <IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
       <IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
+      <IDSymbol name="ConvertVBToCSProjectCtxCommandId" value="0x0203" />
+      <IDSymbol name="ConvertVBToCSSolutionCtxCommandId" value="0x0204" />
     </GuidSymbol>
   </Symbols>
 </CommandTable>

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
-using Constants = Microsoft.VisualStudio.OLE.Interop.Constants;
 
 namespace CodeConverter.VsExtension
 {
@@ -129,59 +128,6 @@ namespace CodeConverter.VsExtension
                 OLEMSGICON.OLEMSGICON_CRITICAL,
                 OLEMSGBUTTON.OLEMSGBUTTON_OK,
                 OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
-        }
-
-        /// <summary>
-        /// Identifies the internal object types.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        [Conditional("DEBUG")]
-        public static void IdentifyInternalObjectTypes(UIHierarchyItem item)
-        {
-            if (item == null) {
-                Debug.WriteLine("No item provided.");
-
-                return;
-            }
-
-            if (item.Object == null) {
-                Debug.WriteLine("No item object is available.");
-
-                return;
-            }
-
-            // Loop through all the assemblies in the current app domain
-            Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-            // Loop through each assembly
-            for (Int32 index = 0; index < loadedAssemblies.Length; index++) {
-                // Assume that the assembly to check against is EnvDTE.dll
-                IdentifyInternalObjectTypes(item, loadedAssemblies[index]);
-            }
-        }
-
-        /// <summary>
-        /// Identifies the internal object types.
-        /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="assemblyToCheck">The assembly to check.</param>
-        [Conditional("DEBUG")]
-        public static void IdentifyInternalObjectTypes(UIHierarchyItem item, Assembly assemblyToCheck)
-        {
-            try {
-                // Get the types that are publically available
-                Type[] exportedTypes = assemblyToCheck.GetExportedTypes();
-
-                // Loop through each type
-                for (Int32 index = 0; index < exportedTypes.Length; index++) {
-                    // Check if the object instance is of this type
-                    if (exportedTypes[index].IsInstanceOfType(item.Object)) {
-                        Debug.WriteLine(exportedTypes[index].FullName);
-                    }
-                }
-            } catch (Exception e) {
-                
-            }
         }
     }
 }

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -76,6 +76,21 @@ namespace CodeConverter.VsExtension
             return Dte.ItemOperations.OpenFile(fileInfo.FullName, EnvDTE.Constants.vsViewKindTextView);
         }
 
+        public static Window NewTextWindow(string windowTitle, string windowContents)
+        {
+            var newTextWindow = Dte.ItemOperations.NewFile(Name: windowTitle, ViewKind: EnvDTE.Constants.vsViewKindTextView);
+            newTextWindow.AppendLine(windowContents);
+            return newTextWindow;
+        }
+
+        private static void AppendLine(this Window newTextWindow, string textToAppend)
+        {
+            var textSelection = (TextSelection) newTextWindow.Document.Selection;
+            textSelection.EndOfDocument();
+            textSelection.Text = Environment.NewLine + textToAppend;
+            textSelection.StartOfDocument();
+        }
+
         private static DTE2 Dte => Package.GetGlobalService(typeof(DTE)) as DTE2;
 
 

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -14,6 +15,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Constants = Microsoft.VisualStudio.OLE.Interop.Constants;
 
 namespace CodeConverter.VsExtension
 {
@@ -68,6 +70,11 @@ namespace CodeConverter.VsExtension
 
             var returnType = typeof(T);
             return selectedItems.Select(item => item.Object).Where(returnType.IsInstanceOfType).Cast<T>();
+        }
+
+        public static Window OpenFile(FileInfo fileInfo)
+        {
+            return Dte.ItemOperations.OpenFile(fileInfo.FullName, EnvDTE.Constants.vsViewKindTextView);
         }
 
         private static DTE2 Dte => Package.GetGlobalService(typeof(DTE)) as DTE2;

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
+using EnvDTE;
+using EnvDTE80;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.LanguageServices;
@@ -54,6 +58,20 @@ namespace CodeConverter.VsExtension
                     Marshal.Release(hierarchyPtr);
                 }
             }
+        }
+        private static IEnumerable<T> GetSelectedSolutionExplorerItems<T>() where T: class
+        {
+            var selectedItems = (IEnumerable<object>) Dte.ToolWindows.SolutionExplorer.SelectedItems;
+            return selectedItems.OfType<UIHierarchyItem>().Select(i => i.Object).OfType<T>();
+        }
+
+        private static DTE2 Dte => Package.GetGlobalService(typeof(DTE2)) as DTE2;
+
+
+        public static List<Project> GetSelectedProjects(string projectExtension)
+        {
+            var items = GetSelectedSolutionExplorerItems<Project>().Where(project => project.FullName.EndsWith(projectExtension, StringComparison.InvariantCultureIgnoreCase)).ToList();
+            return items;
         }
 
         public static IWpfTextViewHost GetCurrentViewHost(IServiceProvider serviceProvider)

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="7e2a69d6-193b-4cdf-878d-3370d5931942" Version="5.5.0.0" Language="en-US" Publisher="IC#Code"/>
+        <Identity Id="7e2a69d6-193b-4cdf-878d-3370d5931942" Version="5.6.0.0" Language="en-US" Publisher="IC#Code"/>
         <DisplayName>Code Converter C# to/from VB.NET</DisplayName>
         <Description xml:space="preserve">Based on Roslyn, this converter allows you to convert C# code to VB.NET and vice versa</Description>
         <License>license.txt</License>

--- a/Web/Properties/AssemblyInfo.cs
+++ b/Web/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CodeConverterWebApp")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Web/Properties/AssemblyInfo.cs
+++ b/Web/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("5.6.0.0")]
+[assembly: AssemblyFileVersion("5.6.0.0")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 ﻿platform: Any CPU
-version: 5.5.{build}
+version: 5.6.{build}
 configuration: Debug
 image: Visual Studio 2017
 


### PR DESCRIPTION
Fixes #10 for both C# and VB
Fixes #9 for C# (it was already done for VB)

New behaviour when projects/solution selected in solution explorer:
* For file.cs will write out file.vb in the same folder
* For file.vb will write out file.cs in the same folder
* For single file conversion, writes out the file and opens it in visual studio (instead of existing clipboard behaviour)

### To do
* [x] Show the last/longest file converted with explanation of what's been done and listing any errors
* [x] Manual testing on various different solutions