### PR TITLE
Dormant: Rewrite trivia at end

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
@@ -27,50 +27,49 @@ namespace ICSharpCode.CodeConverter.CSharp
             return TriviaConverter.PortConvertedTrivia(node, wrappedVisitor.Visit(node));
         }
 
-        //public override CSharpSyntaxNode VisitModuleBlock(VbSyntax.ModuleBlockSyntax node)
-        //{
-        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        //}
+        public override CSharpSyntaxNode VisitModuleBlock(VbSyntax.ModuleBlockSyntax node)
+        {
+            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        }
 
-        //public override CSharpSyntaxNode VisitStructureBlock(VbSyntax.StructureBlockSyntax node)
-        //{
-        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        //}
+        public override CSharpSyntaxNode VisitStructureBlock(VbSyntax.StructureBlockSyntax node)
+        {
+            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        }
 
-        //public override CSharpSyntaxNode VisitInterfaceBlock(VbSyntax.InterfaceBlockSyntax node)
-        //{
-        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        //}
+        public override CSharpSyntaxNode VisitInterfaceBlock(VbSyntax.InterfaceBlockSyntax node)
+        {
+            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        }
 
-        //public override CSharpSyntaxNode VisitClassBlock(VbSyntax.ClassBlockSyntax node)
-        //{
-        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        //}
+        public override CSharpSyntaxNode VisitClassBlock(VbSyntax.ClassBlockSyntax node)
+        {
+            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        }
 
-        //public override CSharpSyntaxNode VisitCompilationUnit(VbSyntax.CompilationUnitSyntax node)
-        //{
-        //    var cSharpSyntaxNode = (CsSyntax.CompilationUnitSyntax) base.VisitCompilationUnit(node);
-        //    cSharpSyntaxNode = cSharpSyntaxNode.WithEndOfFileToken(
-        //        cSharpSyntaxNode.EndOfFileToken.WithConvertedLeadingTriviaFrom(node.EndOfFileToken));
-        //    ; 
-        //    return TriviaConverter.IsAllTriviaConverted() 
-        //        ? cSharpSyntaxNode 
-        //        : cSharpSyntaxNode.WithAppendedTrailingTrivia(SyntaxFactory.Comment("/* Some trivia (e.g. comments) could not be converted */"));
-        //}
+        public override CSharpSyntaxNode VisitCompilationUnit(VbSyntax.CompilationUnitSyntax node)
+        {
+            var cSharpSyntaxNode = (CsSyntax.CompilationUnitSyntax)base.VisitCompilationUnit(node);
+            cSharpSyntaxNode = cSharpSyntaxNode.WithEndOfFileToken(
+                cSharpSyntaxNode.EndOfFileToken.WithConvertedLeadingTriviaFrom(node.EndOfFileToken));
+            ;
+            return TriviaConverter.IsAllTriviaConverted()
+                ? cSharpSyntaxNode
+                : cSharpSyntaxNode.WithAppendedTrailingTrivia(SyntaxFactory.Comment("/* Some trivia (e.g. comments) could not be converted */"));
+        }
 
-        //private TDest WithPortedTrivia<TSource, TDest>(SyntaxNode node, Func<TSource, TDest, TDest> portExtraTrivia) where TSource : SyntaxNode where TDest : CSharpSyntaxNode
-        //{
-        //    var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)wrappedVisitor.Visit(node));
-        //    return TriviaConverter.PortConvertedTrivia(node, cSharpSyntaxNode);
-        //}
+        private TDest WithPortedTrivia<TSource, TDest>(SyntaxNode node, Func<TSource, TDest, TDest> portExtraTrivia) where TSource : SyntaxNode where TDest : CSharpSyntaxNode
+        {
+            var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)wrappedVisitor.Visit(node));
+            return TriviaConverter.PortConvertedTrivia(node, cSharpSyntaxNode);
+        }
 
-        //private CsSyntax.BaseTypeDeclarationSyntax WithTypeBlockTrivia(VbSyntax.TypeBlockSyntax sourceNode, CsSyntax.BaseTypeDeclarationSyntax destNode)
-        //{
-        //    var beforeOpenBrace = destNode.OpenBraceToken.GetPreviousToken();
-        //    var withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.BlockStatement, beforeOpenBrace);
-        //    withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Inherits, withAnnotation);
-        //    withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Implements, withAnnotation);
-        //    return destNode.ReplaceToken(beforeOpenBrace, withAnnotation);
-        //}
+        private CsSyntax.BaseTypeDeclarationSyntax WithTypeBlockTrivia(VbSyntax.TypeBlockSyntax sourceNode, CsSyntax.BaseTypeDeclarationSyntax destNode)
+        {
+            var withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.BlockStatement, destNode);
+            withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Inherits, withAnnotation);
+            withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Implements, withAnnotation);
+            return withAnnotation;
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommentConvertingNodesVisitor.cs
@@ -27,50 +27,50 @@ namespace ICSharpCode.CodeConverter.CSharp
             return TriviaConverter.PortConvertedTrivia(node, wrappedVisitor.Visit(node));
         }
 
-        public override CSharpSyntaxNode VisitModuleBlock(VbSyntax.ModuleBlockSyntax node)
-        {
-            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        }
+        //public override CSharpSyntaxNode VisitModuleBlock(VbSyntax.ModuleBlockSyntax node)
+        //{
+        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        //}
 
-        public override CSharpSyntaxNode VisitStructureBlock(VbSyntax.StructureBlockSyntax node)
-        {
-            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        }
+        //public override CSharpSyntaxNode VisitStructureBlock(VbSyntax.StructureBlockSyntax node)
+        //{
+        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        //}
 
-        public override CSharpSyntaxNode VisitInterfaceBlock(VbSyntax.InterfaceBlockSyntax node)
-        {
-            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        }
+        //public override CSharpSyntaxNode VisitInterfaceBlock(VbSyntax.InterfaceBlockSyntax node)
+        //{
+        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        //}
 
-        public override CSharpSyntaxNode VisitClassBlock(VbSyntax.ClassBlockSyntax node)
-        {
-            return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
-        }
+        //public override CSharpSyntaxNode VisitClassBlock(VbSyntax.ClassBlockSyntax node)
+        //{
+        //    return WithPortedTrivia<VbSyntax.TypeBlockSyntax, CsSyntax.BaseTypeDeclarationSyntax>(node, WithTypeBlockTrivia);
+        //}
 
-        public override CSharpSyntaxNode VisitCompilationUnit(VbSyntax.CompilationUnitSyntax node)
-        {
-            var cSharpSyntaxNode = (CsSyntax.CompilationUnitSyntax) base.VisitCompilationUnit(node);
-            cSharpSyntaxNode = cSharpSyntaxNode.WithEndOfFileToken(
-                cSharpSyntaxNode.EndOfFileToken.WithConvertedLeadingTriviaFrom(node.EndOfFileToken));
-            ; 
-            return TriviaConverter.IsAllTriviaConverted() 
-                ? cSharpSyntaxNode 
-                : cSharpSyntaxNode.WithAppendedTrailingTrivia(SyntaxFactory.Comment("/* Some trivia (e.g. comments) could not be converted */"));
-        }
+        //public override CSharpSyntaxNode VisitCompilationUnit(VbSyntax.CompilationUnitSyntax node)
+        //{
+        //    var cSharpSyntaxNode = (CsSyntax.CompilationUnitSyntax) base.VisitCompilationUnit(node);
+        //    cSharpSyntaxNode = cSharpSyntaxNode.WithEndOfFileToken(
+        //        cSharpSyntaxNode.EndOfFileToken.WithConvertedLeadingTriviaFrom(node.EndOfFileToken));
+        //    ; 
+        //    return TriviaConverter.IsAllTriviaConverted() 
+        //        ? cSharpSyntaxNode 
+        //        : cSharpSyntaxNode.WithAppendedTrailingTrivia(SyntaxFactory.Comment("/* Some trivia (e.g. comments) could not be converted */"));
+        //}
 
-        private TDest WithPortedTrivia<TSource, TDest>(SyntaxNode node, Func<TSource, TDest, TDest> portExtraTrivia) where TSource : SyntaxNode where TDest : CSharpSyntaxNode
-        {
-            var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)wrappedVisitor.Visit(node));
-            return TriviaConverter.PortConvertedTrivia(node, cSharpSyntaxNode);
-        }
+        //private TDest WithPortedTrivia<TSource, TDest>(SyntaxNode node, Func<TSource, TDest, TDest> portExtraTrivia) where TSource : SyntaxNode where TDest : CSharpSyntaxNode
+        //{
+        //    var cSharpSyntaxNode = portExtraTrivia((TSource)node, (TDest)wrappedVisitor.Visit(node));
+        //    return TriviaConverter.PortConvertedTrivia(node, cSharpSyntaxNode);
+        //}
 
-        private CsSyntax.BaseTypeDeclarationSyntax WithTypeBlockTrivia(VbSyntax.TypeBlockSyntax sourceNode, CsSyntax.BaseTypeDeclarationSyntax destNode)
-        {
-            var beforeOpenBrace = destNode.OpenBraceToken.GetPreviousToken();
-            var withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.BlockStatement, beforeOpenBrace);
-            withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Inherits, withAnnotation);
-            withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Implements, withAnnotation);
-            return destNode.ReplaceToken(beforeOpenBrace, withAnnotation);
-        }
+        //private CsSyntax.BaseTypeDeclarationSyntax WithTypeBlockTrivia(VbSyntax.TypeBlockSyntax sourceNode, CsSyntax.BaseTypeDeclarationSyntax destNode)
+        //{
+        //    var beforeOpenBrace = destNode.OpenBraceToken.GetPreviousToken();
+        //    var withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.BlockStatement, beforeOpenBrace);
+        //    withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Inherits, withAnnotation);
+        //    withAnnotation = TriviaConverter.WithDelegateToParentAnnotation(sourceNode.Implements, withAnnotation);
+        //    return destNode.ReplaceToken(beforeOpenBrace, withAnnotation);
+        //}
     }
 }

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -691,15 +691,17 @@ namespace ICSharpCode.CodeConverter.CSharp
                         SyntaxFactory.ParseTypeName(typeInfo.ToMinimalDisplayString(semanticModel, node.SpanStart)),
                         ConvertIdentifier(stmt.IdentifierName.Identifier, semanticModel)
                     );
+                    catcher = catcher.WithConvertedTrailingTriviaFromNode(node.CatchStatement.CatchKeyword);
                 }
 
                 var filter = (CatchFilterClauseSyntax)stmt.WhenClause?.Accept(TriviaConvertingVisitor);
 
-                return SyntaxFactory.CatchClause(
+                var catchClause = SyntaxFactory.CatchClause(
                     catcher,
                     filter,
                     SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CreateMethodBodyVisitor())))
                 );
+                return catchClause.WithCatchKeyword(catchClause.CatchKeyword.WithConvertedTrailingTriviaFrom(node.CatchStatement.CatchKeyword));
             }
 
             public override CSharpSyntaxNode VisitCatchFilterClause(VBSyntax.CatchFilterClauseSyntax node)
@@ -709,7 +711,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitFinallyBlock(VBSyntax.FinallyBlockSyntax node)
             {
-                return SyntaxFactory.FinallyClause(SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CreateMethodBodyVisitor()))));
+                var finallyClause = SyntaxFactory.FinallyClause(SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CreateMethodBodyVisitor()))));
+                return finallyClause.WithFinallyKeyword(finallyClause.FinallyKeyword.WithConvertedTrailingTriviaFrom(node.FinallyStatement.FinallyKeyword));
             }
 
 

--- a/ICSharpCode.CodeConverter/CSharp/TriviaConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TriviaConverter.cs
@@ -40,24 +40,6 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             if (!(destination is CS.Syntax.CompilationUnitSyntax)) return destination;
             
-            var firstLineOfBlockConstruct = sourceNode.ChildNodes().OfType<StatementSyntax>().FirstOrDefault(IsFirstLineOfBlockConstruct);
-            if (firstLineOfBlockConstruct != null) {
-                var endOfFirstLineConstructOrDefault = destination.ChildTokens().FirstOrDefault(t => t.IsKind(SyntaxKind.CloseParenToken, SyntaxKind.OpenBraceToken));
-                if (endOfFirstLineConstructOrDefault.IsKind(SyntaxKind.OpenBraceToken)) {
-                    endOfFirstLineConstructOrDefault = endOfFirstLineConstructOrDefault.GetPreviousToken();
-                }
-                if (endOfFirstLineConstructOrDefault != default(SyntaxToken)) {
-                    var withNewAnnotations = MoveChildTrailingEndOfLinesToToken(destination, endOfFirstLineConstructOrDefault);
-                    destination = destination.ReplaceToken(endOfFirstLineConstructOrDefault, withNewAnnotations);
-                }
-            }
-
-            foreach (var leafStatment in destination.DescendantNodesAndSelf().OfType<CS.Syntax.StatementSyntax>().Where(s => !s.DescendantNodes().OfType<CS.Syntax.StatementSyntax>().Any())) {
-                var endOfStatement = leafStatment.GetLastToken();
-                var withNewAnnotations = MoveChildTrailingEndOfLinesToToken(leafStatment, endOfStatement);
-                destination = destination.ReplaceToken(endOfStatement, withNewAnnotations);
-            }
-
             return WithTrailingTriviaConversions(destination, sourceNode.Parent?.GetLastToken(), true);
                 
         }

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -818,6 +818,12 @@ namespace ICSharpCode.CodeConverter.Util
             return node.WithLeadingTrivia(convertedTrivia);
         }
 
+        public static T WithConvertedTrailingTriviaFromNode<T>(this T node, SyntaxToken otherToken) where T: SyntaxNode
+        {
+            var lastToken = node.GetLastToken();
+            return node.ReplaceToken(lastToken, lastToken.WithConvertedTrailingTriviaFrom(otherToken));
+        }
+
         public static SyntaxToken WithConvertedTrailingTriviaFrom(this SyntaxToken node, SyntaxNode otherNode)
         {
             return node.WithConvertedTrailingTriviaFrom(otherNode?.GetLastToken());


### PR DESCRIPTION
Just to keep track of my plan for simplifying/improving after #24 
Essentially the trivia rewriting is overcomplicated, and made less reliable by relying on visiting every node on the way up and just checking its children for trivia porting annotations that need moving.
This is because checking multiple levels deep for annotations on each node seemed like a terrible idea performance-wise.
However, it'd be more reliable, and have a lower computational complexity to just walk the whole tree at the end adding all the trivia. It should also make the code simpler to understand. The only real downside is a small multiplicative constant factor more memory usage. 

The two things to watch out for performance-wise:
* Make sure it remains efficient to insert into the structure when it has lots of annotation data already in
* Make sure the computational complexity of the work done to decide on annotations isn't tied to the size of the annotation data structure (this may involve essentially setting up a two-way dictionary, or might already be fine)