### PR TITLE
VB -> C#: Type inferred const - convert to explicit type

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -68,7 +68,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                         inferredTypeSyntax = SyntaxFactory.PredefinedType(SyntaxFactory.Token(predefined));
                     }
                     else {
-                        inferredTypeSyntax = SyntaxFactory.ParseTypeName(typeInf.ConvertedType.GetFullMetadataName());
+                        var typeName = typeInf.ConvertedType.ToMinimalCSharpDisplayString(_semanticModel, declarator.SpanStart);
+                        inferredTypeSyntax = SyntaxFactory.ParseTypeName(typeName);
                     }
                 }
             }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -62,11 +62,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)
             {
                 var modifiers = CommonConversions.ConvertModifiers(node.Modifiers, TokenContext.Local);
+                var isConst = modifiers.Any(a => a.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConstKeyword);
 
                 var declarations = new List<LocalDeclarationStatementSyntax>();
 
                 foreach (var declarator in node.Declarators)
-                    foreach (var decl in CommonConversions.SplitVariableDeclarations(declarator))
+                    foreach (var decl in CommonConversions.SplitVariableDeclarations(declarator, preferExplicitType: isConst))
                         declarations.Add(SyntaxFactory.LocalDeclarationStatement(modifiers, decl.Value));
 
                 return SyntaxFactory.List<StatementSyntax>(declarations);

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -384,10 +384,11 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var convertableModifiers = node.Modifiers.Where(m => !SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
                 var isWithEvents = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
                 var convertedModifiers = CommonConversions.ConvertModifiers(convertableModifiers, GetMemberContext(node), true);
+                var isConst = convertedModifiers.Any(a => a.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConstKeyword);
                 var declarations = new List<MemberDeclarationSyntax>(node.Declarators.Count);
 
                 foreach (var declarator in node.Declarators) {
-                    foreach (var decl in CommonConversions.SplitVariableDeclarations(declarator).Values) {
+                    foreach (var decl in CommonConversions.SplitVariableDeclarations(declarator, preferExplicitType: isConst).Values) {
                         if (isWithEvents) {
                             var initializers = decl.Variables
                                 .Where(a => a.Initializer != null)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -384,7 +384,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var convertableModifiers = node.Modifiers.Where(m => !SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
                 var isWithEvents = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
                 var convertedModifiers = CommonConversions.ConvertModifiers(convertableModifiers, GetMemberContext(node), true);
-                var isConst = convertedModifiers.Any(a => a.Kind() == Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConstKeyword);
+                var isConst = convertedModifiers.Any(a => a.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConstKeyword));
                 var declarations = new List<MemberDeclarationSyntax>(node.Declarators.Count);
 
                 foreach (var declarator in node.Declarators) {

--- a/ICSharpCode.CodeConverter/Util/CSharpUtil.cs
+++ b/ICSharpCode.CodeConverter/Util/CSharpUtil.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -248,7 +249,7 @@ namespace ICSharpCode.CodeConverter.Util
             throw new NotSupportedException();
         }
 
-        public static TypeSyntax ToCsSyntax(this ITypeSymbol type, SemanticModel model, VBasic.Syntax.TypeSyntax typeSyntax)
+        public static TypeSyntax ToCsSyntax(this ITypeSymbol type, SemanticModel model, Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax typeSyntax)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
@@ -256,13 +257,20 @@ namespace ICSharpCode.CodeConverter.Util
                 .WithLeadingTrivia(typeSyntax.GetLeadingTrivia().ConvertTrivia())
                 .WithTrailingTrivia(typeSyntax.GetTrailingTrivia().ConvertTrivia());
         }
-        public static VBasic.Syntax.TypeSyntax ToVbSyntax(this ITypeSymbol type, SemanticModel model, TypeSyntax typeSyntax)
+        public static Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax ToVbSyntax(this ITypeSymbol type, SemanticModel model, TypeSyntax typeSyntax)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
             return VBasic.SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(model, typeSyntax.SpanStart))
                 .WithLeadingTrivia(typeSyntax.GetLeadingTrivia().ConvertTrivia())
                 .WithTrailingTrivia(typeSyntax.GetTrailingTrivia().ConvertTrivia());
+        }
+
+        public static IEnumerable<T> FollowProperty<T>(this T start, Func<T, T> getProperty) where T : class
+        {
+            for (var current = start; current != null; current = getProperty(current)) {
+                yield return current;
+            }
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/INamespaceOrTypeSymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/INamespaceOrTypeSymbolExtensions.cs
@@ -19,11 +19,6 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static readonly Comparison<INamespaceOrTypeSymbol> CompareNamespaceOrTypeSymbols = CompareTo;
 
-        public static string GetShortName(this INamespaceOrTypeSymbol symbol)
-        {
-            return symbol.ToCSharpDisplayString(s_shortNameFormat);
-        }
-
         public static IEnumerable<IPropertySymbol> GetIndexers(this INamespaceOrTypeSymbol symbol)
         {
             return symbol == null

--- a/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
@@ -182,10 +182,14 @@ namespace ICSharpCode.CodeConverter.Util
             return null;
         }
 
-        public static string ToMinimalCSharpDisplayString(this ISymbol symbol, SemanticModel vbSemanticModel, int position, SymbolDisplayFormat format = null)
+        public static string ToMinimalCSharpDisplayString(this ITypeSymbol symbol, SemanticModel vbSemanticModel, int position, SymbolDisplayFormat format = null)
         {
             if (TryGetSpecialVBTypeConversion(symbol, out var cSharpDisplayString)) return cSharpDisplayString;
-            return symbol.ToMinimalDisplayString(vbSemanticModel, position, format);
+            var minimalCSharpDisplayString = symbol.ToMinimalDisplayString(vbSemanticModel, position, format);
+            var parentTypes = symbol.FollowProperty(t => t?.ContainingSymbol as ITypeSymbol).Count() - 1;
+            // Workaround: The above call can return a name qualified by a partial namespace, e.g. IO.Path if System is already imported.
+            // So check that we don't end up qualifying with non-type symbols by checking the number of dots
+            return minimalCSharpDisplayString.Count(x => x == '.') > parentTypes ? ToCSharpDisplayString(symbol, format) : minimalCSharpDisplayString;
         }
 
         public static string ToCSharpDisplayString(this ISymbol symbol, SymbolDisplayFormat format = null)

--- a/ICSharpCode.CodeConverter/Util/ITypeSymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/ITypeSymbolExtensions.cs
@@ -298,44 +298,6 @@ namespace ICSharpCode.CodeConverter.Util
             return false;
         }
 
-        public static string CreateParameterName(this ITypeSymbol type, bool capitalize = false)
-        {
-            while (true) {
-                var arrayType = type as IArrayTypeSymbol;
-                if (arrayType != null) {
-                    type = arrayType.ElementType;
-                    continue;
-                }
-
-                var pointerType = type as IPointerTypeSymbol;
-                if (pointerType != null) {
-                    type = pointerType.PointedAtType;
-                    continue;
-                }
-
-                break;
-            }
-
-            var shortName = GetParameterName(type);
-            return capitalize ? shortName.ToPascalCase() : shortName.ToCamelCase();
-        }
-
-        private static string GetParameterName(ITypeSymbol type)
-        {
-            if (type == null || type.IsAnonymousType()) {
-                return DefaultParameterName;
-            }
-
-            if (type.IsSpecialType() || type.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T) {
-                return DefaultBuiltInParameterName;
-            }
-
-            var shortName = type.GetShortName();
-            return shortName.Length == 0
-                ? DefaultParameterName
-                    : shortName;
-        }
-
         private static bool IsSpecialType(this ITypeSymbol symbol)
         {
             if (symbol != null) {

--- a/ICSharpCode.CodeConverter/Util/TypeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/TypeExtensions.cs
@@ -29,24 +29,6 @@ namespace ICSharpCode.CodeConverter.Util
         #endregion
 
         /// <summary>
-        /// Gets the full name of the namespace.
-        /// </summary>
-        public static string GetFullName(this INamespaceSymbol ns)
-        {
-            return ns.ToCSharpDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-        }
-
-        /// <summary>
-        /// Gets the full name. The full name is no 1:1 representation of a type it's missing generics and it has a poor
-        /// representation for inner types (just dot separated).
-        /// DO NOT use this method unless you're know what you do. It's only implemented for legacy code.
-        /// </summary>
-        public static string GetFullName(this ITypeSymbol type)
-        {
-            return type.ToCSharpDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
-        }
-
-        /// <summary>
         /// Returns true if the type is public and was tagged with
         /// [System.ComponentModel.ToolboxItem (true)]
         /// </summary>

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -41,12 +41,14 @@ End Module", @"static class TestModule
     Sub TestMethod()
         Const someConst = System.DateTimeKind.Local
     End Sub
-End Class", @"class TestClass
+End Class", @"using System;
+
+class TestClass
 {
     const int someConstField = 42;
     public void TestMethod()
     {
-        const System.DateTimeKind someConst = System.DateTimeKind.Local;
+        const DateTimeKind someConst = System.DateTimeKind.Local;
     }
 }");
         }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -33,6 +33,25 @@ End Module", @"static class TestModule
         }
 
         [Fact]
+        public void TestTypeInferredConst()
+        {
+            TestConversionVisualBasicToCSharp(
+@"Class TestClass
+    Const someConstField = 42
+    Sub TestMethod()
+        Const someConst = System.DateTimeKind.Local
+    End Sub
+End Class", @"class TestClass
+{
+    const int someConstField = 42;
+    public void TestMethod()
+    {
+        const System.DateTimeKind someConst = System.DateTimeKind.Local;
+    }
+}");
+        }
+
+        [Fact]
         public void TestMethod()
         {
             TestConversionVisualBasicToCSharp(


### PR DESCRIPTION
In VB, an As clause isn't required for const fields or locals but in C# an explicit type is required (cannot use "var").  This fix uses the semantic model to add the explicit type when the As clause is missing.