### PR TITLE
VB -> C#: Using statements and array initialization

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,30 +22,63 @@ namespace ICSharpCode.CodeConverter.CSharp
         public CSharpSyntaxNode Fix()
         {
             var syntaxNode = _syntaxTree.GetRoot();
-            return syntaxNode.ReplaceNodes(syntaxNode.DescendantNodes(), ComputeReplacementNode);
+            return syntaxNode.ReplaceNodes(syntaxNode.DescendantNodes(), ComputeReplacementNode)
+                .TypeSwitch(
+                    (CompilationUnitSyntax x) => TidyUsings(x),
+                    node => node
+                );
         }
 
         private SyntaxNode ComputeReplacementNode(SyntaxNode originalNode, SyntaxNode potentiallyRewrittenNode)
         {
-            if (!(potentiallyRewrittenNode is ArgumentListSyntax nodeToReturn)) return potentiallyRewrittenNode;
+            return potentiallyRewrittenNode.TypeSwitch(
+                (ArgumentListSyntax x) => FixOutParameters(x),
+                node => node
+            );
+        }
 
-            var invocationExpression = nodeToReturn.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-            if (invocationExpression == null) return potentiallyRewrittenNode;
+        /// <remarks>These are tidied up so we can add as many GlobalImports as we want when building compilations</remarks>
+        private CSharpSyntaxNode TidyUsings(CompilationUnitSyntax compilationUnitSyntax)
+        {
+            var unusedUsings = _semanticModel.GetDiagnostics().ToList()
+                .Where(d => d.Id == "CS8019")
+                .Select(d => compilationUnitSyntax.FindNode(d.Location.SourceSpan))
+                .ToList();
+            if (unusedUsings.Any()) {
+                compilationUnitSyntax = compilationUnitSyntax.RemoveNodes(unusedUsings, SyntaxRemoveOptions.KeepNoTrivia);
+            }
+
+            return compilationUnitSyntax;
+        }
+
+        private SyntaxNode FixOutParameters(ArgumentListSyntax argumentListSyntax)
+        {
+            var invocationExpression = argumentListSyntax.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocationExpression == null) {
+                return argumentListSyntax;
+            }
 
             var methodSymbol = _semanticModel.GetSymbolInfo(invocationExpression).CandidateSymbols.OfType<IMethodSymbol>()
-                .FirstOrDefault(s => invocationExpression.ArgumentList.Arguments.Count == s.Parameters.Length);
-            if (methodSymbol != null) {
+                .FirstOrDefault(s => argumentListSyntax.Arguments.Count == s.Parameters.Length);
+            if (methodSymbol != null)
+            {
                 //Won't work for named parameters
-                for (var index = 0; index < Math.Min(nodeToReturn.Arguments.Count, methodSymbol.Parameters.Length); index++) {
-                    var argument = nodeToReturn.Arguments[index];
+                for (var index = 0;
+                    index < Math.Min(argumentListSyntax.Arguments.Count, methodSymbol.Parameters.Length);
+                    index++)
+                {
+                    var argument = argumentListSyntax.Arguments[index];
                     var refOrOutKeyword = GetRefKeyword(methodSymbol.Parameters[index]);
-                    var currentSyntaxKind = nodeToReturn.Arguments[index].Kind();
-                    if (!refOrOutKeyword.IsKind(currentSyntaxKind)) {
-                        nodeToReturn = nodeToReturn.ReplaceNode(argument, argument.WithRefOrOutKeyword(refOrOutKeyword));
+                    var currentSyntaxKind = argumentListSyntax.Arguments[index].Kind();
+                    if (!refOrOutKeyword.IsKind(currentSyntaxKind))
+                    {
+                        argumentListSyntax =
+                            argumentListSyntax.ReplaceNode(argument, argument.WithRefOrOutKeyword(refOrOutKeyword));
                     }
                 }
             }
-            return nodeToReturn;
+
+            return argumentListSyntax;
         }
 
         private static SyntaxToken GetRefKeyword(IParameterSymbol formalParameter)

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -257,7 +257,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var predefinedKeywordKind = convertedType.SpecialType.GetPredefinedKeywordKind();
                 if (predefinedKeywordKind != SyntaxKind.None) return SyntaxFactory.PredefinedType(SyntaxFactory.Token(predefinedKeywordKind));
-                return SyntaxFactory.ParseTypeName(convertedType.ToMinimalDisplayString(_semanticModel, nodeSpanStart));
+                return SyntaxFactory.ParseTypeName(convertedType.ToMinimalCSharpDisplayString(_semanticModel, nodeSpanStart));
             }
 
             public override SyntaxList<StatementSyntax> VisitThrowStatement(VBSyntax.ThrowStatementSyntax node)
@@ -303,7 +303,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         else if (info.IsReferenceType)
                             expr = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
                         else if (info.CanBeReferencedByName)
-                            expr = SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(info.ToMinimalDisplayString(_semanticModel, node.SpanStart)));
+                            expr = SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(info.ToMinimalCSharpDisplayString(_semanticModel, node.SpanStart)));
                         else
                             throw new NotSupportedException();
                         return SingleStatement(SyntaxFactory.ReturnStatement(expr));

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -728,7 +728,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 else {
                     var typeInfo = _semanticModel.GetTypeInfo(stmt.IdentifierName).Type;
                     catcher = SyntaxFactory.CatchDeclaration(
-                        SyntaxFactory.ParseTypeName(typeInfo.ToMinimalDisplayString(_semanticModel, node.SpanStart)),
+                        SyntaxFactory.ParseTypeName(typeInfo.ToMinimalCSharpDisplayString(_semanticModel, node.SpanStart)),
                         ConvertIdentifier(stmt.IdentifierName.Identifier)
                     );
                 }
@@ -825,7 +825,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                             .WithTrailingTrivia(
                                 SyntaxFactory.Comment("/* TODO Change to default(_) if this is not a reference type */"));
                     }
-                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(_semanticModel, node.SpanStart))) : Literal(null);
+                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(type.ToMinimalCSharpDisplayString(_semanticModel, node.SpanStart))) : Literal(null);
                 }
                 return Literal(node.Token.Value, node.Token.Text);
             }
@@ -1340,7 +1340,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             public override CSharpSyntaxNode VisitPredefinedType(VBSyntax.PredefinedTypeSyntax node)
             {
                 if (SyntaxTokenExtensions.IsKind(node.Keyword, VBasic.SyntaxKind.DateKeyword)) {
-                    return SyntaxFactory.IdentifierName("System.DateTime");
+                    return SyntaxFactory.IdentifierName("DateTime");
                 }
                 return SyntaxFactory.PredefinedType(node.Keyword.ConvertToken());
             }
@@ -1431,18 +1431,18 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 var targetSymbolInfo = GetSymbolInfoInDocument(node);
 
-                var qualifiedName = targetSymbolInfo?.ToDisplayString(referenceSymbolFormat);
+                var qualifiedName = targetSymbolInfo?.ToCSharpDisplayString(referenceSymbolFormat);
                 var sourceText = node.WithoutTrivia().GetText().ToString().Trim();
                 if (qualifiedName == null || sourceText.Length >= qualifiedName.Length ||
                     !qualifiedName.EndsWith(sourceText, StringComparison.Ordinal)) return defaultNode;
 
                 var typeBlockSyntax = node.GetAncestor<VBSyntax.TypeBlockSyntax>();
 
-                var typeOrNamespace = targetSymbolInfo.ContainingNamespace.ToDisplayString(referenceSymbolFormat);
+                var typeOrNamespace = targetSymbolInfo.ContainingNamespace.ToCSharpDisplayString(referenceSymbolFormat);
                 if (typeBlockSyntax != null) {
                     var declaredSymbol = _semanticModel.GetDeclaredSymbol(typeBlockSyntax);
                     var prefixes = GetSymbolQualification(declaredSymbol)
-                    .Where(x => x != null).Select(p => p.ToDisplayString(referenceSymbolFormat) + ".");
+                    .Where(x => x != null).Select(p => p.ToCSharpDisplayString(referenceSymbolFormat) + ".");
                     var firstMatch = prefixes.FirstOrDefault(p => qualifiedName.StartsWith(p));
                     if (firstMatch != null)
                     {

--- a/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
@@ -25,7 +25,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             _targetCompilation = new Lazy<CSharpCompilation>(() => {
                 var references = _sourceCompilation.References.Select(ConvertReference);
-                return CSharpCompilation.Create("Conversion", _firstPassResults, references);
+                return CSharpCompilation.Create("Conversion", _firstPassResults, references, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             });
         }
 

--- a/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
@@ -118,7 +118,13 @@ End Class";
         {
             var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithRootNamespace("TestProject")
-                .WithGlobalImports(GlobalImport.Parse("System", "System.Collections.Generic", "System.Linq",
+
+                .WithGlobalImports(GlobalImport.Parse(
+                    "System",
+                    "System.Collections.Generic",
+                    "System.Linq",
+                    "System.Text",
+                    "System.Threading.Tasks",
                     "Microsoft.VisualBasic"));
             var compilation = VisualBasicCompilation.Create("Conversion", new[] {tree}, references)
                 .WithOptions(compilationOptions);

--- a/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
@@ -206,7 +206,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             VBasic.SyntaxKind vbSyntaxKind = VBasic.VisualBasicExtensions.Kind(m);
             switch (vbSyntaxKind) {
                 case VBasic.SyntaxKind.DateKeyword:
-                    return SyntaxFactory.Identifier("System.DateTime");
+                    return SyntaxFactory.Identifier("DateTime");
             }
             var token = SyntaxKindExtensions.ConvertToken(vbSyntaxKind, context);
             return token == SyntaxKind.None ? null : new SyntaxToken?(SyntaxFactory.Token(token));

--- a/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VisualBasicConverter.cs
@@ -185,8 +185,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     } else if (text.StartsWith("_", StringComparison.Ordinal) && symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Property) == true) {
 
                         text = fieldSymbol.AssociatedSymbol.Name;
-                    } else
-                        text = symbol.Name;
+                    }
                 }
             }
             return SyntaxFactory.Identifier(text);

--- a/ICSharpCode.CodeConverter/Util/CSharpUtil.cs
+++ b/ICSharpCode.CodeConverter/Util/CSharpUtil.cs
@@ -251,7 +251,7 @@ namespace ICSharpCode.CodeConverter.Util
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
-            return SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(model, typeSyntax.SpanStart))
+            return SyntaxFactory.ParseTypeName(type.ToMinimalCSharpDisplayString(model, typeSyntax.SpanStart))
                 .WithLeadingTrivia(typeSyntax.GetLeadingTrivia())
                 .WithTrailingTrivia(typeSyntax.GetTrailingTrivia());
         }

--- a/ICSharpCode.CodeConverter/Util/INamespaceOrTypeSymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/INamespaceOrTypeSymbolExtensions.cs
@@ -21,7 +21,7 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static string GetShortName(this INamespaceOrTypeSymbol symbol)
         {
-            return symbol.ToDisplayString(s_shortNameFormat);
+            return symbol.ToCSharpDisplayString(s_shortNameFormat);
         }
 
         public static IEnumerable<IPropertySymbol> GetIndexers(this INamespaceOrTypeSymbol symbol)

--- a/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
@@ -178,6 +178,20 @@ namespace ICSharpCode.CodeConverter.Util
                 return info.CandidateSymbols[0];
             return null;
         }
+
+        public static string ToMinimalCSharpDisplayString(this ISymbol symbol, SemanticModel vbSemanticModel, int position, SymbolDisplayFormat format = null)
+        {
+            var output = symbol.ToMinimalDisplayString(vbSemanticModel, position, format);
+            if (symbol is ITypeSymbol && output == "Date") return "DateTime";
+            return output;
+        }
+
+        public static string ToCSharpDisplayString(this ISymbol symbol, SymbolDisplayFormat format = null)
+        {
+            var output = symbol.ToDisplayString(format);
+            if (symbol is ITypeSymbol && output == "Date") return "DateTime";
+            return output;
+        }
     }
 }
 

--- a/ICSharpCode.CodeConverter/Util/TypeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/TypeExtensions.cs
@@ -33,7 +33,7 @@ namespace ICSharpCode.CodeConverter.Util
         /// </summary>
         public static string GetFullName(this INamespaceSymbol ns)
         {
-            return ns.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+            return ns.ToCSharpDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace ICSharpCode.CodeConverter.Util
         /// </summary>
         public static string GetFullName(this ITypeSymbol type)
         {
-            return type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
+            return type.ToCSharpDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
         }
 
         /// <summary>

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -32,12 +32,7 @@ World!"";
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private DefaultDate as Date = Nothing
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private System.DateTime DefaultDate = default(Date);
 }");
@@ -92,7 +87,9 @@ End Class", @"class TestClass
         x \= 4
         x ^= 5
     End Sub
-End Class", @"class TestClass
+End Class", @"using System;
+
+class TestClass
 {
     private void TestMethod()
     {
@@ -139,12 +136,7 @@ End Class", @"class TestClass
     Private Sub TestMethod()
         Dim strings = { ""1"", ""2"" }
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -161,9 +153,6 @@ class TestClass
         Dim str = (New ThreadStaticAttribute).ToString
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -182,12 +171,7 @@ class TestClass
         Dim str = ""Hello, ""
         str &= ""World""
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -204,12 +188,7 @@ class TestClass
     Private Sub TestMethod()
         Dim typ = GetType(String)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -226,12 +205,7 @@ class TestClass
         Dim s = ""1,2""
         Return s.Split(s(1))
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private string[] TestMethod()
     {
@@ -248,12 +222,7 @@ class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim result As Boolean = If((str = """"), True, False)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod(string str)
     {
@@ -270,9 +239,6 @@ class TestClass
         Console.WriteLine(If(str, ""<null>""))
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -294,9 +260,6 @@ class TestClass
         Console.ReadKey()
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -319,10 +282,7 @@ class TestClass
         Dim s As String
         d.TryGetValue(""a"", s)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
+End Class", @"using System.Collections.Generic;
 
 class TestClass
 {
@@ -377,9 +337,6 @@ class TestClass
         Dim redirectUri As String = context.OwinContext.Authentication?.AuthenticationResponseChallenge?.Properties?.RedirectUri
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -443,12 +400,7 @@ End Class", @"class TestClass
     Private Sub TestMethod()
         Me.member = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private int member;
 
@@ -472,12 +424,7 @@ Class TestClass
     Private Sub TestMethod()
         MyBase.member = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class BaseTestClass
+End Class", @"class BaseTestClass
 {
     public int member;
 }
@@ -499,12 +446,7 @@ class TestClass : BaseTestClass
         Dim test = Function(ByVal a As Integer) a * 2
         test(3)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -528,12 +470,7 @@ class TestClass
         Dim test3 = Function(a, b) a Mod b
         test(3)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -564,9 +501,7 @@ class TestClass
         Console.WriteLine(result)
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
+using System.Threading.Tasks;
 
 class TestClass
 {
@@ -657,7 +592,10 @@ Class Test
         Next
     End Sub
 End Class",
-                @"class Product
+                @"using System;
+using System.Linq;
+
+class Product
 {
     public string Category;
     public string ProductName;
@@ -737,12 +675,7 @@ End Function", @"private static string FindPicFilePath(string picId)
     Public Function TestMethod(dir As String) As String
          Return IO.Path.Combine(dir, ""file.txt"")
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public string TestMethod(string dir)
     {
@@ -758,10 +691,7 @@ class TestClass
     Public Function TestMethod() As String
          Return vbCrLf
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
+End Class", @"using Microsoft.VisualBasic;
 
 class TestClass
 {

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -34,7 +34,7 @@ World!"";
     Private DefaultDate as Date = Nothing
 End Class", @"class TestClass
 {
-    private System.DateTime DefaultDate = default(Date);
+    private System.DateTime DefaultDate = default(DateTime);
 }");
         }
 
@@ -538,7 +538,7 @@ End Sub",
 
     foreach (var n in res)
         Console.WriteLine(n);
-}", expectUsings: false);
+}");
         }
 
         [Fact]
@@ -570,7 +570,7 @@ End Sub",
         foreach (var n in g.Numbers)
             Console.WriteLine(n);
     }
-}", expectUsings: false);
+}");
         }
 
         [Fact()]
@@ -647,7 +647,7 @@ End Sub", @"public void Linq103()
         foreach (var p in v.Products)
             Console.WriteLine(""   "" + p.ProductName);
     }
-}", expectUsings: false);
+}");
         }
 
         [Fact]
@@ -665,7 +665,7 @@ End Function", @"private static string FindPicFilePath(string picId)
                                   select FileInfo1)
         return FileInfo.FullName;
     return string.Empty;
-}", expectUsings: false);
+}");
         }
 
         [Fact]

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -32,9 +32,11 @@ World!"";
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private DefaultDate as Date = Nothing
-End Class", @"class TestClass
+End Class", @"using System;
+
+class TestClass
 {
-    private System.DateTime DefaultDate = default(DateTime);
+    private DateTime DefaultDate = default(DateTime);
 }");
         }
 

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -12,12 +12,7 @@ namespace CodeConverter.Tests.CSharp
     Const answer As Integer = 42
     Private value As Integer = 10
     ReadOnly v As Integer = 15
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     const int answer = 42;
     private int value = 10;
@@ -37,9 +32,7 @@ class TestClass
         Console.WriteLine(Enumerable.Empty(Of String))
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -66,12 +59,7 @@ class TestClass
         argument2 = Nothing
         argument3 = Nothing
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     /// <summary>Xml doc</summary>
     public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3)
@@ -93,12 +81,7 @@ class TestClass
     Public Function TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) As Integer
         Return 0
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public int TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3)
         where T : class, new()
@@ -119,12 +102,7 @@ class TestClass
         argument2 = Nothing
         argument3 = Nothing
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public static void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3)
         where T : class, new()
@@ -143,12 +121,7 @@ class TestClass
             TestConversionVisualBasicToCSharp(
 @"Class TestClass
     Public MustOverride Sub TestMethod()
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public abstract void TestMethod();
 }");
@@ -164,12 +137,7 @@ class TestClass
         argument2 = Nothing
         argument3 = Nothing
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public sealed void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3)
         where T : class, new()
@@ -256,12 +224,7 @@ Module TestClass
     <Extension()>
     Sub TestMethod(ByVal str As String)
     End Sub
-End Module", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-using System.Runtime.CompilerServices;
-
+End Module", @"
 static class TestClass
 {
     public static void TestMethod(this string str)
@@ -293,12 +256,7 @@ static class TestClass
             Me.m_test3 = value
         End Set
     End Property
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public int Test { get; set; }
 
@@ -333,12 +291,7 @@ class TestClass
 @"Class TestClass(Of T As {Class, New}, T2 As Structure, T3)
     Public Sub New(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass<T, T2, T3>
+End Class", @"class TestClass<T, T2, T3>
     where T : class, new()
     where T2 : struct
 {
@@ -355,12 +308,7 @@ class TestClass<T, T2, T3>
 @"Class TestClass
     Protected Overrides Sub Finalize()
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     ~TestClass()
     {
@@ -375,9 +323,6 @@ class TestClass
 @"Class TestClass
     Public Event MyEvent As EventHandler
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -427,12 +372,7 @@ class TestClass
     Private Shared Property First As Integer
 
     Private Second As Integer = _First
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private static int First { get; set; }
 
@@ -446,10 +386,7 @@ class TestClass
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private ReadOnly Property First As New List(Of String)
     Private Property Second As Integer = 0
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
+End Class", @"using System.Collections.Generic;
 
 class TestClass
 {
@@ -714,12 +651,7 @@ End Class", @"public class AcmeClass" + /* not valid C# - to implement this you'
         {
             TestConversionVisualBasicToCSharp(@"<Global.System.Diagnostics.DebuggerDisplay(""Hello World"")>
 Class TestClass
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-[global::System.Diagnostics.DebuggerDisplay(""Hello World"")]
+End Class", @"[global::System.Diagnostics.DebuggerDisplay(""Hello World"")]
 class TestClass
 {
 }");
@@ -732,9 +664,6 @@ class TestClass
     <ThreadStatic>
     Private Shared First As Integer
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -749,12 +678,7 @@ class TestClass
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private Sub SomeBools(ParamArray anyName As Boolean())
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void SomeBools(params bool[] anyName)
     {
@@ -768,12 +692,7 @@ class TestClass
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private Sub SomeBools(ParamArray bool As Boolean())
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void SomeBools(params bool[] @bool)
     {
@@ -838,12 +757,7 @@ Class MyClassC
         ClA.MA()
         ClA.ClassB.MB()
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class ClA
+End Class", @"class ClA
 {
     public static void MA()
     {

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -8,12 +8,7 @@ namespace CodeConverter.Tests.CSharp
         public void TestNamespace()
         {
             TestConversionVisualBasicToCSharp(@"Namespace Test
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test
+End Namespace", @"namespace Test
 {
 }");
         }
@@ -22,12 +17,7 @@ namespace Test
         public void TestGlobalNamespace()
         {
             TestConversionVisualBasicToCSharp(@"Namespace Global.Test
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test
+End Namespace", @"namespace Test
 {
 }");
         }
@@ -38,9 +28,6 @@ namespace Test
             TestConversionVisualBasicToCSharp(
                 @"<Assembly: CLSCompliant(True)>",
                 @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 [assembly: CLSCompliant(true)]");
         }
@@ -65,12 +52,7 @@ using VB = Microsoft.VisualBasic;");
             TestConversionVisualBasicToCSharp(@"Namespace Test.[class]
     Class TestClass(Of T)
     End Class
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test.@class
+End Namespace", @"namespace Test.@class
 {
     class TestClass<T>
     {
@@ -89,12 +71,7 @@ namespace Test.@class
         Private Sub Test2()
         End Sub
     End Module
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test.@class
+End Namespace", @"namespace Test.@class
 {
     internal static class TestClass
     {
@@ -115,12 +92,7 @@ namespace Test.@class
             TestConversionVisualBasicToCSharp(@"Namespace Test.[class]
     MustInherit Class TestClass
     End Class
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test.@class
+End Namespace", @"namespace Test.@class
 {
     abstract class TestClass
     {
@@ -134,12 +106,7 @@ namespace Test.@class
             TestConversionVisualBasicToCSharp(@"Namespace Test.[class]
     NotInheritable Class TestClass
     End Class
-End Namespace", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-namespace Test.@class
+End Namespace", @"namespace Test.@class
 {
     sealed class TestClass
     {
@@ -155,12 +122,7 @@ namespace Test.@class
     Inherits System.IDisposable
 
     Sub Test()
-End Interface", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-interface ITest : System.IDisposable
+End Interface", @"interface ITest : System.IDisposable
 {
     void Test();
 }");
@@ -175,12 +137,7 @@ interface ITest : System.IDisposable
     ArgumentOutOfRange_NeedNonNegNum
     ArgumentOutOfRange_NeedNonNegNumRequired
     Arg_ArrayPlusOffTooSmall
-End Enum", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-internal enum ExceptionResource
+End Enum", @"internal enum ExceptionResource
 {
     Argument_ImplementIComparable,
     ArgumentOutOfRange_NeedNonNegNum,
@@ -197,12 +154,7 @@ internal enum ExceptionResource
     Implements System.IDisposable
 
     Protected MustOverride Sub Test()
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-abstract class ClassA : System.IDisposable
+End Class", @"abstract class ClassA : System.IDisposable
 {
     protected abstract void Test();
 }");
@@ -213,12 +165,7 @@ abstract class ClassA : System.IDisposable
     Implements System.IDisposable
 
     Protected MustOverride Sub Test()
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-abstract class ClassA : System.EventArgs, System.IDisposable
+End Class", @"abstract class ClassA : System.EventArgs, System.IDisposable
 {
     protected abstract void Test();
 }");
@@ -270,9 +217,6 @@ struct MyType : System.IComparable<MyType>
     Implements IComparable
 End Class",
                 @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class test : IComparable
 {
@@ -285,12 +229,7 @@ class test : IComparable
             TestConversionVisualBasicToCSharp(@"Class test
     Implements System.IComparable
 End Class",
-                @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class test : System.IComparable
+                @"class test : System.IComparable
 {
 }");
         }
@@ -303,11 +242,7 @@ class test : System.IComparable
 Class test
     Inherits InvalidDataException
 End Class",
-                @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-using System.IO;
+                @"using System.IO;
 
 class test : InvalidDataException
 {
@@ -320,12 +255,7 @@ class test : InvalidDataException
             TestConversionVisualBasicToCSharp(@"Class test
     Inherits System.IO.InvalidDataException
 End Class",
-                @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class test : System.IO.InvalidDataException
+                @"class test : System.IO.InvalidDataException
 {
 }");
         }

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -33,17 +33,34 @@ End Namespace", @"namespace Test
         }
 
         [Fact]
-        public void TestImports()
+        public void AliasedImports()
         {
             TestConversionVisualBasicToCSharp(
-                @"Imports SomeNamespace
-Imports VB = Microsoft.VisualBasic",
+                @"Imports tr = System.IO.TextReader
+
+Public Class Test
+    Private aliased As tr
+End Class",
+                @"using tr = System.IO.TextReader;
+
+public class Test
+{
+    private tr aliased;
+}");
+        }
+
+        [Fact]
+        public void UnaliasedImports()
+        {
+            TestConversionVisualBasicToCSharp(
+                @"Imports UnrecognizedNamespace",
                 @"using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 using Microsoft.VisualBasic;
-using SomeNamespace;
-using VB = Microsoft.VisualBasic;");
+using UnrecognizedNamespace;");
         }
 
         [Fact]
@@ -180,12 +197,7 @@ End Class", @"abstract class ClassA : System.EventArgs, System.IDisposable
 
     Private Sub Test()
     End Sub
-End Structure", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-struct MyType : System.IComparable<MyType>
+End Structure", @"struct MyType : System.IComparable<MyType>
 {
     private void Test()
     {
@@ -198,16 +210,16 @@ struct MyType : System.IComparable<MyType>
         {
             TestConversionVisualBasicToCSharp(
                 @"Public Delegate Sub Test()",
-                @"public delegate void Test();", expectUsings: false);
+                @"public delegate void Test();");
             TestConversionVisualBasicToCSharp(
                 @"Public Delegate Function Test() As Integer",
-                @"public delegate int Test();", expectUsings: false);
+                @"public delegate int Test();");
             TestConversionVisualBasicToCSharp(
                 @"Public Delegate Sub Test(ByVal x As Integer)",
-                @"public delegate void Test(int x);", expectUsings: false);
+                @"public delegate void Test(int x);");
             TestConversionVisualBasicToCSharp(
                 @"Public Delegate Sub Test(ByRef x As Integer)",
-                @"public delegate void Test(ref int x);", expectUsings: false);
+                @"public delegate void Test(ref int x);");
         }
 
         [Fact]

--- a/Tests/CSharp/SpecialConversionTests.cs
+++ b/Tests/CSharp/SpecialConversionTests.cs
@@ -15,9 +15,6 @@ namespace CodeConverter.Tests.CSharp
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {

--- a/Tests/CSharp/StandaloneMultiStatementTests.cs
+++ b/Tests/CSharp/StandaloneMultiStatementTests.cs
@@ -67,7 +67,7 @@ obj = null;",
         {
             TestConversionVisualBasicToCSharp(
                 @"Private x As Integer = 3",
-                @"private int x = 3;", expectUsings: false);
+                @"private int x = 3;");
         }
 
         [Fact]
@@ -86,7 +86,7 @@ End Class",
         {
             TestConversionVisualBasicToCSharp(
                 @"Private MustOverride Sub abs()",
-                @"private abstract void abs();", expectUsings: false);
+                @"private abstract void abs();");
         }
 
         [Fact]
@@ -101,11 +101,9 @@ End Namespace",
         }
 
         [Fact]
-        public void SingleUsing()
+        public void SingleUnusedUsingAliasTidiedAway()
         {
-            TestConversionVisualBasicToCSharp(
-                @"Imports s = System.String",
-                @"using s = System.String;");
+            TestConversionVisualBasicToCSharp(@"Imports tr = System.IO.TextReader", "");
         }
     }
 }

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -256,7 +256,9 @@ End Class", @"class TestClass
         [Fact]
         public void WithBlock2()
         {
-            TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClass
+            TestConversionVisualBasicToCSharpWithoutComments(@"Imports System.Data.SqlClient
+
+Class TestClass
     Private Sub Save()
         Using cmd As SqlCommand = new SqlCommand()
             With cmd
@@ -267,7 +269,9 @@ End Class", @"class TestClass
             End With
         End Using
     End Sub
-End Class", @"class TestClass
+End Class", @"using System.Data.SqlClient;
+
+class TestClass
 {
     private void Save()
     {
@@ -615,15 +619,15 @@ End Class", @"class TestClass
         public void NestedBlockStatementsKeepSameNesting()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClass
-    Shared Function FindTextInCol(w As Worksheet, pTitleRow As Integer, startCol As Integer, needle As String) As Integer
+    Shared Function FindTextInCol(w As String, pTitleRow As Integer, startCol As Integer, needle As String) As Integer
 
-        For c As Integer = startCol To w.Cells.MaxDataColumn
+        For c As Integer = startCol To w.Length
             If needle = """" Then
-                If String.IsNullOrWhiteSpace(w.Cells(pTitleRow, c).StringValue) Then
+                If String.IsNullOrWhiteSpace(w(c).ToString) Then
                     Return c
                 End If
             Else
-                If w.Cells(pTitleRow, c).StringValue = needle Then
+                If w(c).ToString = needle Then
                     Return c
                 End If
             End If
@@ -632,16 +636,16 @@ End Class", @"class TestClass
     End Function
 End Class", @"class TestClass
 {
-    public static int FindTextInCol(Worksheet w, int pTitleRow, int startCol, string needle)
+    public static int FindTextInCol(string w, int pTitleRow, int startCol, string needle)
     {
-        for (int c = startCol; c <= w.Cells.MaxDataColumn; c++)
+        for (int c = startCol; c <= w.Length; c++)
         {
             if (needle == """")
             {
-                if (string.IsNullOrWhiteSpace(w.Cells(pTitleRow, c).StringValue))
+                if (string.IsNullOrWhiteSpace(w[c].ToString()))
                     return c;
             }
-            else if (w.Cells(pTitleRow, c).StringValue == needle)
+            else if (w[c].ToString() == needle)
                 return c;
         }
         return -1;

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -18,12 +18,7 @@ namespace CodeConverter.Tests.CSharp
         Do
         Loop While True
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -51,12 +46,7 @@ class TestClass
         Dim b As Integer
         b = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -73,12 +63,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -94,12 +79,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -116,12 +96,7 @@ class TestClass
         Dim b As String
         b = New String(""test"")
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -138,12 +113,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As String = New String(""test"")
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -159,12 +129,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b = New String(""test"")
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -180,12 +145,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer()
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -209,7 +169,9 @@ class TestClass
         ReDim Preserve y(6,8)
         Return numArray2
     End Function
-End Class", @"public class TestClass
+End Class", @"using System;
+
+public class TestClass
 {
     public static int[] TestMethod(int[] numArray, int[] numArray2)
     {
@@ -243,12 +205,7 @@ End Class", @"public class TestClass
     Private Sub TestMethod()
         End
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -264,12 +221,7 @@ class TestClass
     Private Sub TestMethod()
         Stop
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -288,12 +240,7 @@ class TestClass
             ?.Length = 0
         End With
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -353,12 +300,7 @@ End Class", @"class TestClass
             .Length = withBlock
         End With
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -383,12 +325,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = {1, 2, 3}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -404,12 +341,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b = {1, 2, 3}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -425,12 +357,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = New Integer() {1, 2, 3}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -446,12 +373,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = New Integer(2) {1, 2, 3}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -467,12 +389,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,)
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -488,12 +405,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = {{1, 2}, {3, 4}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -509,12 +421,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = New Integer(,) {{1, 2}, {3, 4}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -530,12 +437,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = New Integer(1, 1) {{1, 2}, {3, 4}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -551,12 +453,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer()()
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -572,12 +469,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer()() = {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -614,12 +506,7 @@ class TestClass
     Private Sub TestMethod()
         Dim b As Integer()() = New Integer(1)() {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -669,7 +556,9 @@ Public Class AcmeClass
         Next
     End Sub
 End Class"
-                , @"using System.Diagnostics;
+                , @"using System;
+using System.Linq;
+using System.Diagnostics;
 
 public class AcmeClass
 {
@@ -704,12 +593,7 @@ public class AcmeClass
             b = 3
         End If
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod(int a)
     {
@@ -746,12 +630,7 @@ class TestClass
         Next
         Return -1
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     public static int FindTextInCol(Worksheet w, int pTitleRow, int startCol, string needle)
     {
@@ -784,12 +663,7 @@ class TestClass
             b = 1
         End While
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -822,12 +696,7 @@ class TestClass
             b = 1
         Loop While b = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -861,12 +730,7 @@ class TestClass
             b = 1
         Loop While b = 0
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -896,12 +760,7 @@ class TestClass
             If val = 3 Then Exit For
         Next
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod(int[] values)
     {
@@ -926,12 +785,7 @@ class TestClass
             If val = 3 Then Exit For
         Next
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod(int[] values)
     {
@@ -958,9 +812,6 @@ class TestClass
         End SyncLock
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -986,12 +837,7 @@ class TestClass
             b(i) = s(i)
         Next
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -1013,12 +859,7 @@ class TestClass
             b(i) = s(i)
         Next
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
@@ -1068,9 +909,6 @@ Finish:
         Console.ReadKey()
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class GotoTest1
 {
@@ -1121,9 +959,6 @@ class GotoTest1
         If nullObject Is Nothing Then Throw New ArgumentNullException(NameOf(nullObject))
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -1146,9 +981,6 @@ class TestClass
         Call TestMethod()
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -1181,9 +1013,6 @@ class TestClass
     Private Sub MyHandler(ByVal sender As Object, ByVal e As EventArgs)
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -1222,9 +1051,6 @@ class TestClass
         End Select
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -1334,9 +1160,6 @@ End Class", @"public class TestClass
         End Try
     End Sub
 End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
 
 class TestClass
 {
@@ -1402,10 +1225,7 @@ class TestClass
             Yield i
         Next
     End Function
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
+End Class", @"using System.Collections.Generic;
 
 class TestClass
 {

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -435,17 +435,27 @@ End Class", @"class TestClass
         }
 
         [Fact]
-        public void MultidimensionalArrayInitializationStatementWithLengths()
+        public void MultidimensionalArrayInitializationStatementWithAndWithoutLengths()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private Sub TestMethod()
+        Dim a As Integer(,) = New Integer(,) {{1, 2}, {3, 4}}
         Dim b As Integer(,) = New Integer(1, 1) {{1, 2}, {3, 4}}
+        Dim c as Integer(,,) = New Integer(,,) {{{1}}}
+        Dim d as Integer(,,) = New Integer(0, 0, 0) {{{1}}}
+        Dim e As Integer()(,) = New Integer()(,) {}
+        Dim f As Integer()(,) = New Integer(-1)(,) {}
     End Sub
 End Class", @"class TestClass
 {
     private void TestMethod()
     {
+        int[,] a = new int[,] { { 1, 2 }, { 3, 4 } };
         int[,] b = new int[2, 2] { { 1, 2 }, { 3, 4 } };
+        int[,,] c = new int[,,] { { { 1 } } };
+        int[,,] d = new int[1, 1, 1] { { { 1 } } };
+        int[][,] e = new int[][,] { };
+        int[][,] f = new int[0][,] { };
     }
 }");
         }
@@ -487,18 +497,13 @@ End Class", @"class TestClass
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
     Private Sub TestMethod()
-        Dim b As Integer()() = New Integer()() {New Integer() {1, 2}, New Integer() {3, 4}}
+        Dim b = New Integer()() {New Integer() {1}}
     End Sub
-End Class", @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class TestClass
+End Class", @"class TestClass
 {
     private void TestMethod()
     {
-        int[][] b = new int[][] { new int[] { 1, 2 }, new int[] { 3, 4 } };
+        var b = new int[][] { new int[] { 1 } };
     }
 }");
         }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -14,12 +14,7 @@ namespace CodeConverter.Tests.CSharp
         Dim o As Object = 5
         Dim i As Integer = CInt(o)
     End Sub
-End Class" + Environment.NewLine, @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+End Class" + Environment.NewLine, @"class Class1
 {
     private void Test()
     {
@@ -77,12 +72,7 @@ End Class", @"class Class1
         Dim l As System.Collections.Generic.List(Of Integer) = CType(o, System.Collections.Generic.List(Of Integer))
     End Sub
 End Class",
-@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+@"class Class1
 {
     private void Test()
     {
@@ -102,12 +92,7 @@ class Class1
         Dim i As System.Nullable(Of Integer) = TryCast(o, Integer)
     End Sub
 End Class",
-@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+@"class Class1
 {
     private void Test()
     {
@@ -127,12 +112,7 @@ class Class1
         Dim l As System.Collections.Generic.List(Of Integer) = TryCast(o, System.Collections.Generic.List(Of Integer))
     End Sub
 End Class",
-@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+@"class Class1
 {
     private void Test()
     {
@@ -151,12 +131,7 @@ class Class1
         Dim o As Object = 5L
     End Sub
 End Class",
-@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+@"class Class1
 {
     private void Test()
     {
@@ -174,12 +149,7 @@ class Class1
         Dim o As Object = 5F
     End Sub
 End Class",
-@"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+@"class Class1
 {
     private void Test()
     {
@@ -196,12 +166,7 @@ class Class1
     Private Sub Test()
         Dim o As Object = 5.0D
     End Sub
-End Class" + Environment.NewLine, @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-
-class Class1
+End Class" + Environment.NewLine, @"class Class1
 {
     private void Test()
     {

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -1,18 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using ICSharpCode.CodeConverter;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Shared;
-using ICSharpCode.CodeConverter.Util;
-using ICSharpCode.CodeConverter.VB;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Formatting;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
 
@@ -48,40 +40,21 @@ End Sub";
             AssertConvertedCodeResultEquals<CSToVBConversion>(csharpCode, expectedVisualBasicCode);
         }
 
-        public void TestConversionVisualBasicToCSharp(string visualBasicCode, string expectedCsharpCode, bool expectUsings = true, bool expectSurroundingBlock = false)
+        public void TestConversionVisualBasicToCSharp(string visualBasicCode, string expectedCsharpCode, bool expectSurroundingBlock = false)
         {
-            if (expectUsings) expectedCsharpCode = AddCSUsings(expectedCsharpCode, expectSurroundingBlock);
+            if (expectSurroundingBlock) expectedCsharpCode = SurroundWithBlock(expectedCsharpCode);
             TestConversionVisualBasicToCSharpWithoutComments(visualBasicCode, expectedCsharpCode, false);
             TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true), false);
         }
 
-        private static string AddCSUsings(string expectedCsharpCode, bool standaloneStatements)
+        private static string SurroundWithBlock(string expectedCsharpCode)
         {
-            if (standaloneStatements)
-            {
-                var indentedStatements = expectedCsharpCode.Replace("\n", "\n    ");
-                expectedCsharpCode =
-                    $@"{{
-    {indentedStatements}
-}}";
-            }
-            else if (!expectedCsharpCode.StartsWith("using System;")) {
-                var possibleNewline = expectedCsharpCode.StartsWith("using ") ? "" : Environment.NewLine;
-
-                expectedCsharpCode =
-                    @"using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.VisualBasic;
-" + possibleNewline + expectedCsharpCode;
-            }
-
-            return expectedCsharpCode;
+            var indentedStatements = expectedCsharpCode.Replace("\n", "\n    ");
+            return $"{{\r\n    {indentedStatements}\r\n}}";
         }
 
         public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode, bool addUsings = true, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
         {
-            if (addUsings) expectedCsharpCode = AddCSUsings(expectedCsharpCode, false);
             AssertConvertedCodeResultEquals<VBToCSConversion>(visualBasicCode, expectedCsharpCode);
         }
 

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -4,6 +4,7 @@ using System.Text;
 using ICSharpCode.CodeConverter;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Shared;
+using ICSharpCode.CodeConverter.VB;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;

--- a/Tests/DiagnosticTestBase.cs
+++ b/Tests/DiagnosticTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 
@@ -6,32 +7,29 @@ namespace CodeConverter.Tests
 {
     public abstract class DiagnosticTestBase
     {
-        static MetadataReference _mscorlib;
-        static MetadataReference _systemAssembly;
-        static MetadataReference _systemXmlLinq;
-        static MetadataReference _systemCore;
-        private static MetadataReference _visualBasic;
-
         internal static MetadataReference[] DefaultMetadataReferences;
 
         static DiagnosticTestBase()
         {
             try {
-                _mscorlib = MetadataReference.CreateFromFile(typeof(Console).Assembly.Location);
-                _systemAssembly = MetadataReference.CreateFromFile(typeof(System.ComponentModel.BrowsableAttribute).Assembly.Location);
-                _systemXmlLinq = MetadataReference.CreateFromFile(typeof(System.Xml.Linq.XElement).Assembly.Location);
-                _systemCore = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
-                _visualBasic = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Constants).Assembly.Location);
-                DefaultMetadataReferences = new[] {
-                    _mscorlib,
-                    _systemAssembly,
-                    _systemCore,
-                    _systemXmlLinq,
-                    _visualBasic
-                };
+                DefaultMetadataReferences = GetRefs(
+                    typeof(System.Text.Encoding),
+                    typeof(System.ComponentModel.BrowsableAttribute),
+                    typeof(System.Dynamic.DynamicObject),
+                    typeof(System.Data.DataRow),
+                    typeof(System.Data.DataRowExtensions),
+                    typeof(System.Net.Http.HttpClient),
+                    typeof(System.Xml.XmlElement),
+                    typeof(System.Xml.Linq.XElement),
+                    typeof(Microsoft.VisualBasic.Constants)).ToArray();
             } catch (Exception e) {
                 Console.WriteLine(e);
             }
+        }
+
+        private static IEnumerable<MetadataReference> GetRefs(params Type[] types)
+        {
+            return types.Select(type => MetadataReference.CreateFromFile(type.Assembly.Location));
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -100,6 +100,8 @@
       <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
     </Reference>


### PR DESCRIPTION
### Problem
A very scarce set of global imports was used, and references via an alias were lost.

Also fixes #71

This is a first step in aid of #60

### Solution
The scarce set of global imports was probably due to worries of cluttering the output and needing to specify all using statements for tests. This PR tidies away unused imports when there are no unresolved symbols, which covers the vast majority of the tests at least. The global imports list is now slightly expanded as a result, which should improve website conversion.

* [x] At least one test covering the code changed
* [x] All tests pass

