### PR TITLE
Fix byref parameter

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -685,15 +685,15 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var invocationExpression = expression as InvocationExpressionSyntax;
                 if (invocationExpression != null) {
-                    InvocationExpressionSyntax ies;
-                    var list = AddRefVariables(invocationExpression, out ies);
-                    list.Add(SyntaxFactory.ExpressionStatement(ies));
-                    return SyntaxFactory.List(list);
+                    InvocationExpressionSyntax newInvocationExpression;
+                    var statements = GetNewStatements(invocationExpression, out newInvocationExpression);
+                    statements.Add(SyntaxFactory.ExpressionStatement(newInvocationExpression));
+                    return SyntaxFactory.List(statements);
                 }
                 return SyntaxFactory.SingletonList<StatementSyntax>(SyntaxFactory.ExpressionStatement(expression));
             }
 
-            private static List<StatementSyntax> AddRefVariables(InvocationExpressionSyntax initialInvocationExpression, out InvocationExpressionSyntax newInvocationExpression)
+            private static List<StatementSyntax> GetNewStatements(InvocationExpressionSyntax initialInvocationExpression, out InvocationExpressionSyntax newInvocationExpression)
             {
                 var newDeclarations = new List<StatementSyntax>();
                 var newArguments = new List<ArgumentSyntax>();

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -681,10 +681,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             SyntaxList<StatementSyntax> MultipleStatements(ExpressionSyntax expression)
             {
-                var invocationExpression = expression as InvocationExpressionSyntax;
-                if (invocationExpression != null) {
-                    InvocationExpressionSyntax newInvocationExpression;
-                    var statements = GetNewStatements(invocationExpression, out newInvocationExpression);
+                if (expression is InvocationExpressionSyntax invocationExpression) {
+                    var statements = GetNewStatements(invocationExpression, out var newInvocationExpression);
                     statements.Add(SyntaxFactory.ExpressionStatement(newInvocationExpression));
                     return SyntaxFactory.List(statements);
                 }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -23,8 +23,6 @@ namespace ICSharpCode.CodeConverter.CSharp
         /// </summary>
         class MethodBodyVisitor : VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>>
         {
-            private static readonly SyntaxToken _refKeywordToken = SyntaxFactory.Token(SyntaxKind.RefKeyword);
-
             private readonly VBasic.VisualBasicSyntaxNode _methodNode;
             private readonly SemanticModel _semanticModel;
             private readonly VBasic.VisualBasicSyntaxVisitor<CSharpSyntaxNode> _nodesVisitor;
@@ -725,7 +723,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             }
 
             private static bool IsByRefParameterWithLiteralValue(ArgumentSyntax argumentSyntax) 
-                => argumentSyntax.RefOrOutKeyword.IsEquivalentTo(_refKeywordToken) && !argumentSyntax.Expression.IsKind(SyntaxKind.IdentifierName);
+                => argumentSyntax.RefOrOutKeyword.IsKind(SyntaxKind.RefKeyword) && !argumentSyntax.Expression.IsKind(SyntaxKind.IdentifierName);
         }
     }
 

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -107,6 +107,34 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void TestMethodWithByRefArguments()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Class TestClass
+    Public Sub DoSomething(ByRef str As String, ByRef val As Boolean, ByRef dble As Double, str2 As String)
+    End Sub
+
+    Public Sub DoSomethingElse()
+        Dim dble As Double = 2
+        DoSomething(""sometext"", True, dble, ""sometext2"")
+    End Sub
+End Class", @"class TestClass
+{
+    public void DoSomething(ref string str, ref bool val, ref double dble, string str2)
+    {
+    }
+
+    public void DoSomethingElse()
+    {
+        double dble = 2;
+        var val0 = ""sometext"";
+        var val1 = true;
+        DoSomething(ref val0, ref val1, ref dble, ""sometext2"");
+    }
+}");
+    }
+
+        [Fact]
         public void TestMethodWithReturnType()
         {
             TestConversionVisualBasicToCSharp(
@@ -713,7 +741,7 @@ Friend Class TestClass2
 
     Public Overrides Sub CreateVirtualInstance()
     End Sub
-End Class", 
+End Class",
 @"internal abstract partial class TestClass1
 {
     public static void CreateStatic()


### PR DESCRIPTION
Fixes #264

### Problem
There is an issue with ByRef parameter that accept literal values when the method is invoked.

`DoSomething(ref "sometext")` is not supported in C# but it does not complain in VB (at least in my project.)

### Solution
For every literal values, I declared a local variable and used it instead.

Hope it helps,

Fabien

PS: I am not familiar with the framework to do code analyses so bear with me while I learn :)

