### PR TITLE
Closes #142 VB -> C#: Remove erroneous 'static' keyword in const field of module

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -273,7 +273,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var m = ConvertModifier(token, context);
                 if (m.HasValue) yield return m.Value;
             }
-            if (context == TokenContext.MemberInModule)
+            if (context == TokenContext.MemberInModule &&
+                    !modifiers.Any(a => VisualBasicExtensions.Kind(a) == SyntaxKind.ConstKeyword ))
                 yield return SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword);
         }
 

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -21,6 +21,18 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void TestConstantFieldInModule()
+        {
+            TestConversionVisualBasicToCSharp(
+@"Module TestModule
+    Const answer As Integer = 42
+End Module", @"static class TestModule
+{
+    const int answer = 42;
+}");
+        }
+
+        [Fact]
         public void TestMethod()
         {
             TestConversionVisualBasicToCSharp(


### PR DESCRIPTION
I can't think of any other members coming from a VB Module that wouldn't need the 'static' keyword added...