### PR TITLE
C# -> VB: Interfaces "implements" clause now converted

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -237,12 +238,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             return SyntaxFactory.Identifier(text);
         }
 
-        public SyntaxTokenList ConvertModifiers(IEnumerable<SyntaxToken> modifiers, SyntaxKindExtensions.TokenContext context = SyntaxKindExtensions.TokenContext.Global, bool isVariableOrConst = false)
+        public SyntaxTokenList ConvertModifiers(IEnumerable<SyntaxToken> modifiers, TokenContext context = TokenContext.Global, bool isVariableOrConst = false)
         {
             return SyntaxFactory.TokenList(ConvertModifiersCore(modifiers, context, isVariableOrConst).Where(t => CSharpExtensions.Kind(t) != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None));
         }
 
-        private SyntaxToken? ConvertModifier(SyntaxToken m, SyntaxKindExtensions.TokenContext context = SyntaxKindExtensions.TokenContext.Global)
+        private SyntaxToken? ConvertModifier(SyntaxToken m, TokenContext context = TokenContext.Global)
         {
             SyntaxKind vbSyntaxKind = VisualBasicExtensions.Kind(m);
             switch (vbSyntaxKind) {
@@ -253,9 +254,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             return token == Microsoft.CodeAnalysis.CSharp.SyntaxKind.None ? null : new SyntaxToken?(SyntaxFactory.Token(token));
         }
 
-        private IEnumerable<SyntaxToken> ConvertModifiersCore(IEnumerable<SyntaxToken> modifiers, SyntaxKindExtensions.TokenContext context, bool isVariableOrConst = false)
+        private IEnumerable<SyntaxToken> ConvertModifiersCore(IEnumerable<SyntaxToken> modifiers, TokenContext context, bool isVariableOrConst = false)
         {
-            var contextsWithIdenticalDefaults = new[] {SyntaxKindExtensions.TokenContext.Global, SyntaxKindExtensions.TokenContext.Local, SyntaxKindExtensions.TokenContext.InterfaceOrModule, SyntaxKindExtensions.TokenContext.MemberInInterface };
+            var contextsWithIdenticalDefaults = new[] {TokenContext.Global, TokenContext.Local, TokenContext.InterfaceOrModule, TokenContext.MemberInInterface };
             if (!contextsWithIdenticalDefaults.Contains(context)) {
                 bool visibility = false;
                 foreach (var token in modifiers) {
@@ -271,11 +272,11 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var m = ConvertModifier(token, context);
                 if (m.HasValue) yield return m.Value;
             }
-            if (context == SyntaxKindExtensions.TokenContext.MemberInModule)
+            if (context == TokenContext.MemberInModule)
                 yield return SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword);
         }
 
-        private bool IgnoreInContext(SyntaxToken m, SyntaxKindExtensions.TokenContext context)
+        private bool IgnoreInContext(SyntaxToken m, TokenContext context)
         {
             switch (VisualBasicExtensions.Kind(m)) {
                 case SyntaxKind.OptionalKeyword:
@@ -295,21 +296,21 @@ namespace ICSharpCode.CodeConverter.CSharp
             return isConvOp;
         }
 
-        private SyntaxToken VisualBasicDefaultVisibility(SyntaxKindExtensions.TokenContext context, bool isVariableOrConst)
+        private SyntaxToken VisualBasicDefaultVisibility(TokenContext context, bool isVariableOrConst)
         {
             switch (context) {
-                case SyntaxKindExtensions.TokenContext.Global:
-                case SyntaxKindExtensions.TokenContext.InterfaceOrModule:
+                case TokenContext.Global:
+                case TokenContext.InterfaceOrModule:
                     return SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.InternalKeyword);
-                case SyntaxKindExtensions.TokenContext.MemberInModule:
-                case SyntaxKindExtensions.TokenContext.MemberInClass:
-                case SyntaxKindExtensions.TokenContext.MemberInInterface:
+                case TokenContext.MemberInModule:
+                case TokenContext.MemberInClass:
+                case TokenContext.MemberInInterface:
                     return SyntaxFactory.Token(isVariableOrConst
                         ? Microsoft.CodeAnalysis.CSharp.SyntaxKind.PrivateKeyword
                         : Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword);
-                case SyntaxKindExtensions.TokenContext.MemberInStruct:
+                case TokenContext.MemberInStruct:
                     return SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword);
-                case SyntaxKindExtensions.TokenContext.Local:
+                case TokenContext.Local:
                     return SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PrivateKeyword);
             }
             throw new ArgumentOutOfRangeException(nameof(context), context, "Specified argument was out of the range of valid values.");

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -582,8 +582,9 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private TokenContext GetMemberContext(VBSyntax.StatementSyntax member)
             {
-                var parentType = member.GetAncestorOrThis<VBSyntax.TypeBlockSyntax>()?.Kind();
-                switch (parentType) {
+                var parentType = member.GetAncestorOrThis<VBSyntax.TypeBlockSyntax>();
+                var parentTypeKind = parentType?.Kind();
+                switch (parentTypeKind) {
                     case VBasic.SyntaxKind.ModuleBlock:
                         return TokenContext.MemberInModule;
                     case VBasic.SyntaxKind.ClassBlock:

--- a/ICSharpCode.CodeConverter/CSharp/SyntaxKindExtensions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/SyntaxKindExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -6,16 +7,6 @@ namespace ICSharpCode.CodeConverter.CSharp
 {
     public static class SyntaxKindExtensions
     {
-        public enum TokenContext
-        {
-            Global,
-            InterfaceOrModule,
-            Local,
-            MemberInModule,
-            MemberInClass,
-            MemberInStruct,
-            MemberInInterface
-        }
 
         public static SyntaxToken ConvertToken(this SyntaxToken t, TokenContext context = TokenContext.Global)
         {

--- a/ICSharpCode.CodeConverter/Shared/TokenContext.cs
+++ b/ICSharpCode.CodeConverter/Shared/TokenContext.cs
@@ -1,0 +1,13 @@
+﻿namespace ICSharpCode.CodeConverter.Shared
+{
+    public enum TokenContext
+    {
+        Global,
+        InterfaceOrModule,
+        Local,
+        MemberInModule,
+        MemberInClass,
+        MemberInStruct,
+        MemberInInterface
+    }
+}

--- a/ICSharpCode.CodeConverter/Util/SymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SymbolExtensions.cs
@@ -1272,61 +1272,6 @@ namespace ICSharpCode.CodeConverter.Util
 
             return getResult.ReturnType;
         }
-
-        /// <summary>
-        /// First, remove symbols from the set if they are overridden by other symbols in the set.
-        /// If a symbol is overridden only by symbols outside of the set, then it is not removed. 
-        /// This is useful for filtering out symbols that cannot be accessed in a given context due
-        /// to the existence of overriding members. Second, remove remaining symbols that are
-        /// unsupported (e.g. pointer types in VB) or not editor browsable based on the EditorBrowsable
-        /// attribute.
-        /// </summary>
-        //        public static IEnumerable<T> FilterToVisibleAndBrowsableSymbols<T>(this IEnumerable<T> symbols, bool hideAdvancedMembers, Compilation compilation) where T : ISymbol
-        //        {
-        //            symbols = symbols.RemoveOverriddenSymbolsWithinSet();
-        //
-        //            // Since all symbols are from the same compilation, find the required attribute
-        //            // constructors once and reuse.
-        //
-        //            var editorBrowsableAttributeConstructor = EditorBrowsableHelpers.GetSpecialEditorBrowsableAttributeConstructor(compilation);
-        //            var typeLibTypeAttributeConstructors = EditorBrowsableHelpers.GetSpecialTypeLibTypeAttributeConstructors(compilation);
-        //            var typeLibFuncAttributeConstructors = EditorBrowsableHelpers.GetSpecialTypeLibFuncAttributeConstructors(compilation);
-        //            var typeLibVarAttributeConstructors = EditorBrowsableHelpers.GetSpecialTypeLibVarAttributeConstructors(compilation);
-        //            var hideModuleNameAttribute = compilation.HideModuleNameAttribute();
-        //
-        //            // PERF: HasUnsupportedMetadata may require recreating the syntax tree to get the base class, so first
-        //            // check to see if we're referencing a symbol defined in source.
-        //            Func<Location, bool> isSymbolDefinedInSource = l => l.IsInSource;
-        //            return symbols.Where(s =>
-        //                (s.Locations.Any(isSymbolDefinedInSource) || !s.HasUnsupportedMetadata) &&
-        //                !s.IsDestructor() &&
-        //                s.IsEditorBrowsable(
-        //                    hideAdvancedMembers,
-        //                    compilation,
-        //                    editorBrowsableAttributeConstructor,
-        //                    typeLibTypeAttributeConstructors,
-        //                    typeLibFuncAttributeConstructors,
-        //                    typeLibVarAttributeConstructors,
-        //                    hideModuleNameAttribute));
-        //        }
-
-        private static IEnumerable<T> RemoveOverriddenSymbolsWithinSet<T>(this IEnumerable<T> symbols) where T : ISymbol
-        {
-            HashSet<ISymbol> overriddenSymbols = new HashSet<ISymbol>();
-
-            foreach (var symbol in symbols) {
-                if (symbol.OverriddenMember() != null && !overriddenSymbols.Contains(symbol.OverriddenMember())) {
-                    overriddenSymbols.Add(symbol.OverriddenMember());
-                }
-            }
-
-            return symbols.Where(s => !overriddenSymbols.Contains(s));
-        }
-
-        //        public static IEnumerable<T> FilterToVisibleAndBrowsableSymbolsAndNotUnsafeSymbols<T>(this IEnumerable<T> symbols, bool hideAdvancedMembers, Compilation compilation) where T : ISymbol
-        //        {
-        //            return symbols.FilterToVisibleAndBrowsableSymbols(hideAdvancedMembers, compilation).Where(s => !s.IsUnsafe());
-        //        }
     }
 
     public enum SymbolVisibility

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -144,7 +144,7 @@ namespace ICSharpCode.CodeConverter.VB
             body = ConvertBody(node.Body, node.ExpressionBody, isIteratorState);
             isIterator = isIteratorState.IsIterator;
             var attributes = SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(_nodesVisitor)));
-            var modifiers = ConvertModifiers(node.Modifiers, SyntaxKindExtensions.TokenContext.Local);
+            var modifiers = ConvertModifiers(node.Modifiers, TokenContext.Local);
             var parent = (BasePropertyDeclarationSyntax)node.Parent.Parent;
             Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterSyntax valueParam;
 
@@ -205,7 +205,7 @@ namespace ICSharpCode.CodeConverter.VB
             SyntaxKind singleLineExpressionKind;
             if (symbol.ReturnsVoid) {
                 header = SyntaxFactory.SubLambdaHeader(SyntaxFactory.List<AttributeListSyntax>(),
-                    ConvertModifiers(modifiers, SyntaxKindExtensions.TokenContext.Local), parameterList, null);
+                    ConvertModifiers(modifiers, TokenContext.Local), parameterList, null);
                 endBlock = SyntaxFactory.EndBlockStatement(SyntaxKind.EndSubStatement,
                     SyntaxFactory.Token(SyntaxKind.SubKeyword));
                 multiLineExpressionKind = SyntaxKind.MultiLineSubLambdaExpression;
@@ -244,7 +244,7 @@ namespace ICSharpCode.CodeConverter.VB
         {
             LambdaHeaderSyntax header;
             header = SyntaxFactory.FunctionLambdaHeader(SyntaxFactory.List<AttributeListSyntax>(),
-                ConvertModifiers(modifiers, SyntaxKindExtensions.TokenContext.Local), parameterList, null);
+                ConvertModifiers(modifiers, TokenContext.Local), parameterList, null);
             endBlock = SyntaxFactory.EndBlockStatement(SyntaxKind.EndFunctionStatement,
                 SyntaxFactory.Token(SyntaxKind.FunctionKeyword));
             multiLineExpressionKind = SyntaxKind.MultiLineFunctionLambdaExpression;
@@ -295,9 +295,9 @@ namespace ICSharpCode.CodeConverter.VB
         }
 
 
-        private static IEnumerable<SyntaxToken> ConvertModifiersCore(IReadOnlyCollection<SyntaxToken> modifiers, SyntaxKindExtensions.TokenContext context)
+        private static IEnumerable<SyntaxToken> ConvertModifiersCore(IReadOnlyCollection<SyntaxToken> modifiers, TokenContext context)
         {
-            if (context != SyntaxKindExtensions.TokenContext.Local && context != SyntaxKindExtensions.TokenContext.MemberInInterface) {
+            if (context != TokenContext.Local && context != TokenContext.MemberInInterface) {
                 bool visibility = false;
                 foreach (var token in modifiers) {
                     if (token.IsCsVisibility(true)) { //TODO Don't treat const as visibility, pass in more context to detect this
@@ -314,37 +314,40 @@ namespace ICSharpCode.CodeConverter.VB
             }
         }
 
-        private static bool IgnoreInContext(SyntaxToken m, SyntaxKindExtensions.TokenContext context)
+        private static bool IgnoreInContext(SyntaxToken m, TokenContext context)
         {
             switch (context) {
-                case SyntaxKindExtensions.TokenContext.InterfaceOrModule:
-                    return m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword, Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword);
+                case TokenContext.InterfaceOrModule:
+                case TokenContext.MemberInModule:
+                    return m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword);
+                case TokenContext.MemberInInterface:
+                    return m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword);
             }
             return false;
         }
 
-        private static SyntaxToken CSharpDefaultVisibility(SyntaxKindExtensions.TokenContext context)
+        private static SyntaxToken CSharpDefaultVisibility(TokenContext context)
         {
             switch (context) {
-                case SyntaxKindExtensions.TokenContext.Global:
-                case SyntaxKindExtensions.TokenContext.InterfaceOrModule:
+                case TokenContext.Global:
+                case TokenContext.InterfaceOrModule:
                     return SyntaxFactory.Token(SyntaxKind.FriendKeyword);
-                case SyntaxKindExtensions.TokenContext.Local:
-                case SyntaxKindExtensions.TokenContext.MemberInClass:
-                case SyntaxKindExtensions.TokenContext.MemberInStruct:
+                case TokenContext.Local:
+                case TokenContext.MemberInClass:
+                case TokenContext.MemberInStruct:
                     return SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
-                case SyntaxKindExtensions.TokenContext.MemberInInterface:
+                case TokenContext.MemberInInterface:
                     return SyntaxFactory.Token(SyntaxKind.PublicKeyword);
             }
             throw new ArgumentOutOfRangeException(nameof(context));
         }
 
-        internal static SyntaxTokenList ConvertModifiers(IReadOnlyCollection<SyntaxToken> modifiers, SyntaxKindExtensions.TokenContext context = SyntaxKindExtensions.TokenContext.Global)
+        internal static SyntaxTokenList ConvertModifiers(IReadOnlyCollection<SyntaxToken> modifiers, TokenContext context = TokenContext.Global)
         {
             return SyntaxFactory.TokenList(ConvertModifiersCore(modifiers, context));
         }
 
-        private static SyntaxToken? ConvertModifier(SyntaxToken m, SyntaxKindExtensions.TokenContext context = SyntaxKindExtensions.TokenContext.Global)
+        private static SyntaxToken? ConvertModifier(SyntaxToken m, TokenContext context = TokenContext.Global)
         {
             var token = CSharpExtensions.Kind(m).ConvertToken(context);
             return token == SyntaxKind.None ? null : new SyntaxToken?(SyntaxFactory.Token(token));

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -320,8 +320,6 @@ namespace ICSharpCode.CodeConverter.VB
                 case TokenContext.InterfaceOrModule:
                 case TokenContext.MemberInModule:
                     return m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword);
-                case TokenContext.MemberInInterface:
-                    return m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword);
             }
             return false;
         }
@@ -334,6 +332,7 @@ namespace ICSharpCode.CodeConverter.VB
                     return SyntaxFactory.Token(SyntaxKind.FriendKeyword);
                 case TokenContext.Local:
                 case TokenContext.MemberInClass:
+                case TokenContext.MemberInModule:
                 case TokenContext.MemberInStruct:
                     return SyntaxFactory.Token(SyntaxKind.PrivateKeyword);
                 case TokenContext.MemberInInterface:

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -547,7 +547,7 @@ namespace ICSharpCode.CodeConverter.VB
             var parentTypeKind = parentType?.Kind();
             switch (parentTypeKind) {
                 case CS.SyntaxKind.ClassDeclaration:
-                    return parentType.GetModifiers().Any(SyntaxKind.StaticKeyword) ? TokenContext.MemberInModule : TokenContext.MemberInClass;
+                    return parentType.GetModifiers().Any(CS.SyntaxKind.StaticKeyword) ? TokenContext.MemberInModule : TokenContext.MemberInClass;
                 case CS.SyntaxKind.InterfaceDeclaration:
                     return TokenContext.MemberInInterface;
                 case CS.SyntaxKind.StructDeclaration:

--- a/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
@@ -9,9 +9,10 @@ namespace ICSharpCode.CodeConverter.VB
         {
             Global,
             InterfaceOrModule,
-            Member,
-            VariableOrConst,
-            Local
+            Local,
+            MemberInClass,
+            MemberInStruct,
+            MemberInInterface
         }
 
         public static SyntaxKind ConvertToken(this Microsoft.CodeAnalysis.CSharp.SyntaxKind t, TokenContext context = TokenContext.Global)

--- a/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
@@ -1,20 +1,11 @@
 ﻿using System;
+using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace ICSharpCode.CodeConverter.VB
 {
     public static class SyntaxKindExtensions
     {
-        public enum TokenContext
-        {
-            Global,
-            InterfaceOrModule,
-            Local,
-            MemberInClass,
-            MemberInStruct,
-            MemberInInterface
-        }
-
         public static SyntaxKind ConvertToken(this Microsoft.CodeAnalysis.CSharp.SyntaxKind t, TokenContext context = TokenContext.Global)
         {
             switch (t)

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -14,7 +14,7 @@ namespace CodeConverter.Tests.VB
         var x = @""Hello,
 World!"";
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim x = ""Hello,
 World!""
@@ -31,7 +31,7 @@ End Class");
     {
         bool result = (str == """") ? true : false;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim result As Boolean = If((str = """"), True, False)
     End Sub
@@ -52,7 +52,7 @@ End Class");
 
         return -1;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Shared Function GetLength(ByVal node As Object) As Integer
         Dim s As String = Nothing
 
@@ -87,7 +87,7 @@ class TestClass
     }
 }", @"Imports System.Collections.Generic
 
-Class TestClass
+Friend Class TestClass
     Private Shared Function [Do]() As Boolean
         Dim d = New Dictionary(Of String, String)()
         Dim output As string = Nothing" + /* Ideally string would have the first letter uppercased but that's out of scope for this test */ @"
@@ -105,7 +105,7 @@ End Class");
     {
         bool result = (str == """") ? throw new Exception(""empty"") : false;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim result As Boolean = If((str = """"), CSharpImpl.__Throw(Of System.Boolean)(New Exception(""empty"")), False)
     End Sub
@@ -129,7 +129,7 @@ End Class");
     private void TestMethod()
     {
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private n As String = NameOf(TestMethod)
 
     Private Sub TestMethod()
@@ -146,7 +146,7 @@ End Class");
     {
         Console.WriteLine(str ?? ""<null>"");
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Console.WriteLine(If(str, ""<null>""))
     End Sub
@@ -165,7 +165,7 @@ End Class");
         Console.WriteLine(""Test"" + length);
         Console.ReadKey();
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim length As Integer
         length = str.Length
@@ -187,7 +187,7 @@ End Class");
         Console.ReadKey();
         string redirectUri = context.OwinContext.Authentication?.AuthenticationResponseChallenge?.Properties?.RedirectUri;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim length As Integer = If(str?.Length, -1)
         Console.WriteLine(length)
@@ -215,11 +215,11 @@ class TestClass
             LastName = ""Playstead"",
         };
     }
-}", @"Class StudentName
+}", @"Friend Class StudentName
     Public LastName, FirstName As String
 End Class
 
-Class TestClass
+Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim student2 As StudentName = New StudentName With {
             .FirstName = ""Craig"",
@@ -241,7 +241,7 @@ End Class");
             LastName = ""Playstead"",
         };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim student2 = New With {Key
             .FirstName = ""Craig"", Key
@@ -291,7 +291,7 @@ End Class");
     {
         this.member = 0;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private member As Integer
 
     Private Sub TestMethod()
@@ -314,11 +314,11 @@ class TestClass : BaseTestClass
     {
         base.member = 0;
     }
-}", @"Class BaseTestClass
+}", @"Friend Class BaseTestClass
     Public member As Integer
 End Class
 
-Class TestClass
+Friend Class TestClass
     Inherits BaseTestClass
 
     Private Sub TestMethod()
@@ -341,7 +341,7 @@ End Class");
 
         test(3);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Shared m_Event1 As Action(Of Integer) = Function()
                                                     End Function
 
@@ -365,7 +365,7 @@ End Class");
 
         test(3);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim test = Function(a) a * 2
         Dim test2 = Function(a, b)
@@ -394,7 +394,7 @@ End Class");
         int result = await SomeAsyncMethod();
         Console.WriteLine(result);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Function SomeAsyncMethod() As Task(Of Integer)
         Return Task.FromResult(0)
     End Function
@@ -504,12 +504,12 @@ class Test {
         }
     }
 }",
-@"Class Product
+@"Friend Class Product
     Public Category As String
     Public ProductName As String
 End Class
 
-Class Test
+Friend Class Test
     Public Sub Linq102()
         Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
         Dim products As Product() = GetProductList()

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -13,10 +13,10 @@ namespace CodeConverter.Tests.VB
     const int answer = 42;
     int value = 10;
     readonly int v = 15;
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Const answer As Integer = 42
     Private value As Integer = 10
-    ReadOnly v As Integer = 15
+    Private ReadOnly v As Integer = 15
 End Class");
         }
 
@@ -34,7 +34,7 @@ End Class");
     }
 }", @"Imports System.Runtime.InteropServices
 
-Class TestClass
+Friend Class TestClass
     Public Sub TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
         argument = Nothing
         argument2 = Nothing
@@ -55,7 +55,7 @@ End Class");
     }
 }", @"Imports System.Runtime.InteropServices
 
-Class TestClass
+Friend Class TestClass
     Public Function TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) As Integer
         Return 0
     End Function
@@ -76,7 +76,7 @@ End Class");
     }
 }", @"Imports System.Runtime.InteropServices
 
-Class TestClass
+Friend Class TestClass
     Public Shared Sub TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
         argument = Nothing
         argument2 = Nothing
@@ -92,7 +92,7 @@ End Class");
                 @"abstract class TestClass
 {
     public abstract void TestMethod();
-}", @"MustInherit Class TestClass
+}", @"Friend MustInherit Class TestClass
     Public MustOverride Sub TestMethod()
 End Class");
         }
@@ -119,7 +119,7 @@ class TestSubclass : TestClass
         TestMethod(3);
         System.Console.WriteLine(""Shadowed implementation"");
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Public Sub TestMethod()
     End Sub
 
@@ -127,7 +127,7 @@ class TestSubclass : TestClass
     End Sub
 End Class
 
-Class TestSubclass
+Friend Class TestSubclass
     Inherits TestClass
 
     Public Overloads Sub TestMethod()
@@ -151,7 +151,7 @@ End Class");
     }
 }", @"Imports System.Runtime.InteropServices
 
-Class TestClass
+Friend Class TestClass
     Public NotOverridable Sub TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
         argument = Nothing
         argument2 = Nothing
@@ -175,7 +175,7 @@ End Class");
     }
 }", @"Imports System.Runtime.CompilerServices
 
-Module TestClass
+Friend Module TestClass
     <Extension()>
     Sub TestMethod(ByVal str As String)
     End Sub
@@ -199,7 +199,7 @@ static class TestClass
     }
 }", @"Imports System.Runtime.CompilerServices
 
-Module TestClass
+Friend Module TestClass
     <Extension()>
     Sub TestMethod(ByVal str As String)
     End Sub
@@ -221,7 +221,7 @@ End Module");
         get { return this.m_test3; }
         set { this.m_test3 = value; }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Public Property Test As Integer
 
     Public ReadOnly Property Test2 As Integer
@@ -278,7 +278,7 @@ End Class");
     private string[] favColor => new string[] {""Red"", ""Green""};
     public string this[int index] => favColor[index];
 }  
-", @"Class MyFavColor
+", @"Friend Class MyFavColor
     Private ReadOnly Property favColor As String()
         Get
             Return New String() {""Red"", ""Green""}
@@ -333,7 +333,7 @@ End Class");
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     int value { get; set; }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     <DatabaseGenerated(DatabaseGeneratedOption.None)>
     Private Property value As Integer
 End Class
@@ -351,7 +351,7 @@ End Class
     }
 }", @"Imports System.Runtime.InteropServices
 
-Class TestClass(Of T As {Class, New}, T2 As Structure, T3)
+Friend Class TestClass(Of T As {Class, New}, T2 As Structure, T3)
     Public Sub New(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
     End Sub
 End Class");
@@ -398,7 +398,7 @@ End Class");
     ~TestClass()
     {
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Protected Overrides Sub Finalize()
     End Sub
 End Class");
@@ -411,7 +411,7 @@ End Class");
                 @"class TestClass
 {
     public event EventHandler MyEvent;
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Public Event MyEvent As EventHandler
 End Class");
         }
@@ -436,7 +436,7 @@ class TestClass
     }
 }", @"Imports System
 
-Class TestClass
+Friend Class TestClass
     Private backingField As EventHandler
 
     Public Event MyEvent As EventHandler
@@ -491,7 +491,7 @@ End Class");
             this.m_test3 = value;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private _Items As Integer()
 
     Default Public Property Item(ByVal index As Integer) As Integer

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -42,7 +42,7 @@ Imports VB = Microsoft.VisualBasic");
     {
     }
 }", @"Namespace Test.[class]
-    Class TestClass(Of T)
+    Friend Class TestClass(Of T)
     End Class
 End Namespace");
         }
@@ -77,7 +77,7 @@ End Namespace");
     {
     }
 }", @"Namespace Test.[class]
-    MustInherit Class TestClass
+    Friend MustInherit Class TestClass
     End Class
 End Namespace");
         }
@@ -91,7 +91,7 @@ End Namespace");
     {
     }
 }", @"Namespace Test.[class]
-    NotInheritable Class TestClass
+    Friend NotInheritable Class TestClass
     End Class
 End Namespace");
         }
@@ -103,7 +103,7 @@ End Namespace");
                 @"interface ITest : System.IDisposable
 {
     void Test ();
-}", @"Interface ITest
+}", @"Friend Interface ITest
     Inherits System.IDisposable
 
     Sub Test()
@@ -118,7 +118,7 @@ End Interface");
 {
     void Test ();
     void Test2 ();
-}", @"Interface ITest
+}", @"Friend Interface ITest
     Inherits System.IDisposable
 
     Sub Test()
@@ -151,7 +151,7 @@ End Enum");
     @"abstract class ClassA : System.IDisposable
 {
     protected abstract void Test();
-}", @"MustInherit Class ClassA
+}", @"Friend MustInherit Class ClassA
     Implements System.IDisposable
 
     Protected MustOverride Sub Test()
@@ -161,7 +161,7 @@ End Class");
                 @"abstract class ClassA : System.EventArgs, System.IDisposable
 {
     protected abstract void Test();
-}", @"MustInherit Class ClassA
+}", @"Friend MustInherit Class ClassA
     Inherits System.EventArgs
     Implements System.IDisposable
 
@@ -176,7 +176,7 @@ End Class");
     @"struct MyType : System.IComparable<MyType>
 {
     void Test() {}
-}", @"Structure MyType
+}", @"Friend Structure MyType
     Implements System.IComparable(Of MyType)
 
     Private Sub Test()
@@ -214,19 +214,40 @@ End Namespace");
         [Fact]
         public void ClassImplementsInterface()
         {
-            TestConversionCSharpToVisualBasic("using System; class test : IComparable { }",
-@"Imports System
+            TestConversionCSharpToVisualBasic(@"public class ToBeDisplayed : iDisplay
+{
+    public string Name { get; set; }
 
-Class test
-    Implements IComparable
-End Class");
+    public void DisplayName()
+    {
+    }
+}
+
+public interface iDisplay
+{
+    string Name { get; set; }
+    void DisplayName();
+}",
+@"Public Class ToBeDisplayed
+    Implements iDisplay
+
+    Public Property Name As String Implements iDisplay.Name
+
+    Public Sub DisplayName() Implements iDisplay.DisplayName
+    End Sub
+End Class
+
+Public Interface iDisplay
+    Property Name As String
+    Sub DisplayName()
+End Interface");
         }
 
         [Fact]
         public void ClassImplementsInterface2()
         {
             TestConversionCSharpToVisualBasic("class test : System.IComparable { }",
-@"Class test
+@"Friend Class test
     Implements System.IComparable
 End Class");
         }
@@ -237,7 +258,7 @@ End Class");
             TestConversionCSharpToVisualBasic("using System.IO; class test : InvalidDataException { }",
 @"Imports System.IO
 
-Class test
+Friend Class test
     Inherits InvalidDataException
 End Class");
         }
@@ -246,7 +267,7 @@ End Class");
         public void ClassInheritsClass2()
         {
             TestConversionCSharpToVisualBasic("class test : System.IO.InvalidDataException { }",
-@"Class test
+@"Friend Class test
     Inherits System.IO.InvalidDataException
 End Class");
         }

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -16,7 +16,7 @@ namespace CodeConverter.Tests.VB
         int a, b;
         b = a = 5;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim a, b As Integer
         b = CSharpImpl.__Assign(a, 5)
@@ -43,7 +43,7 @@ End Class");
         int a = 5, b;
         b = a++;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer, a As Integer = 5
         b = Math.Min(System.Threading.Interlocked.Increment(a), a - 1)
@@ -63,7 +63,7 @@ End Class");
     {
         if (MyEvent != null) MyEvent(this, EventArgs.Empty);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Event MyEvent As EventHandler
 
     Private Sub TestMethod()
@@ -77,7 +77,7 @@ End Class");
     {
         if ((MyEvent != null)) MyEvent(this, EventArgs.Empty);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
@@ -89,7 +89,7 @@ End Class");
     {
         if (null != MyEvent) { MyEvent(this, EventArgs.Empty); }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
@@ -101,7 +101,7 @@ End Class");
     {
         if (this.MyEvent != null) MyEvent(this, EventArgs.Empty);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
@@ -113,7 +113,7 @@ End Class");
     {
         if (MyEvent != null) this.MyEvent(this, EventArgs.Empty);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
@@ -125,7 +125,7 @@ End Class");
     {
         if ((this.MyEvent != null)) { this.MyEvent(this, EventArgs.Empty); }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
@@ -142,7 +142,7 @@ End Class");
     {
         if (FullImage != null) DrawImage();
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then DrawImage()
     End Sub
@@ -155,7 +155,7 @@ End Class");
     {
         if (FullImage != null) e.DrawImage();
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then e.DrawImage()
     End Sub
@@ -168,7 +168,7 @@ End Class");
     {
         if (FullImage != null) { DrawImage(); }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then
             DrawImage()
@@ -182,7 +182,7 @@ End Class");
     {
         if (FullImage != null) { e.DrawImage(); }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then
             e.DrawImage()
@@ -197,7 +197,7 @@ End Class");
     {
         if (Tiles != null) foreach (Tile t in Tiles) this.TileTray.Controls.Remove(t);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If Tiles IsNot Nothing Then
 
@@ -240,7 +240,7 @@ End Class");
     }
 }", @"Imports System.Runtime.CompilerServices
 
-Module TestClass
+Friend Module TestClass
     <Extension()>
     Private Function TypeSwitch(ByVal obj As Object, ByVal matchFunc1 As Func(Of String, Object), ByVal matchFunc2 As Func(Of Integer, Object), ByVal defaultFunc As Func(Of Object, Object)) As Object
         Return Nothing
@@ -269,7 +269,7 @@ End Module");
                 @"class Test
 {
     public int CR = 0x0D * 0b1;
-}", @"Class Test
+}", @"Friend Class Test
     Public CR As Integer = &H0D * &B1
 End Class");
         }

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -21,7 +21,7 @@ namespace CodeConverter.Tests.VB
         do ; while (true);
         ;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         If True Then
         End If
@@ -48,7 +48,7 @@ End Class");
         int b;
         b = 0;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer
         b = 0
@@ -65,7 +65,7 @@ End Class");
     {
         int b = 0;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer = 0
     End Sub
@@ -81,7 +81,7 @@ End Class");
     {
         var b = 0;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b = 0
     End Sub
@@ -98,7 +98,7 @@ End Class");
         string b;
         b = new string(""test"");
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As String
         b = New String(""test"")
@@ -115,7 +115,7 @@ End Class");
     {
         string b = new string(""test"");
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As String = New String(""test"")
     End Sub
@@ -131,7 +131,7 @@ End Class");
     {
         var b = new string(""test"");
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b = New String(""test"")
     End Sub
@@ -147,7 +147,7 @@ End Class");
     {
         int[] b;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer()
     End Sub
@@ -163,7 +163,7 @@ End Class");
     {
         int[] b = { 1, 2, 3 };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = {1, 2, 3}
     End Sub
@@ -179,7 +179,7 @@ End Class");
     {
         var b = { 1, 2, 3 };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b = {1, 2, 3}
     End Sub
@@ -195,7 +195,7 @@ End Class");
     {
         int[] b = new int[] { 1, 2, 3 };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = New Integer() {1, 2, 3}
     End Sub
@@ -211,7 +211,7 @@ End Class");
     {
         int[] b = new int[3] { 1, 2, 3 };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer() = New Integer(2) {1, 2, 3}
     End Sub
@@ -227,7 +227,7 @@ End Class");
     {
         int[,] b;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,)
     End Sub
@@ -246,7 +246,7 @@ End Class");
             {3, 4}
         };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = {
         {1, 2},
@@ -267,7 +267,7 @@ End Class");
             {3, 4}
         };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = New Integer(,) {
         {1, 2},
@@ -288,7 +288,7 @@ End Class");
             {3, 4}
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer(,) = New Integer(1, 1) {
         {1, 2},
@@ -306,7 +306,7 @@ End Class");
     {
         int[][] b;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer()()
     End Sub
@@ -322,7 +322,7 @@ End Class");
     {
         int[][] b = { new int[] { 1, 2 }, new int[] { 3, 4 } };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer()() = {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
@@ -338,7 +338,7 @@ End Class");
     {
         int[][] b = new int[][] { new int[] { 1, 2 }, new int[] { 3, 4 } };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer()() = New Integer()() {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
@@ -354,7 +354,7 @@ End Class");
     {
         int[][] b = new int[2][] { new int[] { 1, 2 }, new int[] { 3, 4 } };
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer()() = New Integer(1)() {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
@@ -374,7 +374,7 @@ the_beginning:
         var text = ""This is my text!"";
         goto the_beginning;
     }
-}", @"Class Test
+}", @"Friend Class Test
     Private Sub TestMethod()
 the_beginning:
         Dim value As Integer = 1
@@ -398,7 +398,7 @@ End Class");
         else
             b = 3;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal a As Integer)
         Dim b As Integer
 
@@ -429,7 +429,7 @@ End Class");
             b = 3;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal a As Integer)
         Dim b As Integer
 
@@ -463,7 +463,7 @@ End Class");
             Console.WriteLine(x);
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Public Shared Sub TestMethod()
         If True Then
             Dim x = 1
@@ -496,7 +496,7 @@ End Class");
             b = 1;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer
         b = 0
@@ -563,7 +563,7 @@ End Class");
         }
         while (b == 0);
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim b As Integer
         b = 0
@@ -592,7 +592,7 @@ End Class");
                 break;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal values As Integer())
         For Each val As Integer In values
             If val = 2 Then Continue For
@@ -617,7 +617,7 @@ End Class");
                 break;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal values As Integer())
         For Each val In values
             If val = 2 Then Continue For
@@ -640,7 +640,7 @@ End Class");
             Console.WriteLine(nullObject);
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal nullObject As Object)
         If nullObject Is Nothing Then Throw New ArgumentNullException(NameOf(nullObject))
 
@@ -661,7 +661,7 @@ End Class");
         for (i = 0; unknownCondition; i++)
             b[i] = s[i];
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         i = 0
 
@@ -684,7 +684,7 @@ End Class");
             b[i] = s[i];
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         Dim i As Integer = 0
 
@@ -705,7 +705,7 @@ End Class");
     {
         for (i = 0; i < end; i++) b[i] = s[i];
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         For i = 0 To [end] - 1
             b(i) = s(i)
@@ -725,7 +725,7 @@ End Class");
             b[i] = s[i];
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod()
         For i = 0 To [end] - 1
             b(i) = s(i)
@@ -777,7 +777,7 @@ End Class");
             Console.WriteLine(""Press any key to exit."");
             Console.ReadKey();
         }
-    }", @"Class GotoTest1
+    }", @"Friend Class GotoTest1
     Private Shared Sub Main()
         Dim x As Integer = 200, y As Integer = 4
         Dim count As Integer = 0
@@ -825,7 +825,7 @@ End Class");
         if (nullObject == null)
             throw new ArgumentNullException(nameof(nullObject));
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal nullObject As Object)
         If nullObject Is Nothing Then Throw New ArgumentNullException(NameOf(nullObject))
     End Sub
@@ -859,7 +859,7 @@ class TestClass
     }
 }", @"Imports System
 
-Class TestClass
+Friend Class TestClass
     Public Event MyEvent As EventHandler
 
     Private Sub TestMethod(ByVal e As EventHandler)
@@ -904,7 +904,7 @@ End Class");
                 break;
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Sub TestMethod(ByVal number As Integer)
         Select Case number
             Case 0, 1, 2
@@ -961,7 +961,7 @@ End Class");
             Console.WriteLine(""finally"");
         }
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Shared Function Log(ByVal message As String) As Boolean
         Console.WriteLine(message)
         Return False
@@ -1007,7 +1007,7 @@ End Class");
         for (int i = 0; i < number; i++)
             yield return i;
     }
-}", @"Class TestClass
+}", @"Friend Class TestClass
     Private Iterator Function TestMethod(ByVal number As Integer) As IEnumerable(Of Integer)
         If number < 0 Then Return
 


### PR DESCRIPTION
Fixes #85 
Fixes #125 

* Which part of this PR is most in need of attention/improvement?

Could really do with more test cases implementing base classes and base base classes.
There's also the edge case in C# where a parent type contains the method which implements a method on an interface of a derived type which I'm not sure what to do about.

However this should be much better than it was, so worth merging I think.
