### PR TITLE
#107 VB -> C#: Add VB root namespace to all converted files

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -142,7 +142,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return SyntaxFactory.QualifiedName(PrependName(qName.Left, toPrepend), qName.Right);
                 }
                 else {
-                    throw new Exception("Unknown name syntax");
+                    throw new ArgumentOutOfRangeException(nameof(name), name, $"{name.GetType().Name} of kind {name.Kind()} not expected within namespace declaration");
                 }
             }
 

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -105,7 +105,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 }
 
                 var attributes = SyntaxFactory.List(node.Attributes.SelectMany(a => a.AttributeLists).SelectMany(ConvertAttribute));
-                var convertedMembers = node.Members.Select(m => (MemberDeclarationSyntax)m.Accept(TriviaConvertingVisitor));
+                var convertedMembers = node.Members.Select(m => (MemberDeclarationSyntax)m.Accept(TriviaConvertingVisitor)).ToReadOnlyCollection();
                 if (!string.IsNullOrEmpty(options.RootNamespace))
                 {
                     var rootNamespaceIdentifier = SyntaxFactory.IdentifierName(options.RootNamespace);
@@ -121,8 +121,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 );
             }
 
-            private IEnumerable<MemberDeclarationSyntax> PrependRootNamespace(
-                    IEnumerable<MemberDeclarationSyntax> memberDeclarations,
+            private IReadOnlyCollection<MemberDeclarationSyntax> PrependRootNamespace(
+                    IReadOnlyCollection<MemberDeclarationSyntax> memberDeclarations,
                     IdentifierNameSyntax rootNamespaceIdentifier)
             {
                 if (!memberDeclarations.Skip(1).Any() && memberDeclarations.FirstOrDefault() is NamespaceDeclarationSyntax nsDecl) {

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -111,13 +111,12 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var rootNamespaceIdentifier = SyntaxFactory.IdentifierName(options.RootNamespace);
                     convertedMembers = PrependRootNamespace(convertedMembers, rootNamespaceIdentifier);
                 }
-                var members = SyntaxFactory.List(convertedMembers);
 
                 return SyntaxFactory.CompilationUnit(
                     SyntaxFactory.List<ExternAliasDirectiveSyntax>(),
                     SyntaxFactory.List(importsClauses.GroupBy(c => c.ToString()).Select(g => g.First()).Select(c => (UsingDirectiveSyntax)c.Accept(TriviaConvertingVisitor))),
                     attributes,
-                    members
+                    SyntaxFactory.List(convertedMembers)
                 );
             }
 
@@ -125,7 +124,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     IReadOnlyCollection<MemberDeclarationSyntax> memberDeclarations,
                     IdentifierNameSyntax rootNamespaceIdentifier)
             {
-                if (!memberDeclarations.Skip(1).Any() && memberDeclarations.FirstOrDefault() is NamespaceDeclarationSyntax nsDecl) {
+                if (memberDeclarations.Count == 1 && memberDeclarations.First() is NamespaceDeclarationSyntax nsDecl) {
                     return new [] { nsDecl.WithName(PrependName(nsDecl.Name, rootNamespaceIdentifier)) };
                 }
 
@@ -133,6 +132,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         .WithMembers(SyntaxFactory.List(memberDeclarations));
                 return new [] { newNamespaceDecl };
             }
+
             private NameSyntax PrependName(NameSyntax name, IdentifierNameSyntax toPrepend)
             {
                 if (name is IdentifierNameSyntax identName) {

--- a/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
@@ -139,7 +139,6 @@ End Class";
         public Compilation CreateCompilationFromTree(SyntaxTree tree, IEnumerable<MetadataReference> references)
         {
             var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithRootNamespace("TestProject")
                 .WithGlobalImports(GlobalImport.Parse(
                     "System",
                     "System.Collections.Generic",

--- a/ICSharpCode.CodeConverter/Util/EnumerableExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/EnumerableExtensions.cs
@@ -37,7 +37,7 @@ namespace ICSharpCode.CodeConverter.Util
             return source;
         }
 
-        public static ReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> source)
+        public static IReadOnlyCollection<T> ToReadOnlyCollection<T>(this IEnumerable<T> source)
         {
             if (source == null) {
                 throw new ArgumentNullException(nameof(source));

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -5,8 +5,6 @@ using ICSharpCode.CodeConverter;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.VB;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
 
 namespace CodeConverter.Tests
@@ -14,7 +12,7 @@ namespace CodeConverter.Tests
     public class ConverterTestBase
     {
         private bool _testCstoVBCommentsByDefault = false;
-        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool expectSurroundingMethodBlock = false, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
+        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool expectSurroundingMethodBlock = false)
         {
             expectedVisualBasicCode = AddSurroundingMethodBlock(expectedVisualBasicCode, expectSurroundingMethodBlock);
 
@@ -43,8 +41,8 @@ End Sub";
         public void TestConversionVisualBasicToCSharp(string visualBasicCode, string expectedCsharpCode, bool expectSurroundingBlock = false)
         {
             if (expectSurroundingBlock) expectedCsharpCode = SurroundWithBlock(expectedCsharpCode);
-            TestConversionVisualBasicToCSharpWithoutComments(visualBasicCode, expectedCsharpCode, false);
-            TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true), false);
+            TestConversionVisualBasicToCSharpWithoutComments(visualBasicCode, expectedCsharpCode);
+            TestConversionVisualBasicToCSharpWithoutComments(AddLineNumberComments(visualBasicCode, "' ", false), AddLineNumberComments(expectedCsharpCode, "// ", true));
         }
 
         private static string SurroundWithBlock(string expectedCsharpCode)
@@ -53,7 +51,7 @@ End Sub";
             return $"{{\r\n    {indentedStatements}\r\n}}";
         }
 
-        public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode, bool addUsings = true, CSharpParseOptions csharpOptions = null, VisualBasicParseOptions vbOptions = null)
+        public void TestConversionVisualBasicToCSharpWithoutComments(string visualBasicCode, string expectedCsharpCode)
         {
             AssertConvertedCodeResultEquals<VBToCSConversion>(visualBasicCode, expectedCsharpCode);
         }


### PR DESCRIPTION
Warning, this will break almost all test cases by enclosing generated code in a namespace.  All the unit tests use an instance of VisualBasicCompilationOptions that uses .WithRootNamespace("TestProject").  Not sure if you want to just change it to use a blank root namespace or how you'd want to handle that.

Anyway, this pull request changes all of a projects generated files as follows:
- if the only member declaration is a namespace declaration, it prepends it with the VB root namespace
- otherwise all member declarations are wrapped in a new top-level namespace
