### PR TITLE
Fixes #197

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -263,17 +263,21 @@ namespace ICSharpCode.CodeConverter.CSharp
         public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false)
         {
             string text = id.ValueText;
+
             var keywordKind = SyntaxFacts.GetKeywordKind(text);
             if (keywordKind != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None)
                 return SyntaxFactory.Identifier("@" + text);
+
             if (id.SyntaxTree == _semanticModel.SyntaxTree) {
                 var symbol = _semanticModel.GetSymbolInfo(id.Parent).Symbol;
-                if (symbol != null && !String.IsNullOrWhiteSpace(symbol.Name)) {
+                if (symbol != null && !string.IsNullOrWhiteSpace(symbol.Name)) {
                     if (symbol.IsConstructor() && isAttribute) {
                         text = symbol.ContainingType.Name;
                         if (text.EndsWith("Attribute", StringComparison.Ordinal))
                             text = text.Remove(text.Length - "Attribute".Length);
-                    } else if (symbol.IsKind(SymbolKind.Parameter) && symbol.Name == "Value") {
+                    } else if (symbol.IsKind(SymbolKind.Parameter) && symbol.ContainingSymbol.IsAccessorPropertySet() && ((symbol.IsImplicitlyDeclared && symbol.Name == "Value") || symbol.ContainingSymbol.GetParameters().FirstOrDefault(x => !x.IsImplicitlyDeclared) == symbol)) {
+                        // The case above is basically that if the symbol is a parameter, and the corresponding definition is a property set definition 
+                        // AND the first explicitly declared parameter is this symbol, we need to replace it with value.
                         text = "value";
                     } else if (text.StartsWith("_", StringComparison.Ordinal) && symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Property) == true) {
                         text = fieldSymbol.AssociatedSymbol.Name;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -434,6 +434,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 bool hasBody = node.Parent is VBSyntax.PropertyBlockSyntax;
                 var attributes = node.AttributeLists.SelectMany(ConvertAttribute);
                 var isReadonly = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.ReadOnlyKeyword));
+                var isWriteOnly = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WriteOnlyKeyword));
                 var convertibleModifiers = node.Modifiers.Where(m => !m.IsKind(VBasic.SyntaxKind.ReadOnlyKeyword, VBasic.SyntaxKind.WriteOnlyKeyword, VBasic.SyntaxKind.DefaultKeyword));
                 var modifiers = CommonConversions.ConvertModifiers(convertibleModifiers, GetMemberContext(node));
                 var isIndexer = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.DefaultKeyword));
@@ -450,9 +451,11 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 AccessorListSyntax accessors = null;
                 if (!hasBody) {
-                    var accessorList = new List<AccessorDeclarationSyntax> {
-                        SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SemicolonToken)
-                    };
+                    var accessorList = new List<AccessorDeclarationSyntax>();
+
+                    if (!isWriteOnly) {
+                        accessorList.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration).WithSemicolonToken(SemicolonToken));
+                    }
                     if (!isReadonly) {
                         accessorList.Add(SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration).WithSemicolonToken(SemicolonToken));
                     }

--- a/ICSharpCode.CodeConverter/Util/SymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SymbolExtensions.cs
@@ -208,6 +208,12 @@ namespace ICSharpCode.CodeConverter.Util
                     accessorSymbol.MethodKind == MethodKind.EventRemove || accessorSymbol.MethodKind == MethodKind.EventAdd);
         }
 
+        public static bool IsAccessorPropertySet(this ISymbol symbol)
+        {
+            var accessorSymbol = symbol as IMethodSymbol;
+            return accessorSymbol != null && accessorSymbol.MethodKind == MethodKind.PropertySet;
+        }
+
         public static bool IsPublic(this ISymbol symbol)
         {
             return symbol.DeclaredAccessibility == Accessibility.Public;

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -1240,5 +1240,36 @@ End Interface", @"interface TestInterface
     int[] Items { set; }
 }");
         }
+
+        [Fact]
+        public void TestSetWithNamedParameterProperties()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Class TestClass
+    Private _Items As Integer()
+    Property Items As Integer()
+        Get
+            Return _Items
+        End Get
+        Set(v As Integer())
+            _Items = v
+        End Set
+    End Property
+End Class", @"class TestClass
+{
+    private int[] _Items;
+    public int[] Items
+    {
+        get
+        {
+            return _Items;
+        }
+        set
+        {
+            _Items = value;
+        }
+    }
+}");
+        }
     }
 }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -1228,5 +1228,17 @@ End Class", @"class TestClass
     }
 }");
         }
+
+        [Fact]
+        public void TestWriteOnlyProperties()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Interface TestInterface
+    WriteOnly Property Items As Integer()
+End Interface", @"interface TestInterface
+{
+    int[] Items { set; }
+}");
+        }
     }
 }


### PR DESCRIPTION
[Fixes #197 ](https://github.com/icsharpcode/CodeConverter/issues/197)

### Problem
WriteOnly properties on interfaces are converted incorrectly.

### Solution
* Just made a minor modification to the property syntax converter to watch for the WriteOnly keyword.

* [X] At least one test covering the code changed
* [X] All tests pass

