### PR TITLE
Closes #147 VB -> C#: Conversion error for indexer on property value of unresolved type

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1061,7 +1061,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return node.Expression.Accept(TriviaConvertingVisitor);
                 var symbol = GetInvocationSymbol(invocation);
                 SyntaxToken token = default(SyntaxToken);
-                if (symbol != null) {
+                if (symbol != null && !(symbol.Kind == SymbolKind.Property && symbol.GetParameters().Length == 0)) {
                     var parameterKinds = symbol.GetParameters().Select(param => param.RefKind).ToList();
                     //WARNING: If named parameters can reach here it won't work properly for them
                     var refKind = argId >= parameterKinds.Count && symbol.IsParams() ? RefKind.None : parameterKinds[argId];

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1420,7 +1420,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var invocationSymbol = _semanticModel.GetSymbolInfo(node).ExtractBestMatch();
                 var symbol = _semanticModel.GetSymbolInfo(node.Expression).ExtractBestMatch();
-                if (invocationSymbol?.IsIndexer() == true || symbol?.GetReturnType()?.IsArrayType() == true && !(symbol is IMethodSymbol)) //The null case happens quite a bit - should try to fix
+                var symbolReturnType = symbol?.GetReturnType();
+                // Chances of having an unknown delegate stored as a field/local seem lower than having an unknown non-delegate type with an indexer stored, so for a standalone identifier err on the side of assuming it's an indexer
+                if (invocationSymbol?.IsIndexer() == true || symbolReturnType.IsArrayType() && !(symbol is IMethodSymbol) || symbolReturnType.IsErrorType() && node.Expression is VBSyntax.IdentifierNameSyntax)
                 {
                     return SyntaxFactory.ElementAccessExpression(
                         (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor),

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1061,10 +1061,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return node.Expression.Accept(TriviaConvertingVisitor);
                 var symbol = GetInvocationSymbol(invocation);
                 SyntaxToken token = default(SyntaxToken);
-                if (symbol != null && !(symbol.Kind == SymbolKind.Property && symbol.GetParameters().Length == 0)) {
+                if (symbol != null) {
                     var parameterKinds = symbol.GetParameters().Select(param => param.RefKind).ToList();
                     //WARNING: If named parameters can reach here it won't work properly for them
-                    var refKind = argId >= parameterKinds.Count && symbol.IsParams() ? RefKind.None : parameterKinds[argId];
+                    var refKind = argId >= parameterKinds.Count ? RefKind.None : parameterKinds[argId];
                     switch (refKind) {
                         case RefKind.None:
                             token = default(SyntaxToken);

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -377,7 +377,7 @@ End Class", @"class TestClass
     public System.Some.UnknownType SomeProperty { get; set; }
     private void TestMethod()
     {
-        var value = SomeProperty(0);
+        var value = SomeProperty[0];
     }
 }");
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -365,6 +365,24 @@ class TestClass
         }
 
         [Fact]
+        public void InvokeIndexerOnPropertyValue()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Public Property SomeProperty As System.Some.UnknownType
+    Private Sub TestMethod()
+        Dim value = SomeProperty(0)
+    End Sub
+End Class", @"class TestClass
+{
+    public System.Some.UnknownType SomeProperty { get; set; }
+    private void TestMethod()
+    {
+        var value = SomeProperty(0);
+    }
+}");
+        }
+
+        [Fact]
         public void ExternalReferenceToOutParameter()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass


### PR DESCRIPTION
In VB, properties can have indexers like this:
```vbnet
Public Property SomeProp(index As Integer) As Integer
```
When running the provided test case, VisitSimpleArgument gets an ArgumentOutOfRangeException on the call to:
```C#
parameterKinds[argId]
```
Here's why.  VisitSimpleArgument calls GetInvocationSymbol on the invocation involving SomeProperty which returns a symbol with information about that property.  The current program looks like it was mostly written with method invocation in mind so it's trying to determine if the method parameter corresponding to the argument being passed is a ref or out parameter.  In the test case, the invocation is trying to target the value _returned by_ the property (like if the value was an array or a list) as opposed to calling an indexer on the property itself.  But instead, GetParameters is called for the "SomeProperty" symbol which doesn't have an indexer and therefore has zero parameters.  So you get the ArgumentOutOfRangeException.

When I tried declaring SomeProperty as an array type instead of a type that Roslyn couldn't resolve, I got a null value back from GetInvocationSymbol.  I'm not sure why that is.