### PR TITLE
Better C# -> VB attribute formatting and slight VB -> C# linq syntax improvement

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1004,8 +1004,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var vbFromClause = node.Clauses.OfType<VBSyntax.FromClauseSyntax>().Single();
                 var fromClauseSyntax = ConvertFromClauseSyntax(vbFromClause);
                 var vbGroupClause = node.Clauses.OfType<VBSyntax.GroupByClauseSyntax>().SingleOrDefault();
-                var vbSelectClause = node.Clauses.OfType<VBSyntax.SelectClauseSyntax>().Single();
-                var selectClauseSyntax = ConvertSelectClauseSyntax(vbSelectClause);
+                var vbSelectClause = node.Clauses.OfType<VBSyntax.SelectClauseSyntax>().SingleOrDefault();
+                var selectClauseSyntax = vbSelectClause != null
+                    ? ConvertSelectClauseSyntax(vbSelectClause)
+                    : CreateDefaultSelectClause(fromClauseSyntax);
                 var alreadyConverted = new VBSyntax.QueryClauseSyntax[] { vbFromClause, vbGroupClause, vbSelectClause };
                 var vbBodyClauses = node.Clauses;
                 SelectOrGroupClauseSyntax selectOrGroup = null;
@@ -1039,6 +1041,11 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return SyntaxFactory.SelectClause(
                     (ExpressionSyntax)collectionRangeVariableSyntax.Expression.Accept(TriviaConvertingVisitor)
                 );
+            }
+
+            private static SelectClauseSyntax CreateDefaultSelectClause(FromClauseSyntax fromClauseSyntax)
+            {
+                return SyntaxFactory.SelectClause(SyntaxFactory.IdentifierName(fromClauseSyntax.Identifier));
             }
 
             private QueryClauseSyntax ConvertQueryBodyClause(VBSyntax.QueryClauseSyntax node)

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using VbSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using CsSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+using SyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
 
 namespace ICSharpCode.CodeConverter.VB
 {
@@ -25,6 +26,13 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode DefaultVisit(SyntaxNode node)
         {
             return TriviaConverter.PortConvertedTrivia(node, _wrappedVisitor.Visit(node));
+        }
+
+        public override VisualBasicSyntaxNode VisitAttributeList(CsSyntax.AttributeListSyntax node)
+        {
+            var convertedNode = _wrappedVisitor.Visit(node)
+                .WithPrependedLeadingTrivia(SyntaxFactory.EndOfLineTrivia(Environment.NewLine));
+            return TriviaConverter.PortConvertedTrivia(node, convertedNode);
         }
     }
 }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -593,6 +593,24 @@ End Sub", @"public void Linq103()
         }
 
         [Fact]
+        public void Linq5()
+        {
+            TestConversionVisualBasicToCSharp(@"Private Shared Function FindPicFilePath(picId As String) As String
+    For Each FileInfo As FileInfo In From FileInfo1 In AList Where FileInfo1.Name.Substring(0, 6) = picId
+        Return FileInfo.FullName
+    Next
+    Return String.Empty
+End Function", @"private static string FindPicFilePath(string picId)
+{
+    foreach (FileInfo FileInfo in from FileInfo1 in AList
+                                  where FileInfo1.Name.Substring(0, 6) == picId
+                                  select FileInfo1)
+        return FileInfo.FullName;
+    return string.Empty;
+}");
+        }
+
+        [Fact]
         public void PartiallyQualifiedName()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -188,6 +188,21 @@ End Class");
         }
 
         [Fact]
+        public void TestPropertyWithAttribute()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"class TestClass
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    int value { get; set; }
+}", @"Class TestClass
+    <DatabaseGenerated(DatabaseGeneratedOption.None)>
+    Private Property value As Integer
+End Class
+");
+        }
+
+        [Fact]
         public void TestConstructor()
         {
             TestConversionCSharpToVisualBasic(


### PR DESCRIPTION
Should fix up specific examples from #15 and #29, though doesn't fully solve the overarching issue