### PR TITLE
Closes #139 - VB -> C#: Array literals not always converted to implicit C# array

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1162,11 +1162,13 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitCollectionInitializer(VBSyntax.CollectionInitializerSyntax node)
             {
-                var typeInfo = _semanticModel.GetTypeInfo(node);
-                var isArrayType = typeInfo.ConvertedType?.IsKind(SymbolKind.ArrayType) == true;
-                var initializerType = isArrayType ? SyntaxKind.ArrayInitializerExpression : SyntaxKind.CollectionInitializerExpression;
+                var isArrayLiteral =
+                    !( node.Parent is VBSyntax.ObjectCollectionInitializerSyntax
+                    || node.Parent is VBSyntax.CollectionInitializerSyntax
+                    || node.Parent is VBSyntax.ArrayCreationExpressionSyntax);
+                var initializerType = isArrayLiteral ? SyntaxKind.ArrayInitializerExpression : SyntaxKind.CollectionInitializerExpression;
                 var initializer = SyntaxFactory.InitializerExpression(initializerType, SyntaxFactory.SeparatedList(node.Initializers.Select(i => (ExpressionSyntax)i.Accept(TriviaConvertingVisitor))));
-                return typeInfo.Type == null && (typeInfo.ConvertedType?.SpecialType == SpecialType.System_Collections_IEnumerable || isArrayType)
+                return isArrayLiteral
                     ? (CSharpSyntaxNode)SyntaxFactory.ImplicitArrayCreationExpression(initializer)
                     : initializer;
             }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -488,6 +488,32 @@ End Class", @"class TestClass
     }
 }");
         }
+        [Fact]
+        public void CollectionInitializers()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClass
+    Private Sub DoStuff(a As Object)
+    End Sub
+    Private Sub TestMethod()
+        DoStuff({1, 2})
+        Dim intList As New List(Of Integer) From {1}
+        Dim dict As New Dictionary(Of Integer, Integer) From {{1, 2}, {3, 4}}
+    End Sub
+End Class", @"using System.Collections.Generic;
+
+class TestClass
+{
+    private void DoStuff(object a)
+    {
+    }
+    private void TestMethod()
+    {
+        DoStuff(new[] { 1, 2 });
+        List<int> intList = new List<int>() { 1 };
+        Dictionary<int, int> dict = new Dictionary<int, int>() { { 1, 2 }, { 3, 4 } };
+    }
+}");
+        }
 
         [Fact]
         public void ThisMemberAccessExpression()


### PR DESCRIPTION
I checked all occurrences of 'CollectionInitializer' in the [VB.NET grammar](https://docs.microsoft.com/en-us/dotnet/visual-basic/reference/language-specification/expressions) to try and make sure that there isn't any other node that a CollectionInitializer could belong to where you _wouldn't_ turn it into an implicit C# array.