### PR TITLE
Support VB's DirectCast, and improve Shadows keyword conversion

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -736,11 +736,21 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitCTypeExpression(VBSyntax.CTypeExpressionSyntax node)
             {
-                var expressionSyntax = (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor);
                 var convertMethodForKeywordOrNull = GetConvertMethodForKeywordOrNull(node.Type);
+                return ConvertCastExpression(node, convertMethodForKeywordOrNull);
+            }
 
-                return convertMethodForKeywordOrNull != null ?
-                    SyntaxFactory.InvocationExpression(convertMethodForKeywordOrNull,
+            public override CSharpSyntaxNode VisitDirectCastExpression(VBSyntax.DirectCastExpressionSyntax node)
+            {
+                return ConvertCastExpression(node);
+            }
+
+            private CSharpSyntaxNode ConvertCastExpression(VBSyntax.CastExpressionSyntax node, ExpressionSyntax convertMethodOrNull = null)
+            {
+                var expressionSyntax = (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor);
+
+                return convertMethodOrNull != null ?
+                    SyntaxFactory.InvocationExpression(convertMethodOrNull,
                         SyntaxFactory.ArgumentList(
                             SyntaxFactory.SingletonSeparatedList(
                                 SyntaxFactory.Argument(expressionSyntax)))

--- a/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
@@ -311,6 +311,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return SyntaxKind.ReadOnlyKeyword;
                 case VBasic.SyntaxKind.OverridesKeyword:
                     return SyntaxKind.OverrideKeyword;
+                //New isn't as restrictive as shadows, but it will behave the same for all existing programs
+                case VBasic.SyntaxKind.ShadowsKeyword:
                 case VBasic.SyntaxKind.OverloadsKeyword:
                     return SyntaxKind.NewKeyword;
                 case VBasic.SyntaxKind.OverridableKeyword:

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -279,7 +279,7 @@ namespace ICSharpCode.CodeConverter.VB
                     // not supported
                     return SyntaxKind.None;
                 case CS.SyntaxKind.NewKeyword:
-                    return SyntaxKind.ShadowsKeyword;
+                    return SyntaxKind.OverloadsKeyword;
                 case CS.SyntaxKind.ParamsKeyword:
                     return SyntaxKind.ParamArrayKeyword;
                 // others

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -1464,11 +1464,14 @@ End Function";
 
             VisualBasicSyntaxNode WrapTypedNameIfNecessary(ExpressionSyntax name, CSS.ExpressionSyntax originalName)
             {
-                if (originalName.Parent is CSS.NameSyntax || originalName.Parent is CSS.AttributeSyntax || originalName.Parent is CSS.MemberAccessExpressionSyntax || originalName.Parent is CSS.MemberBindingExpressionSyntax) return name;
-                if (originalName != null && originalName.Parent is CSS.InvocationExpressionSyntax)
+                if (originalName.Parent is CSS.NameSyntax
+                    || originalName.Parent is CSS.AttributeSyntax
+                    || originalName.Parent is CSS.MemberAccessExpressionSyntax
+                    || originalName.Parent is CSS.MemberBindingExpressionSyntax
+                    || originalName.Parent is CSS.InvocationExpressionSyntax)
                     return name;
 
-                var symbolInfo = ModelExtensions.GetSymbolInfo(semanticModel, originalName);
+                var symbolInfo = semanticModel.GetSymbolInfo(originalName);
                 var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
                 if (symbol.IsKind(SymbolKind.Method))
                     return SyntaxFactory.AddressOfExpression(name);

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -181,6 +181,46 @@ class TestClass
         }
 
         [Fact]
+        public void TestShadowedMethod()
+        {
+            TestConversionVisualBasicToCSharp(
+                @"Class TestClass
+    Public Sub TestMethod()
+    End Sub
+
+    Public Sub TestMethod(i as Integer)
+    End Sub
+End Class
+
+Class TestSubclass
+    Inherits TestClass
+
+    Public Shadows Sub TestMethod()
+        ' Not possible: TestMethod(3)
+        System.Console.WriteLine(""New implementation"")
+    End Sub
+End Class", @"class TestClass
+{
+    public void TestMethod()
+    {
+    }
+
+    public void TestMethod(int i)
+    {
+    }
+}
+
+class TestSubclass : TestClass
+{
+    public new void TestMethod()
+    {
+        // Not possible: TestMethod(3)
+        System.Console.WriteLine(""New implementation"");
+    }
+}");
+        }
+
+        [Fact]
         public void TestExtensionMethod()
         {
             TestConversionVisualBasicToCSharp(

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -38,12 +38,7 @@ class Class1
         Dim o As Object = ""Test""
         Dim s As String = CStr(o)
     End Sub
-End Class" + Environment.NewLine, @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+End Class" + Environment.NewLine, @"class Class1
 {
     private void Test()
     {
@@ -51,6 +46,25 @@ class Class1
         string s = System.Convert.ToString(o);
     }
 }" + Environment.NewLine);
+        }
+
+        [Fact]
+        public void DirectCastDoubleToInt()
+        {
+            TestConversionVisualBasicToCSharp(
+@"Class Class1
+    Private Sub Test()
+        Dim q = 2.37
+        Dim j = DirectCast(q, Integer)
+    End Sub
+End Class", @"class Class1
+{
+    private void Test()
+    {
+        var q = 2.37;
+        var j = (int)q;
+    }
+}");
         }
 
         [Fact]

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -92,6 +92,46 @@ End Class");
         }
 
         [Fact]
+        public void TestNewMethodIsOverloadsNotShadows()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"class TestClass
+{
+    public void TestMethod()
+    {
+    }
+
+    public void TestMethod(int i)
+    {
+    }
+}
+
+class TestSubclass : TestClass
+{
+    public new void TestMethod()
+    {
+        TestMethod(3);
+        System.Console.WriteLine(""Shadowed implementation"");
+    }
+}", @"Class TestClass
+    Public Sub TestMethod()
+    End Sub
+
+    Public Sub TestMethod(ByVal i As Integer)
+    End Sub
+End Class
+
+Class TestSubclass
+    Inherits TestClass
+
+    Public Overloads Sub TestMethod()
+        TestMethod(3)
+        System.Console.WriteLine(""Shadowed implementation"")
+    End Sub
+End Class");
+        }
+
+        [Fact]
         public void TestSealedMethod()
         {
             TestConversionCSharpToVisualBasic(

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -113,7 +113,7 @@ End Class");
         }
 
         [Fact]
-        public void NarrowingWideningExpression()
+        public void TestNarrowingWideningConversionOperator()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class MyInt
     Public Shared Narrowing Operator CType(i As Integer) As MyInt


### PR DESCRIPTION
* Handle DirectCast
* VB -> C#: Convert Shadows to "new"  …
* Fix bug: New keyword should map to overloads, not shadows  …