### PR TITLE
#152 VB -> C#: Fix QualifyNode to handle inheritance

### DIFF
--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -912,6 +912,34 @@ End Class", @"class TestClass
     }
 }");
         }
+        
+        [Fact]
+        public void NameQualifyingHandlesInheritance()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClassBase
+    Sub DoStuff()
+    End Sub
+End Class
+Class TestClass
+    Inherits TestClassBase
+    Private Sub TestMethod()
+        DoStuff()
+    End Sub
+End Class", @"class TestClassBase
+{
+    public void DoStuff()
+    {
+    }
+}
+
+class TestClass : TestClassBase
+{
+    private void TestMethod()
+    {
+        DoStuff();
+    }
+}");
+        }
 
         [Fact]
         public void UsingGlobalImport()


### PR DESCRIPTION
I think this fixes the problem, but I don't know my way around the Roslyn type symbols too well.
EDIT:  This breaks the PartiallyQualifiedName test because the while loop I added keeps checking base classes all the way to System.Object in which case the enumerable of prefixes will contain "System".