### PR TITLE
VB -> C# - String Interpolation With Double Quotes Not Properly Escaping Double Quotes

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -13,7 +13,6 @@ using ArrayRankSpecifierSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankS
 using ArrayTypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayTypeSyntax;
 using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
 using ExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax;
-using ISymbolExtensions = ICSharpCode.CodeConverter.Util.ISymbolExtensions;
 using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using SyntaxFacts = Microsoft.CodeAnalysis.CSharp.SyntaxFacts;
 using SyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
@@ -138,12 +137,12 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public ExpressionSyntax Literal(object o, string valueText = null) => GetLiteralExpression(o, valueText);
 
-        internal ExpressionSyntax GetLiteralExpression(object value, string valueText = null)
+        internal ExpressionSyntax GetLiteralExpression(object value, string fullText = null)
         {
-            if (value is string s) {
-                valueText = GetStringValueText(s, valueText);
+            if (value is string valueText) {
+                fullText = GetStringValueText(valueText, fullText);
                 return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StringLiteralExpression,
-                    SyntaxFactory.Literal(valueText, s));
+                    SyntaxFactory.Literal(fullText, valueText));
             }
 
             if (value == null)
@@ -151,33 +150,33 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (value is bool)
                 return SyntaxFactory.LiteralExpression((bool)value ? Microsoft.CodeAnalysis.CSharp.SyntaxKind.TrueLiteralExpression : Microsoft.CodeAnalysis.CSharp.SyntaxKind.FalseLiteralExpression);
 
-            valueText = valueText != null ? ConvertNumericLiteralValueText(valueText, value) : value.ToString();
+            fullText = fullText != null ? ConvertNumericLiteralValueText(fullText, value) : value.ToString();
 
             if (value is byte)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (byte)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (byte)value));
             if (value is sbyte)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (sbyte)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (sbyte)value));
             if (value is short)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (short)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (short)value));
             if (value is ushort)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (ushort)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (ushort)value));
             if (value is int)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (int)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (int)value));
             if (value is uint)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (uint)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (uint)value));
             if (value is long)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (long)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (long)value));
             if (value is ulong)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (ulong)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (ulong)value));
 
             if (value is float)
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (float)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (float)value));
             if (value is double) {
                 // Important to use value text, otherwise "10.0" gets coerced to and integer literal of 10 which can change semantics
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (double)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (double)value));
             }
             if (value is decimal) {
-                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (decimal)value));
+                return SyntaxFactory.LiteralExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(fullText, (decimal)value));
             }
 
             if (value is char)
@@ -187,16 +186,25 @@ namespace ICSharpCode.CodeConverter.CSharp
             throw new ArgumentOutOfRangeException(nameof(value), value, null);
         }
 
-        internal string GetStringValueText(string s1, string valueText)
+        internal string GetStringValueText(string valueText, string fullText)
         {
-            var worthBeingAVerbatimString = IsWorthBeingAVerbatimString(s1);
+            var worthBeingAVerbatimString = IsWorthBeingAVerbatimString(valueText);
             if (worthBeingAVerbatimString)
             {
-                var valueWithReplacements = s1.Replace("\"", "\"\"");
+                var valueWithReplacements = CleanContentsOfString(valueText, fullText, true);
                 return $"@\"{valueWithReplacements}\"";
             } 
 
-            return "\"" + valueText.Substring(1, valueText.Length - 2).Replace("\"\"", "\\\"") + "\"";
+            return "\"" + CleanContentsOfString(valueText, fullText.Substring(1, fullText.Length - 2), false) + "\"";
+        }
+
+        internal string CleanContentsOfString(string s1, string valueText, bool isVerbatimString)
+        {
+            if (isVerbatimString) {
+                return s1.Replace("\"", "\"\"");
+            } else {
+                return valueText.Replace("\"\"", "\\\"");
+            }
         }
 
         public bool IsWorthBeingAVerbatimString(string s1)

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -199,12 +199,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             return "\"" + CleanContentsOfString(valueText, fullText.Substring(1, fullText.Length - 2), false) + "\"";
         }
 
-        internal string CleanContentsOfString(string s1, string valueText, bool isVerbatimString)
+        internal string CleanContentsOfString(string valueText, string fullText, bool isVerbatimString)
         {
             if (isVerbatimString) {
-                return s1.Replace("\"", "\"\"");
+                return valueText.Replace("\"", "\"\"");
             } else {
-                return valueText.Replace("\"\"", "\\\"");
+                return fullText.Replace("\"\"", "\\\"");
             }
         }
 

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -13,6 +13,7 @@ using ArrayRankSpecifierSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankS
 using ArrayTypeSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayTypeSyntax;
 using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
 using ExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax;
+using ISymbolExtensions = ICSharpCode.CodeConverter.Util.ISymbolExtensions;
 using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using SyntaxFacts = Microsoft.CodeAnalysis.CSharp.SyntaxFacts;
 using SyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -966,7 +966,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                             .WithTrailingTrivia(
                                 SyntaxFactory.Comment("/* TODO Change to default(_) if this is not a reference type */"));
                     }
-                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(CommonConversions.ToCsTypeSyntax(type, node)) : CommonConversions.Literal(null);
+                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(type.ToMinimalCSharpDisplayString(_semanticModel, node.SpanStart))) : CommonConversions.Literal(null);
                 }
                 return CommonConversions.Literal(node.Token.Value, node.Token.Text);
             }
@@ -980,7 +980,9 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitInterpolatedStringText(VBSyntax.InterpolatedStringTextSyntax node)
             {
-                return SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.InterpolatedStringTextToken, node.TextToken.Text, node.TextToken.ValueText, default(SyntaxTriviaList)));
+                var useVerbatim = node.Parent.DescendantNodes().OfType<VBSyntax.InterpolatedStringTextSyntax>().Any(c => CommonConversions.IsWorthBeingAVerbatimString(c.TextToken.Text));
+                var escapedString = CommonConversions.CleanContentsOfString(node.TextToken.ValueText, node.TextToken.Text, useVerbatim);
+                return SyntaxFactory.InterpolatedStringText(SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.InterpolatedStringTextToken, escapedString, node.TextToken.ValueText, default(SyntaxTriviaList)));
             }
 
             public override CSharpSyntaxNode VisitInterpolation(VBSyntax.InterpolationSyntax node)

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -315,32 +315,6 @@ End Class", @"class TestClass
         }
 
         [Fact]
-        public void NullableInteger()
-        {
-            //BUG: Line comments after "else" aren't converted
-            TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClass
-    Public Function Bar(value As String) As Integer?
-        Dim result As Integer
-        If Integer.TryParse(value, result) Then
-            Return result
-        Else
-            Return Nothing
-        End If
-    End Function
-End Class", @"class TestClass
-{
-    public int? Bar(string value)
-    {
-        int result;
-        if (int.TryParse(value, out result))
-            return result;
-        else
-            return default(int?);
-    }
-}");
-        }
-
-        [Fact]
         public void UsesSquareBracketsForIndexerButParenthesesForMethodInvocation()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
@@ -1251,6 +1225,29 @@ End Function",
                 @"public bool GetString(bool yourBoolean)
 {
     return 1 != 1 || yourBoolean ? true : false;
+}");
+        }
+
+        [Fact]
+        public void StringInterpolationWithDoubleQuotes()
+        {
+            TestConversionVisualBasicToCSharp(
+@"Namespace [Global].InnerNamespace
+    Public Class Test
+        Public Function StringInter(t As String) As String
+            Return $""{t} """" t""
+        End Function
+    End Class
+End Namespace",
+@"namespace Global.InnerNamespace
+{
+    public class Test
+    {
+        public string StringInter(string t)
+        {
+            return $""{t} \"" t"";
+        }
+    }
 }");
         }
     }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -315,6 +315,32 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void NullableInteger()
+        {
+            //BUG: Line comments after "else" aren't converted
+            TestConversionVisualBasicToCSharpWithoutComments(@"Class TestClass
+    Public Function Bar(value As String) As Integer?
+        Dim result As Integer
+        If Integer.TryParse(value, result) Then
+            Return result
+        Else
+            Return Nothing
+        End If
+    End Function
+End Class", @"class TestClass
+{
+    public int? Bar(string value)
+    {
+        int result;
+        if (int.TryParse(value, out result))
+            return result;
+        else
+            return default(int?);
+    }
+}");
+        }
+
+        [Fact]
         public void UsesSquareBracketsForIndexerButParenthesesForMethodInvocation()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass


### PR DESCRIPTION
[https://github.com/icsharpcode/CodeConverter/issues/192](https://github.com/icsharpcode/CodeConverter/issues/192)

### Problem
String interpolation with a double quote fails to convert properly

### Solution
* Variables were a tad inconsistent on their names vs what they represent.  Made a minor rename to make it more clear.
* How to properly clean the string for a VB -> C# conversion.  I isolated the logic around replace the double quotes and reused that functionality in case there are more edge cases to take care of there.

* [x] At least one test covering the code changed
* [x] All tests pass

