### PR TITLE
VB -> C#: Improve query syntax support

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -19,6 +19,7 @@ using SyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
 using TypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax;
 using VariableDeclaratorSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.VariableDeclaratorSyntax;
 using VisualBasicExtensions = Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
@@ -346,7 +347,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         }
 
         internal SyntaxList<ArrayRankSpecifierSyntax> ConvertArrayRankSpecifierSyntaxes(
-            SyntaxList<Microsoft.CodeAnalysis.VisualBasic.Syntax.ArrayRankSpecifierSyntax> arrayRankSpecifierSyntaxs,
+            SyntaxList<VBSyntax.ArrayRankSpecifierSyntax> arrayRankSpecifierSyntaxs,
             ArgumentListSyntax nodeArrayBounds, bool withSizes = true)
         {
             var bounds = SyntaxFactory.List(arrayRankSpecifierSyntaxs.Select(r => (ArrayRankSpecifierSyntax)r.Accept(_nodesVisitor)));
@@ -372,7 +373,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return argumentListSyntax.Arguments.Select(a => IncreaseArrayUpperBoundExpression(((SimpleArgumentSyntax)a).Expression));
         }
 
-        private ExpressionSyntax IncreaseArrayUpperBoundExpression(Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax expr)
+        private ExpressionSyntax IncreaseArrayUpperBoundExpression(VBSyntax.ExpressionSyntax expr)
         {
             var constant = _semanticModel.GetConstantValue(expr);
             if (constant.HasValue && constant.Value is int)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1266,7 +1266,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return queryClauseSyntax is VBSyntax.GroupByClauseSyntax
                        || queryClauseSyntax is VBSyntax.SelectClauseSyntax
                        || queryClauseSyntax is VBSyntax.PartitionClauseSyntax
-                       || queryClauseSyntax is VBSyntax.PartitionWhileClauseSyntax;
+                       || queryClauseSyntax is VBSyntax.PartitionWhileClauseSyntax
+                       || queryClauseSyntax is VBSyntax.DistinctClauseSyntax;
 
             }
 

--- a/ICSharpCode.CodeConverter/CSharp/QueryConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/QueryConverter.cs
@@ -111,7 +111,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     if (!gcs.Items.Any()) {
                         var identifierNameSyntax =
                             SyntaxFactory.IdentifierName(CommonConversions.ConvertIdentifier(fromClauseSyntax.Identifier));
-                        var letGroupKey = SyntaxFactory.LetClause(GetGroupKeyIdentifiers(gcs).First(), SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName(GetGroupIdentifier(gcs)), SyntaxFactory.IdentifierName("Key")));
+                        var letGroupKey = SyntaxFactory.LetClause(GetGroupKeyIdentifiers(gcs).Single(), SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName(GetGroupIdentifier(gcs)), SyntaxFactory.IdentifierName("Key")));
                         continuationClauses = continuationClauses.Add(letGroupKey);
                         selectOrGroup = SyntaxFactory.GroupClause(identifierNameSyntax, GetGroupExpression(gcs));
                     } else {
@@ -229,11 +229,10 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         private SyntaxToken GetGroupIdentifier(VBSyntax.GroupByClauseSyntax gs)
         {
-            var names = gs.AggregationVariables.Select(v => v.Aggregation is VBSyntax.FunctionAggregationSyntax f
+            var name = gs.AggregationVariables.Select(v => v.Aggregation is VBSyntax.FunctionAggregationSyntax f
                     ? f.FunctionName.Text : v.Aggregation is VBSyntax.GroupAggregationSyntax g ? g.GroupKeyword.Text : null)
-                .Where(x => x != null)
-                .DefaultIfEmpty(gs.Keys.Select(k => k.NameEquals.Identifier.Identifier.Text).First());
-            return SyntaxFactory.Identifier(names.First());
+                .SingleOrDefault(x => x != null) ?? gs.Keys.Select(k => k.NameEquals.Identifier.Identifier.Text).Single();
+            return SyntaxFactory.Identifier(name);
         }
 
         private IEnumerable<string> GetGroupKeyIdentifiers(VBSyntax.GroupByClauseSyntax gs)

--- a/ICSharpCode.CodeConverter/CSharp/QueryConverter.cs
+++ b/ICSharpCode.CodeConverter/CSharp/QueryConverter.cs
@@ -1,0 +1,291 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    /// <remarks>
+    ///  Grammar info: http://kursinfo.himolde.no/in-kurs/IBE150/VBspec.htm#_Toc248253288
+    /// </remarks>
+    internal class QueryConverter
+    {
+        private readonly CommentConvertingNodesVisitor _triviaConvertingVisitor;
+
+        public QueryConverter(CommonConversions commonConversions, CommentConvertingNodesVisitor triviaConvertingVisitor)
+        {
+            CommonConversions = commonConversions;
+            _triviaConvertingVisitor = triviaConvertingVisitor;
+        }
+
+        private CommonConversions CommonConversions { get; }
+
+        public CSharpSyntaxNode ConvertClauses(SyntaxList<VBSyntax.QueryClauseSyntax> clauses)
+        {
+            var vbBodyClauses = new Queue<VBSyntax.QueryClauseSyntax>(clauses);
+
+            var vbFromClause = (VBSyntax.FromClauseSyntax) vbBodyClauses.Dequeue();
+            var fromClauseSyntax = ConvertFromClauseSyntax(vbFromClause);
+
+            var querySegments = GetQuerySegments(vbBodyClauses);
+                
+            return ConvertQuerySegments(querySegments, fromClauseSyntax);
+        }
+
+        private CSharpSyntaxNode ConvertQuerySegments(IEnumerable<(Queue<(SyntaxList<CSSyntax.QueryClauseSyntax>, VBSyntax.QueryClauseSyntax)>, VBSyntax.QueryClauseSyntax)> querySegments, CSSyntax.FromClauseSyntax fromClauseSyntax)
+        {
+            CSSyntax.ExpressionSyntax query = null;
+            foreach (var (queryContinuation, queryEnd) in querySegments) {
+                query = (CSSyntax.ExpressionSyntax) ConvertQueryWithContinuations(queryContinuation, fromClauseSyntax);
+                if (queryEnd == null) return query;
+                var queryWithoutTrivia = ConvertQueryToLinq(fromClauseSyntax, queryEnd, query);
+                query = _triviaConvertingVisitor.TriviaConverter.PortConvertedTrivia(queryEnd, queryWithoutTrivia);
+                fromClauseSyntax = SyntaxFactory.FromClause(fromClauseSyntax.Identifier, query);
+            }
+
+            return query ?? throw new ArgumentOutOfRangeException(nameof(querySegments), querySegments, null);
+        }
+
+        private CSSyntax.InvocationExpressionSyntax ConvertQueryToLinq(CSSyntax.FromClauseSyntax fromClauseSyntax, VBSyntax.QueryClauseSyntax queryEnd,
+            CSSyntax.ExpressionSyntax query)
+        {
+            var linqMethodName = GetLinqMethodName(queryEnd);
+            var parenthesizedQuery = query is CSSyntax.QueryExpressionSyntax ? SyntaxFactory.ParenthesizedExpression(query) : query;
+            var linqMethod = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, parenthesizedQuery,
+                SyntaxFactory.IdentifierName(linqMethodName));
+            var linqArguments = SyntaxFactory.ArgumentList(
+                SyntaxFactory.SeparatedList(GetLinqArguments(fromClauseSyntax, queryEnd).Select(SyntaxFactory.Argument)));
+            var invocationExpressionSyntax = SyntaxFactory.InvocationExpression(linqMethod, linqArguments);
+            return invocationExpressionSyntax;
+        }
+
+        private IEnumerable<(Queue<(SyntaxList<CSSyntax.QueryClauseSyntax>, VBSyntax.QueryClauseSyntax)>, VBSyntax.QueryClauseSyntax)> GetQuerySegments(Queue<VBSyntax.QueryClauseSyntax> vbBodyClauses)
+        {
+            while (vbBodyClauses.Any()) {
+                var querySectionsReversed =
+                    new Queue<(SyntaxList<CSSyntax.QueryClauseSyntax>, VBSyntax.QueryClauseSyntax)>();
+                while (vbBodyClauses.Any() && !RequiresMethodInvocation(vbBodyClauses.Peek())) {
+                    var convertedClauses = new List<CSSyntax.QueryClauseSyntax>();
+                    while (vbBodyClauses.Any() && !RequiredContinuation(vbBodyClauses.Peek())) {
+                        convertedClauses.Add(ConvertQueryBodyClause(vbBodyClauses.Dequeue()));
+                    }
+
+                    var convertQueryBodyClauses = (SyntaxFactory.List(convertedClauses),
+                        vbBodyClauses.Any() ? vbBodyClauses.Dequeue() : null);
+                    querySectionsReversed.Enqueue(convertQueryBodyClauses);
+                }
+                yield return (querySectionsReversed, vbBodyClauses.Any() ? vbBodyClauses.Dequeue() : null);
+            }
+        }
+
+        private CSharpSyntaxNode ConvertQueryWithContinuations(Queue<(SyntaxList<CSSyntax.QueryClauseSyntax>, VBSyntax.QueryClauseSyntax)> queryContinuation, CSSyntax.FromClauseSyntax fromClauseSyntax)
+        {
+            var subQuery = ConvertQueryWithContinuation(queryContinuation, fromClauseSyntax);
+            return subQuery != null ? SyntaxFactory.QueryExpression(fromClauseSyntax, subQuery) : fromClauseSyntax.Expression;
+        }
+
+        private CSSyntax.QueryBodySyntax ConvertQueryWithContinuation(Queue<(SyntaxList<CSSyntax.QueryClauseSyntax>, VBSyntax.QueryClauseSyntax)> querySectionsReversed, CSSyntax.FromClauseSyntax fromClauseSyntax)
+        {
+            if (!querySectionsReversed.Any()) return null;
+            var (convertedClauses, clauseEnd) = querySectionsReversed.Dequeue();
+
+            var nestedClause = ConvertQueryWithContinuation(querySectionsReversed, fromClauseSyntax);
+            return ConvertSubQuery(fromClauseSyntax, clauseEnd, nestedClause, convertedClauses);
+        }
+
+        private CSSyntax.QueryBodySyntax ConvertSubQuery(CSSyntax.FromClauseSyntax fromClauseSyntax, VBSyntax.QueryClauseSyntax clauseEnd,
+            CSSyntax.QueryBodySyntax nestedClause, SyntaxList<CSSyntax.QueryClauseSyntax> convertedClauses)
+        {
+            CSSyntax.SelectOrGroupClauseSyntax selectOrGroup = null;
+            CSSyntax.QueryContinuationSyntax queryContinuation = null;
+            switch (clauseEnd) {
+                case null:
+                    selectOrGroup = CreateDefaultSelectClause(fromClauseSyntax);
+                    break;
+                case VBSyntax.GroupByClauseSyntax gcs:
+                    var continuationClauses = SyntaxFactory.List<CSSyntax.QueryClauseSyntax>();
+                    if (!gcs.Items.Any()) {
+                        var identifierNameSyntax =
+                            SyntaxFactory.IdentifierName(CommonConversions.ConvertIdentifier(fromClauseSyntax.Identifier));
+                        var letGroupKey = SyntaxFactory.LetClause(GetGroupKeyIdentifiers(gcs).First(), SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.IdentifierName(GetGroupIdentifier(gcs)), SyntaxFactory.IdentifierName("Key")));
+                        continuationClauses = continuationClauses.Add(letGroupKey);
+                        selectOrGroup = SyntaxFactory.GroupClause(identifierNameSyntax, GetGroupExpression(gcs));
+                    } else {
+                        var item = (CSSyntax.IdentifierNameSyntax)gcs.Items.Single().Expression.Accept(_triviaConvertingVisitor);
+                        var keyExpression = (CSSyntax.ExpressionSyntax)gcs.Keys.Single().Expression.Accept(_triviaConvertingVisitor);
+                        selectOrGroup = SyntaxFactory.GroupClause(item, keyExpression);
+                    }
+                    queryContinuation = CreateGroupByContinuation(gcs, continuationClauses, nestedClause);
+                    break;
+                case VBSyntax.SelectClauseSyntax scs:
+                    selectOrGroup = ConvertSelectClauseSyntax(scs);
+                    break;
+                default:
+                    throw new NotImplementedException($"Clause kind '{clauseEnd.Kind()}' is not yet implemented");
+            }
+
+            return SyntaxFactory.QueryBody(convertedClauses, selectOrGroup, queryContinuation);
+        }
+
+        private CSSyntax.QueryContinuationSyntax CreateGroupByContinuation(VBSyntax.GroupByClauseSyntax gcs, SyntaxList<CSSyntax.QueryClauseSyntax> convertedClauses, CSSyntax.QueryBodySyntax body)
+        {
+            var queryBody = SyntaxFactory.QueryBody(convertedClauses, body?.SelectOrGroup, null);
+            return SyntaxFactory.QueryContinuation(GetGroupIdentifier(gcs), queryBody);
+        }
+
+        private IEnumerable<CSSyntax.ExpressionSyntax> GetLinqArguments(CSSyntax.FromClauseSyntax fromClauseSyntax,
+            VBSyntax.QueryClauseSyntax linqQuery)
+        {
+            switch (linqQuery) {
+                case VBSyntax.DistinctClauseSyntax _:
+                    return Enumerable.Empty<CSSyntax.ExpressionSyntax>();
+                case VBSyntax.PartitionClauseSyntax pcs:
+                    return new[] {(CSSyntax.ExpressionSyntax)pcs.Count.Accept(_triviaConvertingVisitor)};
+                case VBSyntax.PartitionWhileClauseSyntax pwcs: {
+                    var lambdaParam = SyntaxFactory.Parameter(fromClauseSyntax.Identifier);
+                    var lambdaBody = (CSSyntax.ExpressionSyntax) pwcs.Condition.Accept(_triviaConvertingVisitor);
+                    return new[] {(CSSyntax.ExpressionSyntax) SyntaxFactory.SimpleLambdaExpression(lambdaParam, lambdaBody)};
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(linqQuery), linqQuery.Kind(), null);
+            }
+        }
+
+        private static string GetLinqMethodName(VBSyntax.QueryClauseSyntax queryEnd)
+        {
+            switch (queryEnd) {
+                case VBSyntax.DistinctClauseSyntax _:
+                    return nameof(Enumerable.Distinct);
+                case VBSyntax.PartitionClauseSyntax pcs:
+                    return pcs.SkipOrTakeKeyword.IsKind(Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.SkipKeyword) ? nameof(Enumerable.Skip) : nameof(Enumerable.Take);
+                case VBSyntax.PartitionWhileClauseSyntax pwcs:
+                    return pwcs.SkipOrTakeKeyword.IsKind(Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.SkipKeyword) ? nameof(Enumerable.SkipWhile) : nameof(Enumerable.TakeWhile);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(queryEnd), queryEnd.Kind(), null);
+            }
+        }
+
+        private static bool RequiresMethodInvocation(VBSyntax.QueryClauseSyntax queryClauseSyntax)
+        {
+            return queryClauseSyntax is VBSyntax.PartitionClauseSyntax
+                   || queryClauseSyntax is VBSyntax.PartitionWhileClauseSyntax
+                   || queryClauseSyntax is VBSyntax.DistinctClauseSyntax;
+        }
+
+        private static bool RequiredContinuation(VBSyntax.QueryClauseSyntax queryClauseSyntax)
+        {
+            return queryClauseSyntax is VBSyntax.GroupByClauseSyntax
+                   || queryClauseSyntax is VBSyntax.SelectClauseSyntax;
+        }
+
+        private CSSyntax.FromClauseSyntax ConvertFromClauseSyntax(VBSyntax.FromClauseSyntax vbFromClause)
+        {
+            var collectionRangeVariableSyntax = vbFromClause.Variables.Single();
+            var fromClauseSyntax = SyntaxFactory.FromClause(
+                CommonConversions.ConvertIdentifier(collectionRangeVariableSyntax.Identifier.Identifier),
+                (CSSyntax.ExpressionSyntax) collectionRangeVariableSyntax.Expression.Accept(_triviaConvertingVisitor));
+            return fromClauseSyntax;
+        }
+
+        private CSSyntax.SelectClauseSyntax ConvertSelectClauseSyntax(VBSyntax.SelectClauseSyntax vbFromClause)
+        {
+            var collectionRangeVariableSyntax = vbFromClause.Variables.Single();
+            return SyntaxFactory.SelectClause(
+                (CSSyntax.ExpressionSyntax)collectionRangeVariableSyntax.Expression.Accept(_triviaConvertingVisitor)
+            );
+        }
+
+        /// <summary>
+        /// TODO: In the case of multiple Froms and no Select, VB returns an anonymous type containing all the variables created by the from clause
+        /// </summary>
+        private static CSSyntax.SelectClauseSyntax CreateDefaultSelectClause(CSSyntax.FromClauseSyntax fromClauseSyntax)
+        {
+            return SyntaxFactory.SelectClause(SyntaxFactory.IdentifierName(fromClauseSyntax.Identifier));
+        }
+
+        private CSSyntax.QueryClauseSyntax ConvertQueryBodyClause(VBSyntax.QueryClauseSyntax node)
+        {
+            return node.TypeSwitch<VBSyntax.QueryClauseSyntax, VBSyntax.FromClauseSyntax, VBSyntax.JoinClauseSyntax, VBSyntax.LetClauseSyntax, VBSyntax.OrderByClauseSyntax, VBSyntax.WhereClauseSyntax, CSSyntax.QueryClauseSyntax>(
+                //(VBSyntax.AggregateClauseSyntax ags) => null,
+                //(VBSyntax.DistinctClauseSyntax ds) => null,
+                ConvertFromClauseSyntax,
+                ConvertJoinClause,
+                ConvertLetClause,
+                ConvertOrderByClause,
+                //(VBSyntax.PartitionClauseSyntax ps) => null, // TODO Convert to Skip and Take methods (they don't exist in C#s query syntax)
+                //(VBSyntax.PartitionWhileClauseSyntax pws) => null, // TODO Convert to SkipWhile and TakeWhile methods (they don't exist in C#s query syntax)
+                ConvertWhereClause,
+                _ => throw new NotImplementedException($"Conversion for query clause with kind '{node.Kind()}' not implemented"));
+        }
+
+        private CSSyntax.ExpressionSyntax GetGroupExpression(VBSyntax.GroupByClauseSyntax gs)
+        {
+            return (CSSyntax.ExpressionSyntax) gs.Keys.Single().Expression.Accept(_triviaConvertingVisitor);
+        }
+
+        private SyntaxToken GetGroupIdentifier(VBSyntax.GroupByClauseSyntax gs)
+        {
+            var names = gs.AggregationVariables.Select(v => v.Aggregation is VBSyntax.FunctionAggregationSyntax f
+                    ? f.FunctionName.Text : v.Aggregation is VBSyntax.GroupAggregationSyntax g ? g.GroupKeyword.Text : null)
+                .Where(x => x != null)
+                .DefaultIfEmpty(gs.Keys.Select(k => k.NameEquals.Identifier.Identifier.Text).First());
+            return SyntaxFactory.Identifier(names.First());
+        }
+
+        private IEnumerable<string> GetGroupKeyIdentifiers(VBSyntax.GroupByClauseSyntax gs)
+        {
+            return gs.AggregationVariables
+                .Select(x => x.NameEquals?.Identifier.Identifier.Text)
+                .Concat(gs.Keys.Select(k => k.NameEquals?.Identifier.Identifier.Text))
+                .Where(x => x != null);
+        }
+
+        private CSSyntax.QueryClauseSyntax ConvertWhereClause(VBSyntax.WhereClauseSyntax ws)
+        {
+            return SyntaxFactory.WhereClause((CSSyntax.ExpressionSyntax) ws.Condition.Accept(_triviaConvertingVisitor));
+        }
+
+        private CSSyntax.QueryClauseSyntax ConvertLetClause(VBSyntax.LetClauseSyntax ls)
+        {
+            var singleVariable = ls.Variables.Single();
+            return SyntaxFactory.LetClause(CommonConversions.ConvertIdentifier(singleVariable.NameEquals.Identifier.Identifier), (CSSyntax.ExpressionSyntax) singleVariable.Expression.Accept(_triviaConvertingVisitor));
+        }
+
+        private CSSyntax.QueryClauseSyntax ConvertOrderByClause(VBSyntax.OrderByClauseSyntax os)
+        {
+            return SyntaxFactory.OrderByClause(SyntaxFactory.SeparatedList(os.Orderings.Select(o => (CSSyntax.OrderingSyntax) o.Accept(_triviaConvertingVisitor))));
+        }
+
+        private CSSyntax.QueryClauseSyntax ConvertJoinClause(VBSyntax.JoinClauseSyntax js)
+        {
+            var variable = js.JoinedVariables.Single();
+            var joinLhs = SingleExpression(js.JoinConditions.Select(c => c.Left.Accept(_triviaConvertingVisitor))
+                .Cast<CSSyntax.ExpressionSyntax>().ToList());
+            var joinRhs = SingleExpression(js.JoinConditions.Select(c => c.Right.Accept(_triviaConvertingVisitor))
+                .Cast<CSSyntax.ExpressionSyntax>().ToList());
+            var convertIdentifier = CommonConversions.ConvertIdentifier(variable.Identifier.Identifier);
+            var expressionSyntax = (CSSyntax.ExpressionSyntax) variable.Expression.Accept(_triviaConvertingVisitor);
+
+            CSSyntax.JoinIntoClauseSyntax joinIntoClauseSyntax = null;
+            if (js is VBSyntax.GroupJoinClauseSyntax gjs) {
+                joinIntoClauseSyntax = gjs.AggregationVariables
+                    .Where(a => a.Aggregation is VBSyntax.GroupAggregationSyntax)
+                    .Select(a => SyntaxFactory.JoinIntoClause(CommonConversions.ConvertIdentifier(a.NameEquals.Identifier.Identifier)))
+                    .SingleOrDefault();
+            }
+            return SyntaxFactory.JoinClause(null, convertIdentifier, expressionSyntax, joinLhs, joinRhs, joinIntoClauseSyntax);
+        }
+
+        private CSSyntax.ExpressionSyntax SingleExpression(IReadOnlyCollection<CSSyntax.ExpressionSyntax> expressions)
+        {
+            if (expressions.Count == 1) return expressions.Single();
+            return SyntaxFactory.AnonymousObjectCreationExpression(SyntaxFactory.SeparatedList(expressions.Select((e, i) =>
+                SyntaxFactory.AnonymousObjectMemberDeclarator(SyntaxFactory.NameEquals($"key{i}"), e)
+            )));
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
@@ -17,7 +17,6 @@ namespace ICSharpCode.CodeConverter.Shared
 {
     public class ProjectConversion
     {
-        private readonly string _solutionDir;
         private readonly Compilation _sourceCompilation;
         private readonly IEnumerable<SyntaxTree> _syntaxTreesToConvert;
         // ReSharper disable once StaticMemberInGenericType - Stateless
@@ -30,7 +29,7 @@ namespace ICSharpCode.CodeConverter.Shared
         private ProjectConversion(Compilation sourceCompilation, IEnumerable<SyntaxTree> syntaxTreesToConvert, ILanguageConversion languageConversion, Compilation convertedCompilation)
         {
             _languageConversion = languageConversion;
-            this._sourceCompilation = sourceCompilation;
+            _sourceCompilation = sourceCompilation;
             _syntaxTreesToConvert = syntaxTreesToConvert.ToList();
             _handlePartialConversion = _syntaxTreesToConvert.Count() == 1;
             languageConversion.Initialize(convertedCompilation.RemoveAllSyntaxTrees());
@@ -149,7 +148,7 @@ namespace ICSharpCode.CodeConverter.Shared
             var nonFatalWarningsOrNull = _languageConversion.GetWarningsOrNull();
             if (!string.IsNullOrWhiteSpace(nonFatalWarningsOrNull))
             {
-                var warningsDescription = Path.Combine(_solutionDir ?? "", _sourceCompilation.AssemblyName, "ConversionWarnings.txt");
+                var warningsDescription = Path.Combine("", _sourceCompilation.AssemblyName, "ConversionWarnings.txt");
                 _errors.TryAdd(warningsDescription, nonFatalWarningsOrNull);
             }
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -922,6 +922,124 @@ End Function", @"private static IEnumerable<string> FindPicFilePath()
         }
 
         [Fact]
+        public void LinqGroupByAnonymous()
+        {
+            //Very hard to automated test comments on such a complicated query
+            TestConversionVisualBasicToCSharpWithoutComments(@"Imports System.Runtime.CompilerServices
+
+Public Class AccountEntry
+    Public Property LookupAccountEntryTypeId As Object
+    Public Property LookupAccountEntrySourceId As Object
+    Public Property SponsorId As Object
+    Public Property LookupFundTypeId As Object
+    Public Property StartDate As Object
+    Public Property SatisfiedDate As Object
+    Public Property InterestStartDate As Object
+    Public Property ComputeInterestFlag As Object
+    Public Property SponsorClaimRevision As Object
+    Public Property Amount As Decimal
+    Public Property AccountTransactions As List(Of Object)
+    Public Property AccountEntryClaimDetails As List(Of AccountEntry)
+End Class
+
+Module Ext
+    <Extension>
+    Public Function Reduce(ByVal accountEntries As IEnumerable(Of AccountEntry)) As IEnumerable(Of AccountEntry)
+        Return (
+            From _accountEntry In accountEntries
+                Where _accountEntry.Amount > 0D
+                Group By _keys = New With
+                    {
+                    Key .LookupAccountEntryTypeId = _accountEntry.LookupAccountEntryTypeId,
+                    Key .LookupAccountEntrySourceId = _accountEntry.LookupAccountEntrySourceId,
+                    Key .SponsorId = _accountEntry.SponsorId,
+                    Key .LookupFundTypeId = _accountEntry.LookupFundTypeId,
+                    Key .StartDate = _accountEntry.StartDate,
+                    Key .SatisfiedDate = _accountEntry.SatisfiedDate,
+                    Key .InterestStartDate = _accountEntry.InterestStartDate,
+                    Key .ComputeInterestFlag = _accountEntry.ComputeInterestFlag,
+                    Key .SponsorClaimRevision = _accountEntry.SponsorClaimRevision
+                    } Into Group
+                Select New AccountEntry() With
+                    {
+                    .LookupAccountEntryTypeId = _keys.LookupAccountEntryTypeId,
+                    .LookupAccountEntrySourceId = _keys.LookupAccountEntrySourceId,
+                    .SponsorId = _keys.SponsorId,
+                    .LookupFundTypeId = _keys.LookupFundTypeId,
+                    .StartDate = _keys.StartDate,
+                    .SatisfiedDate = _keys.SatisfiedDate,
+                    .ComputeInterestFlag = _keys.ComputeInterestFlag,
+                    .InterestStartDate = _keys.InterestStartDate,
+                    .SponsorClaimRevision = _keys.SponsorClaimRevision,
+                    .Amount = Group.Sum(Function(accountEntry) accountEntry.Amount),
+                    .AccountTransactions = New List(Of Object)(),
+                    .AccountEntryClaimDetails =
+                        (From _accountEntry In Group From _claimDetail In _accountEntry.AccountEntryClaimDetails
+                            Select _claimDetail).Reduce().ToList
+                    }
+            )
+    End Function
+End Module", @"using System.Collections.Generic;
+using System.Linq;
+
+public class AccountEntry
+{
+    public object LookupAccountEntryTypeId { get; set; }
+    public object LookupAccountEntrySourceId { get; set; }
+    public object SponsorId { get; set; }
+    public object LookupFundTypeId { get; set; }
+    public object StartDate { get; set; }
+    public object SatisfiedDate { get; set; }
+    public object InterestStartDate { get; set; }
+    public object ComputeInterestFlag { get; set; }
+    public object SponsorClaimRevision { get; set; }
+    public decimal Amount { get; set; }
+    public List<object> AccountTransactions { get; set; }
+    public List<AccountEntry> AccountEntryClaimDetails { get; set; }
+}
+
+static class Ext
+{
+    public static IEnumerable<AccountEntry> Reduce(this IEnumerable<AccountEntry> accountEntries)
+    {
+        return (from _accountEntry in accountEntries
+                where _accountEntry.Amount > 0M
+                group _accountEntry by new
+                {
+                    LookupAccountEntryTypeId = _accountEntry.LookupAccountEntryTypeId,
+                    LookupAccountEntrySourceId = _accountEntry.LookupAccountEntrySourceId,
+                    SponsorId = _accountEntry.SponsorId,
+                    LookupFundTypeId = _accountEntry.LookupFundTypeId,
+                    StartDate = _accountEntry.StartDate,
+                    SatisfiedDate = _accountEntry.SatisfiedDate,
+                    InterestStartDate = _accountEntry.InterestStartDate,
+                    ComputeInterestFlag = _accountEntry.ComputeInterestFlag,
+                    SponsorClaimRevision = _accountEntry.SponsorClaimRevision
+                } into Group
+                let _keys = Group.Key
+                select new AccountEntry()
+                {
+                    LookupAccountEntryTypeId = _keys.LookupAccountEntryTypeId,
+                    LookupAccountEntrySourceId = _keys.LookupAccountEntrySourceId,
+                    SponsorId = _keys.SponsorId,
+                    LookupFundTypeId = _keys.LookupFundTypeId,
+                    StartDate = _keys.StartDate,
+                    SatisfiedDate = _keys.SatisfiedDate,
+                    ComputeInterestFlag = _keys.ComputeInterestFlag,
+                    InterestStartDate = _keys.InterestStartDate,
+                    SponsorClaimRevision = _keys.SponsorClaimRevision,
+                    Amount = Group.Sum(accountEntry => accountEntry.Amount),
+                    AccountTransactions = new List<object>(),
+                    AccountEntryClaimDetails = (from _accountEntry in Group
+                                                from _claimDetail in _accountEntry.AccountEntryClaimDetails
+                                                select _claimDetail).Reduce().ToList()
+                }
+);
+    }
+}");
+        }
+
+        [Fact]
         public void PartiallyQualifiedName()
         {
             TestConversionVisualBasicToCSharp(@"Imports System.Collections

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -898,6 +898,30 @@ End Sub", @"private static void LinqSub()
         }
 
         [Fact]
+        public void LinqPartitionDistinct()
+        {
+            TestConversionVisualBasicToCSharp(@"Private Shared Function FindPicFilePath() As IEnumerable(Of String)
+    Dim words = {""an"", ""apple"", ""a"", ""day"", ""keeps"", ""the"", ""doctor"", ""away""}
+
+    Return From word In words
+            Skip 1
+            Skip While word.Length >= 1
+            Take While word.Length < 5
+            Take 2
+            Distinct
+End Function", @"private static IEnumerable<string> FindPicFilePath()
+{
+    var words = new[] {""an"", ""apple"", ""a"", ""day"", ""keeps"", ""the"", ""doctor"", ""away""};
+    return words
+        .Skip(1)
+        .SkipWhile(word => word.Length >= 1)
+        .TakeWhile(word => word.Length < 5)
+        .Take(2)
+        .Distinct();
+}");
+        }
+
+        [Fact]
         public void PartiallyQualifiedName()
         {
             TestConversionVisualBasicToCSharp(@"Imports System.Collections

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -911,13 +911,14 @@ End Sub", @"private static void LinqSub()
             Distinct
 End Function", @"private static IEnumerable<string> FindPicFilePath()
 {
-    var words = new[] {""an"", ""apple"", ""a"", ""day"", ""keeps"", ""the"", ""doctor"", ""away""};
+    var words = new[] { ""an"", ""apple"", ""a"", ""day"", ""keeps"", ""the"", ""doctor"", ""away"" };
+
     return words
-        .Skip(1)
-        .SkipWhile(word => word.Length >= 1)
-        .TakeWhile(word => word.Length < 5)
-        .Take(2)
-        .Distinct();
+.Skip(1)
+.SkipWhile(word => word.Length >= 1)
+.TakeWhile(word => word.Length < 5)
+.Take(2)
+.Distinct();
 }");
         }
 

--- a/Tests/ProjectConverterTestBase.cs
+++ b/Tests/ProjectConverterTestBase.cs
@@ -72,7 +72,7 @@ namespace CodeConverter.Tests
             Dictionary<string, ConversionResult> conversionResults, DirectoryInfo expectedResultDirectory,
             string originalSolutionDir)
         {
-            AssertSubset(expectedFiles.Select(f => f.FullName), conversionResults.Select(r => r.Key.Replace(originalSolutionDir, expectedResultDirectory.FullName)));
+            AssertSubset(expectedFiles.Select(f => f.FullName.Replace(expectedResultDirectory.FullName, "")), conversionResults.Select(r => r.Key.Replace(originalSolutionDir, "")));
         }
 
         private void AssertAllExpectedFilesAreEqual(FileInfo[] expectedFiles, Dictionary<string, ConversionResult> conversionResults,
@@ -92,9 +92,11 @@ namespace CodeConverter.Tests
             Assert.Empty(errors);
         }
 
-        private static void AssertSubset(IEnumerable<string> expectedFiles, IEnumerable<string> collection)
+        private static void AssertSubset(IEnumerable<string> superset, IEnumerable<string> subset)
         {
-            Assert.Subset(new HashSet<string>(expectedFiles, StringComparer.OrdinalIgnoreCase), new HashSet<string>(collection, StringComparer.OrdinalIgnoreCase));
+            var notExpected = new HashSet<string>(subset, StringComparer.OrdinalIgnoreCase);
+            notExpected.ExceptWith(new HashSet<string>(superset, StringComparer.OrdinalIgnoreCase));
+            Assert.Empty(notExpected);
         }
 
         private void AssertFileEqual(Dictionary<string, ConversionResult> conversionResults,


### PR DESCRIPTION
https://github.com/icsharpcode/CodeConverter/issues/29

### Problem
Currently don't handle several keywords, or nested statements

### Solution
* First step was to handle nested statements by chunking sections together.

* [x] At least one test covering the code changed
* [x] All tests pass

Which part of this PR is most in need of attention/improvement:
* The higher level methods in the `QueryConverter` are pretty much write-only code. They just batch up bits of the query for other methods to handle later, but are missing appropriate naming and probably a data structure of their own.
* The lower level methods still don't handle many cases, currently they will just throw an exception due to using `Single` in places where there can be multiple elements - I don't have examples of the more advanced cases, so I think this is fine for now, and better than barreling on missing information without informing the user.
