### PR TITLE
VB -> C#: Fix Qualify function to handle names that are already partially qualified

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1655,6 +1655,9 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private static QualifiedNameSyntax Qualify(string qualification, ExpressionSyntax toBeQualified)
             {
+                if (toBeQualified is QualifiedNameSyntax qName) {
+                    toBeQualified = qName.Right;
+                }
                 return SyntaxFactory.QualifiedName(
                     SyntaxFactory.ParseName(qualification),
                     (SimpleNameSyntax)toBeQualified);

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -900,15 +900,18 @@ End Sub", @"private static void LinqSub()
         [Fact]
         public void PartiallyQualifiedName()
         {
-            TestConversionVisualBasicToCSharp(@"Class TestClass
-    Public Function TestMethod(dir As String) As String
-         Return IO.Path.Combine(dir, ""file.txt"")
-    End Function
+            TestConversionVisualBasicToCSharp(@"Imports System.Collections
+Class TestClass
+    Public Sub TestMethod(dir As String)
+        IO.Path.Combine(dir, ""file.txt"")
+        Dim c As New ObjectModel.ObservableCollection(Of String)
+    End Sub
 End Class", @"class TestClass
 {
-    public string TestMethod(string dir)
+    public void TestMethod(string dir)
     {
-        return System.IO.Path.Combine(dir, ""file.txt"");
+        System.IO.Path.Combine(dir, ""file.txt"");
+        System.Collections.ObjectModel.ObservableCollection<string> c = new System.Collections.ObjectModel.ObservableCollection<string>();
     }
 }");
         }


### PR DESCRIPTION
This pull request contains an updated test for qualifying a name that is already partially qualified as well as a code change that makes the test pass.  I'm not sure if this is the correct way to handle it.  Also, there could be some scenarios with nested classes that this doesn't handle right.