### PR TITLE
vb -> C# Add parentheses around conditional expression in string interpolation

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1376,11 +1376,16 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitTernaryConditionalExpression(VBSyntax.TernaryConditionalExpressionSyntax node)
             {
-                return SyntaxFactory.ConditionalExpression(
+                var expr = SyntaxFactory.ConditionalExpression(
                     (ExpressionSyntax)node.Condition.Accept(TriviaConvertingVisitor),
                     (ExpressionSyntax)node.WhenTrue.Accept(TriviaConvertingVisitor),
                     (ExpressionSyntax)node.WhenFalse.Accept(TriviaConvertingVisitor)
                 );
+
+                if (node.Parent.GetType() == typeof(VBSyntax.InterpolationSyntax))
+                    return SyntaxFactory.ParenthesizedExpression(expr);
+                
+                return expr;
             }
 
             public override CSharpSyntaxNode VisitTypeOfExpression(VBSyntax.TypeOfExpressionSyntax node)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1382,7 +1382,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     (ExpressionSyntax)node.WhenFalse.Accept(TriviaConvertingVisitor)
                 );
 
-                if (node.Parent.GetType() == typeof(VBSyntax.InterpolationSyntax))
+                if (node.Parent is VBSyntax.InterpolationSyntax)
                     return SyntaxFactory.ParenthesizedExpression(expr);
                 
                 return expr;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1382,7 +1382,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     (ExpressionSyntax)node.WhenFalse.Accept(TriviaConvertingVisitor)
                 );
 
-                if (node.Parent is VBSyntax.InterpolationSyntax)
+                if (node.Parent.IsKind(VBasic.SyntaxKind.Interpolation))
                     return SyntaxFactory.ParenthesizedExpression(expr);
                 
                 return expr;

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1350,5 +1350,18 @@ class TestClass
     }
 }");
         }
+
+        [Fact]
+        public void StringInterpolationWithConditionalOperator()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Public Function GetString(yourBoolean as Boolean) As String
+    Return $""You {if (yourBoolean, ""do"", ""do not"")} have a true value""
+End Function", 
+@"public string GetString(bool yourBoolean)
+{
+    return $""You {(yourBoolean ? ""do"" : ""do not"")} have a true value"";
+}");
+        }
     }
 }


### PR DESCRIPTION
Fixes #154 

### Problem
There was a compiler error when using a conditional operator in String Interpolation

### Solution
* I took a look at the other code in NodeVisitor.cs, and it appears that it is common to conditionally change the return information based upon certain situations
* I am most concerned about 2 parts of this:
  * `node.Parent.GetType() == typeof(VBSyntax.InterpolationSyntax)` - Is there a better way to do this?
  * Location of my test. Does it belong in a better place?

* [x] At least one test covering the code changed
* [x] All tests pass - The tests did not pass, but when I reverted my changes, the same tests failed, so I do not believe the tests were previously passing, so I will check this off. If this is wrong, please let me know

