### PR TITLE
Closes #136 - VB -> C# Use parentheses around single parameter in lambda when parameter has explicit type

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1442,7 +1442,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     body = node.Body.Accept(TriviaConvertingVisitor);
                 }
                 var param = (ParameterListSyntax)node.SubOrFunctionHeader.ParameterList.Accept(TriviaConvertingVisitor);
-                if (param.Parameters.Count == 1)
+                if (param.Parameters.Count == 1 && param.Parameters.Single().Type == null)
                     return SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body);
                 return SyntaxFactory.ParenthesizedLambdaExpression(param, body);
             }
@@ -1451,7 +1451,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var body = SyntaxFactory.Block(node.Statements.SelectMany(s => s.Accept(CreateMethodBodyVisitor())));
                 var param = (ParameterListSyntax)node.SubOrFunctionHeader.ParameterList.Accept(TriviaConvertingVisitor);
-                if (param.Parameters.Count == 1)
+                if (param.Parameters.Count == 1 && param.Parameters.Single().Type == null)
                     return SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body);
                 return SyntaxFactory.ParenthesizedLambdaExpression(param, body);
             }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -550,7 +550,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        Func<int, int> test = int a => a * 2;
+        Func<int, int> test = (int a) => a * 2;
         test(3);
     }
 }");


### PR DESCRIPTION
There was an existing test case that showed the issue so this pull request updates that test and doesn't add any new tests.