### PR TITLE
VB -> C#: Namespace conversion issue caused by VisitQualifiedName

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1621,7 +1621,12 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var lhsSyntax = (NameSyntax)node.Left.Accept(TriviaConvertingVisitor);
                 var rhsSyntax = (SimpleNameSyntax)node.Right.Accept(TriviaConvertingVisitor);
 
-                var partOfNamespaceDeclaration = node.Parent.IsKind(VBasic.SyntaxKind.NamespaceStatement);
+                VBSyntax.NameSyntax topLevelName = node;
+                while (topLevelName.Parent is VBSyntax.NameSyntax parentName)
+                {
+                    topLevelName = parentName;
+                }
+                var partOfNamespaceDeclaration = topLevelName.Parent.IsKind(VBasic.SyntaxKind.NamespaceStatement);
                 var leftIsGlobal = node.Left.IsKind(VBasic.SyntaxKind.GlobalName);
 
                 ExpressionSyntax qualifiedName;

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -14,6 +14,15 @@ End Namespace", @"namespace Test
         }
 
         [Fact]
+        public void TestLongNamespace()
+        {
+            TestConversionVisualBasicToCSharp(@"Namespace Test1.Test2.Test3
+End Namespace", @"namespace Test1.Test2.Test3
+{
+}");
+        }
+
+        [Fact]
         public void TestGlobalNamespace()
         {
             TestConversionVisualBasicToCSharp(@"Namespace Global.Test


### PR DESCRIPTION
The VisitQualifiedName method was prepending namespace declarations that consist of 2 or more parts (might've actually been 3 or more) with the project's root namespace.  The default root namespace that all of the tests use is "TestProject" and that gets prepended to longer namespace declarations.  Hopefully this change makes sense.  Thanks!