### PR TITLE
Raise event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 All notable changes to the code converter will be documented here.
 
-# 6.5.0 TBC
+# 6.6.0 TBC
+
+### C# -> VB
+* Improve event identifier conversion
+
+# 6.5.0 03/03/2019
 * Avoid fatal error converting a project in a solution containing a website project (#243)
 * Improve best-effort conversion in the presence of errors
 * Improved nuget package and web converter's snippet detection

--- a/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
@@ -19,7 +19,6 @@ namespace ICSharpCode.CodeConverter.Shared
     {
         private readonly Compilation _sourceCompilation;
         private readonly IEnumerable<SyntaxTree> _syntaxTreesToConvert;
-        // ReSharper disable once StaticMemberInGenericType - Stateless
         private static readonly AdhocWorkspace AdhocWorkspace = new AdhocWorkspace();
         private readonly ConcurrentDictionary<string, string> _errors = new ConcurrentDictionary<string, string>();
         private readonly Dictionary<string, SyntaxTree> _firstPassResults = new Dictionary<string, SyntaxTree>();

--- a/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
@@ -19,7 +19,6 @@ namespace ICSharpCode.CodeConverter.Shared
     {
         private readonly Compilation _sourceCompilation;
         private readonly IEnumerable<SyntaxTree> _syntaxTreesToConvert;
-        private static readonly AdhocWorkspace AdhocWorkspace = new AdhocWorkspace();
         private readonly ConcurrentDictionary<string, string> _errors = new ConcurrentDictionary<string, string>();
         private readonly Dictionary<string, SyntaxTree> _firstPassResults = new Dictionary<string, SyntaxTree>();
         private readonly ILanguageConversion _languageConversion;
@@ -146,12 +145,13 @@ namespace ICSharpCode.CodeConverter.Shared
         private Dictionary<string, SyntaxNode> SecondPass()
         {
             var secondPassByFilePath = new Dictionary<string, SyntaxNode>();
+            var adhocWorkspace = new AdhocWorkspace();
             foreach (var firstPassResult in _firstPassResults) {
                 var treeFilePath = firstPassResult.Key;
                 try {
-                    secondPassByFilePath.Add(treeFilePath, SingleSecondPass(firstPassResult));
+                    secondPassByFilePath.Add(treeFilePath, SingleSecondPass(firstPassResult, adhocWorkspace));
                 }  catch (Exception e) {
-                    secondPassByFilePath.Add(treeFilePath, Format(firstPassResult.Value.GetRoot()));
+                    secondPassByFilePath.Add(treeFilePath, Format(firstPassResult.Value.GetRoot(), adhocWorkspace));
                     _errors.TryAdd(treeFilePath, e.ToString());
                 }
             }
@@ -168,10 +168,10 @@ namespace ICSharpCode.CodeConverter.Shared
             }
         }
 
-        private SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs)
+        private SyntaxNode SingleSecondPass(KeyValuePair<string, SyntaxTree> cs, AdhocWorkspace workspace)
         {
             var secondPassNode = _languageConversion.SingleSecondPass(cs);
-            return Format(secondPassNode);
+            return Format(secondPassNode, workspace);
         }
 
         private void FirstPass()
@@ -236,10 +236,11 @@ namespace ICSharpCode.CodeConverter.Shared
             return root.WithAnnotatedNode(selectedNode, AnnotationConstants.SelectedNodeAnnotationKind);
         }
 
-        private SyntaxNode Format(SyntaxNode resultNode)
+        private SyntaxNode Format(SyntaxNode resultNode, Workspace workspace)
         {
             SyntaxNode selectedNode = _handlePartialConversion ? GetSelectedNode(resultNode) : resultNode;
-            return Formatter.Format(selectedNode ?? resultNode, AdhocWorkspace);
+            SyntaxNode nodeToFormat = selectedNode ?? resultNode;
+            return Formatter.Format(nodeToFormat, workspace);
         }
 
         private SyntaxNode GetSelectedNode(SyntaxNode resultNode)

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -406,7 +406,7 @@ namespace ICSharpCode.CodeConverter.VB
         public SyntaxToken ConvertIdentifier(SyntaxToken id)
         {
             CSharpSyntaxNode parent = (CSharpSyntaxNode) id.Parent;
-            var idText = IsEventHandlerIdentifier(parent) ? id.ValueText + "Event" : id.ValueText;
+            var idText = IsEventHandlerIdentifier(parent) && !IsEventHandlerAssignLhs(parent) ? id.ValueText + "Event" : id.ValueText;
             // Underscore is a special character in VB lexer which continues lines - not sure where to find the whole set of other similar tokens if any
             // Rather than a complicated contextual rename, just add an extra dash to all identifiers and hope this method is consistently used
             bool keywordRequiresEscaping = KeywordRequiresEscaping(id);
@@ -541,14 +541,14 @@ namespace ICSharpCode.CodeConverter.VB
 
         public bool IsEventHandlerIdentifier(CSharpSyntaxNode syntax)
         {
-            return GetSymbol(syntax).IsKind(SymbolKind.Event) && !IsEventHandlerAssignLhs(syntax);
+            return GetSymbol(syntax).IsKind(SymbolKind.Event);
         }
 
         private static bool IsEventHandlerAssignLhs(CSharpSyntaxNode syntax)
         {
             var assignmentExpressionSyntax = syntax.GetAncestor<AssignmentExpressionSyntax>();
             return assignmentExpressionSyntax != null && assignmentExpressionSyntax.IsKind(CSSyntaxKind.AddAssignmentExpression, CSSyntaxKind.SubtractAssignmentExpression)
-                       && assignmentExpressionSyntax.Left.DescendantNodes().Contains(syntax) == true;
+                       && assignmentExpressionSyntax.Left.DescendantNodes().Contains(syntax);
         }
 
         private ISymbol GetSymbol(CSharpSyntaxNode syntax)

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -403,7 +403,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public SyntaxToken ConvertIdentifier(SyntaxToken id)
         {
-            var idText = id.ValueText;
+            var idText = IsEventHandlerType((CSharpSyntaxNode) id.Parent) ? id.ValueText + "Event" : id.ValueText;
             // Underscore is a special character in VB lexer which continues lines - not sure where to find the whole set of other similar tokens if any
             // Rather than a complicated contextual rename, just add an extra dash to all identifiers and hope this method is consistently used
             if (idText.All(c => c == '_')) idText += "_";

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -207,7 +207,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public LambdaExpressionSyntax ConvertLambdaExpression(AnonymousFunctionExpressionSyntax node, CSharpSyntaxNode body, IEnumerable<ParameterSyntax> parameters, SyntaxTokenList modifiers)
         {
-            var symbol = ModelExtensions.GetSymbolInfo(_semanticModel, node).Symbol as IMethodSymbol;
+            var symbol = (IMethodSymbol) ModelExtensions.GetSymbolInfo(_semanticModel, node).Symbol;
             var parameterList = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(parameters.Select(p => (Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterSyntax)p.Accept(_nodesVisitor))));
             LambdaHeaderSyntax header;
             EndBlockStatementSyntax endBlock;
@@ -234,7 +234,8 @@ namespace ICSharpCode.CodeConverter.VB
                 var vbThrowExpression = (ExpressionSyntax)csThrowExpression.Expression.Accept(_nodesVisitor);
                 var vbThrowStatement = SyntaxFactory.ThrowStatement(SyntaxFactory.Token(SyntaxKind.ThrowKeyword), vbThrowExpression);
 
-                return SyntaxFactory.MultiLineFunctionLambdaExpression(header, SyntaxFactory.SingletonList<StatementSyntax>(vbThrowStatement), endBlock);
+                return SyntaxFactory.MultiLineFunctionLambdaExpression(header,
+                    SyntaxFactory.SingletonList<StatementSyntax>(vbThrowStatement), endBlock);
             } else {
                 statements = InsertRequiredDeclarations(
                     SyntaxFactory.SingletonList<StatementSyntax>(

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -396,12 +396,12 @@ namespace ICSharpCode.CodeConverter.VB
             return topLevelExpression.Accept(_nodesVisitor);
         }
 
-        private static ModifiedIdentifierSyntax ExtractIdentifier(Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax v)
+        private ModifiedIdentifierSyntax ExtractIdentifier(Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax v)
         {
             return SyntaxFactory.ModifiedIdentifier(ConvertIdentifier(v.Identifier));
         }
 
-        public static SyntaxToken ConvertIdentifier(SyntaxToken id)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id)
         {
             var idText = id.ValueText;
             // Underscore is a special character in VB lexer which continues lines - not sure where to find the whole set of other similar tokens if any
@@ -529,6 +529,11 @@ namespace ICSharpCode.CodeConverter.VB
         private static string UppercaseFirstLetter(string sourceText)
         {
             return sourceText.Substring(0, 1).ToUpper() + sourceText.Substring(1);
+        }
+
+        public bool IsEventHandlerType(CSharpSyntaxNode syntax)
+        {
+            return _semanticModel.GetTypeInfo(syntax).Type?.GetFullMetadataName()?.StartsWith("System.EventHandler") == true;
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -292,7 +292,7 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitDelegateDeclaration(CSS.DelegateDeclarationSyntax node)
         {
             var id = _commonConversions.ConvertIdentifier(node.Identifier);
-            var methodInfo = ModelExtensions.GetDeclaredSymbol(_semanticModel, node) as INamedTypeSymbol;
+            var methodInfo = (INamedTypeSymbol) _semanticModel.GetDeclaredSymbol(node);
             if (methodInfo.DelegateInvokeMethod.GetReturnType()?.SpecialType == SpecialType.System_Void) {
                 return SyntaxFactory.DelegateSubStatement(
                     SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers),

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -1520,15 +1520,11 @@ namespace ICSharpCode.CodeConverter.VB
                 var argIndex = ies.ArgumentList.Arguments.IndexOf(nameArgument);
                 //TODO: Deal with named parameters
                 var symbolInfo = _semanticModel.GetSymbolInfo(ies.Expression);
-                // We ignore symbolInfo.Symbol, since if there's an exact match it isn't overloaded
-                var destinationType = symbolInfo.CandidateSymbols
-                    .Select(m => m.GetParameters()).Where(p => p.Length > argIndex).Select(p => p[argIndex].Type)
-                    .FirstOrDefault();
-
+                var destinationType = symbolInfo.ExtractBestMatch(m => m.GetParameters().Length > argIndex);
                 if (destinationType != null) {
                     var toCreate = (TypeSyntax)
                         CS.SyntaxFactory
-                            .ParseTypeName(destinationType.ToMinimalDisplayString(_semanticModel,
+                            .ParseTypeName(destinationType.GetParameters()[argIndex].Type.ToMinimalDisplayString(_semanticModel,
                                 argumentChildExpression.SpanStart))
                             .Accept(TriviaConvertingVisitor);
                     return toCreate;

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -179,7 +179,7 @@ namespace ICSharpCode.CodeConverter.VB
             ImportAliasClauseSyntax alias = null;
             if (node.Alias != null) {
                 var name = node.Alias.Name;
-                var id = CommonConversions.ConvertIdentifier(name.Identifier);
+                var id = _commonConversions.ConvertIdentifier(name.Identifier);
                 alias = SyntaxFactory.ImportAliasClause(id);
             }
             ImportsClauseSyntax clause = SyntaxFactory.SimpleImportsClause(alias, (NameSyntax)node.Name.Accept(TriviaConvertingVisitor));
@@ -193,7 +193,7 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitClassDeclaration(CSS.ClassDeclarationSyntax node)
         {
             var members = ConvertMembers(node).ToList();
-            var id = CommonConversions.ConvertIdentifier(node.Identifier);
+            var id = _commonConversions.ConvertIdentifier(node.Identifier);
 
             List<InheritsStatementSyntax> inherits = new List<InheritsStatementSyntax>();
             List<ImplementsStatementSyntax> implements = new List<ImplementsStatementSyntax>();
@@ -238,7 +238,7 @@ namespace ICSharpCode.CodeConverter.VB
 
             return SyntaxFactory.StructureBlock(
                 SyntaxFactory.StructureStatement(
-                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers), CommonConversions.ConvertIdentifier(node.Identifier),
+                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers), _commonConversions.ConvertIdentifier(node.Identifier),
                     (TypeParameterListSyntax)node.TypeParameterList?.Accept(TriviaConvertingVisitor)
                 ),
                 SyntaxFactory.List(inherits),
@@ -257,7 +257,7 @@ namespace ICSharpCode.CodeConverter.VB
 
             return SyntaxFactory.InterfaceBlock(
                 SyntaxFactory.InterfaceStatement(
-                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers, TokenContext.InterfaceOrModule), CommonConversions.ConvertIdentifier(node.Identifier),
+                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers, TokenContext.InterfaceOrModule), _commonConversions.ConvertIdentifier(node.Identifier),
                     (TypeParameterListSyntax)node.TypeParameterList?.Accept(TriviaConvertingVisitor)
                 ),
                 SyntaxFactory.List(inherits),
@@ -273,7 +273,7 @@ namespace ICSharpCode.CodeConverter.VB
                 .Types.OfType<CSS.SimpleBaseTypeSyntax>().Single().Type.Accept(TriviaConvertingVisitor);
             return SyntaxFactory.EnumBlock(
                 SyntaxFactory.EnumStatement(
-                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers), CommonConversions.ConvertIdentifier(node.Identifier),
+                    SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertModifiers(node.Modifiers), _commonConversions.ConvertIdentifier(node.Identifier),
                     baseType == null ? null : SyntaxFactory.SimpleAsClause(baseType)
                 ),
                 SyntaxFactory.List(members)
@@ -284,14 +284,14 @@ namespace ICSharpCode.CodeConverter.VB
         {
             var initializer = (ExpressionSyntax)node.EqualsValue?.Value.Accept(TriviaConvertingVisitor);
             return SyntaxFactory.EnumMemberDeclaration(
-                SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), CommonConversions.ConvertIdentifier(node.Identifier),
+                SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor))), _commonConversions.ConvertIdentifier(node.Identifier),
                 initializer == null ? null : SyntaxFactory.EqualsValue(initializer)
             );
         }
 
         public override VisualBasicSyntaxNode VisitDelegateDeclaration(CSS.DelegateDeclarationSyntax node)
         {
-            var id = CommonConversions.ConvertIdentifier(node.Identifier);
+            var id = _commonConversions.ConvertIdentifier(node.Identifier);
             var methodInfo = ModelExtensions.GetDeclaredSymbol(_semanticModel, node) as INamedTypeSymbol;
             if (methodInfo.DelegateInvokeMethod.GetReturnType()?.SpecialType == SpecialType.System_Void) {
                 return SyntaxFactory.DelegateSubStatement(
@@ -360,7 +360,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitSingleVariableDesignation(CSS.SingleVariableDesignationSyntax node)
         {
-            return SyntaxFactory.IdentifierName(CommonConversions.ConvertIdentifier(node.Identifier));
+            return SyntaxFactory.IdentifierName(_commonConversions.ConvertIdentifier(node.Identifier));
         }
 
         public override VisualBasicSyntaxNode VisitDiscardDesignation(CSS.DiscardDesignationSyntax node)
@@ -411,7 +411,7 @@ namespace ICSharpCode.CodeConverter.VB
             if (node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, CS.SyntaxKind.ExternKeyword))) {
                 block = SyntaxFactory.List<StatementSyntax>();
             }
-            var id = CommonConversions.ConvertIdentifier(node.Identifier);
+            var id = _commonConversions.ConvertIdentifier(node.Identifier);
             var methodInfo = ModelExtensions.GetDeclaredSymbol(_semanticModel, node);
             var containingType = methodInfo?.ContainingType;
             var attributes = SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor)));
@@ -472,7 +472,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitPropertyDeclaration(CSS.PropertyDeclarationSyntax node)
         {
-            var id = CommonConversions.ConvertIdentifier(node.Identifier);
+            var id = _commonConversions.ConvertIdentifier(node.Identifier);
             var modifiers = CommonConversions.ConvertModifiers(node.Modifiers, GetMemberContext(node));
             var initializer = node.Initializer == null ? null
                 : SyntaxFactory.EqualsValue((ExpressionSyntax)_commonConversions.ConvertTopLevelExpression(node.Initializer.Value));
@@ -568,7 +568,7 @@ namespace ICSharpCode.CodeConverter.VB
         {
             ConvertAndSplitAttributes(node.AttributeLists, out SyntaxList<AttributeListSyntax> attributes, out SyntaxList<AttributeListSyntax> returnAttributes);
             var stmt = SyntaxFactory.EventStatement(
-                attributes, CommonConversions.ConvertModifiers(node.Modifiers, GetMemberContext(node)), CommonConversions.ConvertIdentifier(node.Identifier), null,
+                attributes, CommonConversions.ConvertModifiers(node.Modifiers, GetMemberContext(node)), _commonConversions.ConvertIdentifier(node.Identifier), null,
                 SyntaxFactory.SimpleAsClause(returnAttributes, (TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)),
                 CreateImplementsClauseSyntaxOrNull(_semanticModel.GetDeclaredSymbol(node))
             );
@@ -704,7 +704,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitParameter(CSS.ParameterSyntax node)
         {
-            var id = CommonConversions.ConvertIdentifier(node.Identifier);
+            var id = _commonConversions.ConvertIdentifier(node.Identifier);
             var returnType = (TypeSyntax)node.Type?.Accept(TriviaConvertingVisitor);
             EqualsValueSyntax @default = null;
             if (node.Default != null) {
@@ -1241,7 +1241,7 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitFromClause(CSS.FromClauseSyntax node)
         {
             return SyntaxFactory.FromClause(
-                SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(CommonConversions.ConvertIdentifier(node.Identifier)),
+                SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(_commonConversions.ConvertIdentifier(node.Identifier)),
                 (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor))
             );
         }
@@ -1267,7 +1267,7 @@ namespace ICSharpCode.CodeConverter.VB
             } else {
                 var group = (CSS.GroupClauseSyntax)body.SelectOrGroup;
                 var newGroupKeyName = GeneratePlaceholder("groupByKey");
-                var csGroupId = CommonConversions.ConvertIdentifier(body.Continuation.Identifier);
+                var csGroupId = _commonConversions.ConvertIdentifier(body.Continuation.Identifier);
                 var groupIdEquals = SyntaxFactory.VariableNameEquals(SyntaxFactory.ModifiedIdentifier(csGroupId));
                 var aggregationRangeVariableSyntax = SyntaxFactory.AggregationRangeVariable(groupIdEquals, SyntaxFactory.GroupAggregation());
                 yield return SyntaxFactory.GroupByClause(
@@ -1296,7 +1296,7 @@ namespace ICSharpCode.CodeConverter.VB
             return SyntaxFactory.LetClause(
                 SyntaxFactory.SingletonSeparatedList(
                     SyntaxFactory.ExpressionRangeVariable(
-                        SyntaxFactory.VariableNameEquals(SyntaxFactory.ModifiedIdentifier(CommonConversions.ConvertIdentifier(node.Identifier))),
+                        SyntaxFactory.VariableNameEquals(SyntaxFactory.ModifiedIdentifier(_commonConversions.ConvertIdentifier(node.Identifier))),
                         (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor)
                     )
                 )
@@ -1307,13 +1307,13 @@ namespace ICSharpCode.CodeConverter.VB
         {
             if (node.Into != null) {
                 return SyntaxFactory.GroupJoinClause(
-                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(CommonConversions.ConvertIdentifier(node.Identifier)), node.Type == null ? null : SyntaxFactory.SimpleAsClause((TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)), (ExpressionSyntax)node.InExpression.Accept(TriviaConvertingVisitor))),
+                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(_commonConversions.ConvertIdentifier(node.Identifier)), node.Type == null ? null : SyntaxFactory.SimpleAsClause((TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)), (ExpressionSyntax)node.InExpression.Accept(TriviaConvertingVisitor))),
                     SyntaxFactory.SingletonSeparatedList(SyntaxFactory.JoinCondition((ExpressionSyntax)node.LeftExpression.Accept(TriviaConvertingVisitor), (ExpressionSyntax)node.RightExpression.Accept(TriviaConvertingVisitor))),
-                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.AggregationRangeVariable(SyntaxFactory.VariableNameEquals(SyntaxFactory.ModifiedIdentifier(CommonConversions.ConvertIdentifier(node.Into.Identifier))), SyntaxFactory.GroupAggregation()))
+                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.AggregationRangeVariable(SyntaxFactory.VariableNameEquals(SyntaxFactory.ModifiedIdentifier(_commonConversions.ConvertIdentifier(node.Into.Identifier))), SyntaxFactory.GroupAggregation()))
                 );
             } else {
                 return SyntaxFactory.SimpleJoinClause(
-                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(CommonConversions.ConvertIdentifier(node.Identifier)), node.Type == null ? null : SyntaxFactory.SimpleAsClause((TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)), (ExpressionSyntax)node.InExpression.Accept(TriviaConvertingVisitor))),
+                    SyntaxFactory.SingletonSeparatedList(SyntaxFactory.CollectionRangeVariable(SyntaxFactory.ModifiedIdentifier(_commonConversions.ConvertIdentifier(node.Identifier)), node.Type == null ? null : SyntaxFactory.SimpleAsClause((TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)), (ExpressionSyntax)node.InExpression.Accept(TriviaConvertingVisitor))),
                     SyntaxFactory.SingletonSeparatedList(SyntaxFactory.JoinCondition((ExpressionSyntax)node.LeftExpression.Accept(TriviaConvertingVisitor), (ExpressionSyntax)node.RightExpression.Accept(TriviaConvertingVisitor)))
                 );
             }
@@ -1398,7 +1398,7 @@ namespace ICSharpCode.CodeConverter.VB
             }
             // copy generic constraints
             var clause = FindClauseForParameter(node);
-            return SyntaxFactory.TypeParameter(variance, CommonConversions.ConvertIdentifier(node.Identifier), (TypeParameterConstraintClauseSyntax)clause?.Accept(TriviaConvertingVisitor));
+            return SyntaxFactory.TypeParameter(variance, _commonConversions.ConvertIdentifier(node.Identifier), (TypeParameterConstraintClauseSyntax)clause?.Accept(TriviaConvertingVisitor));
         }
 
         public override VisualBasicSyntaxNode VisitTypeParameterConstraintClause(CSS.TypeParameterConstraintClauseSyntax node)
@@ -1461,12 +1461,12 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitIdentifierName(CSS.IdentifierNameSyntax node)
         {
-            return WrapTypedNameIfNecessary(SyntaxFactory.IdentifierName(CommonConversions.ConvertIdentifier(node.Identifier)), node);
+            return WrapTypedNameIfNecessary(SyntaxFactory.IdentifierName(_commonConversions.ConvertIdentifier(node.Identifier)), node);
         }
 
         public override VisualBasicSyntaxNode VisitGenericName(CSS.GenericNameSyntax node)
         {
-            return WrapTypedNameIfNecessary(SyntaxFactory.GenericName(CommonConversions.ConvertIdentifier(node.Identifier), (TypeArgumentListSyntax)node.TypeArgumentList.Accept(TriviaConvertingVisitor)), node);
+            return WrapTypedNameIfNecessary(SyntaxFactory.GenericName(_commonConversions.ConvertIdentifier(node.Identifier), (TypeArgumentListSyntax)node.TypeArgumentList.Accept(TriviaConvertingVisitor)), node);
         }
 
         public override VisualBasicSyntaxNode VisitQualifiedName(CSS.QualifiedNameSyntax node)

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -1522,11 +1522,10 @@ namespace ICSharpCode.CodeConverter.VB
                 var symbolInfo = _semanticModel.GetSymbolInfo(ies.Expression);
                 var destinationType = symbolInfo.ExtractBestMatch(m => m.GetParameters().Length > argIndex);
                 if (destinationType != null) {
-                    var toCreate = (TypeSyntax)
-                        CS.SyntaxFactory
-                            .ParseTypeName(destinationType.GetParameters()[argIndex].Type.ToMinimalDisplayString(_semanticModel,
-                                argumentChildExpression.SpanStart))
-                            .Accept(TriviaConvertingVisitor);
+                    string symbolName = destinationType.GetParameters()[argIndex].Type
+                        .ToMinimalDisplayString(_semanticModel, argumentChildExpression.SpanStart);
+                    var csType = CS.SyntaxFactory.ParseTypeName(symbolName);
+                    var toCreate = (TypeSyntax) csType.Accept(TriviaConvertingVisitor);
                     return toCreate;
                 }
             }

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -28,7 +28,7 @@ namespace CodeConverter.Tests.TestRunners
             return convertedCode;
         }
 
-        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool expectSurroundingMethodBlock = false)
+        public void TestConversionCSharpToVisualBasic(string csharpCode, string expectedVisualBasicCode, bool expectSurroundingMethodBlock = false, bool expectCompilationErrors = false)
         {
             expectedVisualBasicCode = AddSurroundingMethodBlock(expectedVisualBasicCode, expectSurroundingMethodBlock);
 

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -218,7 +218,9 @@ End Class");
         [Fact]
         public void AddressOfWhereVbTypeInferenceIsWeaker()
         {
-            TestConversionCSharpToVisualBasic(@"static class TestClass
+            TestConversionCSharpToVisualBasic(@"using System;
+
+static class TestClass
 {
     private static object TypeSwitch(this object obj, Func<string, object> matchFunc1, Func<int, object> matchFunc2, Func<object, object> defaultFunc)
     {
@@ -239,7 +241,8 @@ End Class");
     {
         return node.TypeSwitch(ConvertString, ConvertInt, _ => throw new NotImplementedException($""Conversion for '{node.GetType()}' not implemented""));
     }
-}", @"Imports System.Runtime.CompilerServices
+}", @"Imports System
+Imports System.Runtime.CompilerServices
 
 Friend Module TestClass
     <Extension()>

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -53,6 +53,37 @@ End Class");
         }
 
         [Fact]
+        public void RaiseEventOneLiners()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
+{
+    event EventHandler MyEvent;
+
+    void TestMethod()
+    {
+        MyEvent(this, EventArgs.Empty);
+        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
+        MyEvent.Invoke(this, EventArgs.Empty);
+        MyEvent?.Invoke(this, EventArgs.Empty);
+    }
+}", @"Imports System
+
+Friend Class TestClass
+    Private Event MyEvent As EventHandler
+
+    Private Sub TestMethod()
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+    End Sub
+End Class");
+        }
+
+        [Fact]
         public void RaiseEventInElse()
         {
             TestConversionCSharpToVisualBasic(
@@ -83,52 +114,6 @@ Public Class Foo
     End Sub
 End Class
 ");
-        }
-
-        [Fact]
-        public void RaiseEventMinimal()
-        {
-            TestConversionCSharpToVisualBasic(
-                @"using System;
-
-class TestClass
-{
-    event EventHandler MyEvent;
-
-    void TestMethod()
-    {
-        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
-    }
-}", @"Imports System
-
-Friend Class TestClass
-    Private Event MyEvent As EventHandler
-
-    Private Sub TestMethod()
-        RaiseEvent MyEvent(Me, EventArgs.Empty)
-    End Sub
-End Class");
-        }
-
-        [Fact]
-        public void CharacterizeRaiseEventWithMissingDefinitionActsLikeFunc()
-        {
-            TestConversionCSharpToVisualBasic(
-                @"using System;
-
-class TestClass
-{
-    void TestMethod()
-    {
-        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
-    }
-}", @"Imports System
-
-Friend Class TestClass
-    Private Sub TestMethod()
-        If MyEvent IsNot Nothing Then MyEvent(Me, EventArgs.Empty)
-    End Sub
-End Class");
         }
 
         [Fact]
@@ -168,7 +153,7 @@ class TestClass
 
     void TestMethod()
     {
-        if (this.MyEvent != null) MyEvent(this, EventArgs.Empty);
+        if (this.MyEvent != null) this.MyEvent(this, EventArgs.Empty);
     }
 }", @"Imports System
 
@@ -193,7 +178,7 @@ class TestClass
 
     void TestMethod()
     {
-        if ((MyEvent != null)) this.MyEvent(this, EventArgs.Empty);
+        if ((MyEvent != null)) this.MyEvent.Invoke(this, EventArgs.Empty);
     }
 }", @"Imports System
 
@@ -227,6 +212,27 @@ Friend Class TestClass
 
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void CharacterizeRaiseEventWithMissingDefinitionActsLikeFunc()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
+    }
+}", @"Imports System
+
+Friend Class TestClass
+    Private Sub TestMethod()
+        If MyEvent IsNot Nothing Then MyEvent(Me, EventArgs.Empty)
     End Sub
 End Class");
         }

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -53,10 +53,45 @@ End Class");
         }
 
         [Fact]
-        public void RaiseEvent()
+        public void RaiseEventInElse()
         {
             TestConversionCSharpToVisualBasic(
-                @"class TestClass
+                @"using System;
+
+public class Foo
+{
+    public event EventHandler<EventArgs> Bar;
+
+    protected void OnBar(EventArgs e)
+    {
+        if (Bar == null)
+            System.Diagnostics.Debug.WriteLine(""No subscriber"");
+        else
+            Bar.Invoke(this, e);
+    }
+}", @"Imports System
+
+Public Class Foo
+    Public Event Bar As EventHandler(Of EventArgs)
+
+    Protected Sub OnBar(ByVal e As EventArgs)
+        If BarEvent Is Nothing Then
+            System.Diagnostics.Debug.WriteLine(""No subscriber"")
+        Else
+            RaiseEvent Bar(Me, e)
+        End If
+    End Sub
+End Class
+");
+        }
+
+        [Fact]
+        public void RaiseEventMinimal()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
 {
     event EventHandler MyEvent;
 
@@ -64,75 +99,141 @@ End Class");
     {
         if (MyEvent != null) MyEvent(this, EventArgs.Empty);
     }
-}", @"Friend Class TestClass
+}", @"Imports System
+
+Friend Class TestClass
     Private Event MyEvent As EventHandler
 
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
 End Class");
+        }
+
+        [Fact]
+        public void CharacterizeRaiseEventWithMissingDefinitionActsLikeFunc()
+        {
             TestConversionCSharpToVisualBasic(
-                @"class TestClass
+                @"using System;
+
+class TestClass
 {
     void TestMethod()
     {
-        if ((MyEvent != null)) MyEvent(this, EventArgs.Empty);
+        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
     }
-}", @"Friend Class TestClass
+}", @"Imports System
+
+Friend Class TestClass
     Private Sub TestMethod()
-        RaiseEvent MyEvent(Me, EventArgs.Empty)
+        If MyEvent IsNot Nothing Then MyEvent(Me, EventArgs.Empty)
     End Sub
 End Class");
+        }
+
+        [Fact]
+        public void RaiseEventReversedConditional()
+        {
             TestConversionCSharpToVisualBasic(
-                @"class TestClass
+                @"using System;
+
+class TestClass
 {
+    event EventHandler MyEvent;
+
     void TestMethod()
     {
         if (null != MyEvent) { MyEvent(this, EventArgs.Empty); }
     }
-}", @"Friend Class TestClass
-    Private Sub TestMethod()
-        RaiseEvent MyEvent(Me, EventArgs.Empty)
-    End Sub
-End Class");
-            TestConversionCSharpToVisualBasic(
-                @"class TestClass
-{
-    void TestMethod()
-    {
-        if (this.MyEvent != null) MyEvent(this, EventArgs.Empty);
-    }
-}", @"Friend Class TestClass
-    Private Sub TestMethod()
-        RaiseEvent MyEvent(Me, EventArgs.Empty)
-    End Sub
-End Class");
-            TestConversionCSharpToVisualBasic(
-                @"class TestClass
-{
-    void TestMethod()
-    {
-        if (MyEvent != null) this.MyEvent(this, EventArgs.Empty);
-    }
-}", @"Friend Class TestClass
-    Private Sub TestMethod()
-        RaiseEvent MyEvent(Me, EventArgs.Empty)
-    End Sub
-End Class");
-            TestConversionCSharpToVisualBasic(
-                @"class TestClass
-{
-    void TestMethod()
-    {
-        if ((this.MyEvent != null)) { this.MyEvent(this, EventArgs.Empty); }
-    }
-}", @"Friend Class TestClass
+}", @"Imports System
+
+Friend Class TestClass
+    Private Event MyEvent As EventHandler
+
     Private Sub TestMethod()
         RaiseEvent MyEvent(Me, EventArgs.Empty)
     End Sub
 End Class");
         }
 
+        [Fact]
+        public void RaiseEventQualified()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
+{
+    event EventHandler MyEvent;
+
+    void TestMethod()
+    {
+        if (this.MyEvent != null) MyEvent(this, EventArgs.Empty);
+    }
+}", @"Imports System
+
+Friend Class TestClass
+    Private Event MyEvent As EventHandler
+
+    Private Sub TestMethod()
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void RaiseEventInNestedBrackets()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
+{
+    event EventHandler MyEvent;
+
+    void TestMethod()
+    {
+        if ((MyEvent != null)) this.MyEvent(this, EventArgs.Empty);
+    }
+}", @"Imports System
+
+Friend Class TestClass
+    Private Event MyEvent As EventHandler
+
+    Private Sub TestMethod()
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+    End Sub
+End Class");
+        }
+
+        [Fact]
+        public void RaiseEventQualifiedWithNestedBrackets()
+        {
+            TestConversionCSharpToVisualBasic(
+                @"using System;
+
+class TestClass
+{
+    event EventHandler MyEvent;
+
+    void TestMethod()
+    {
+        if ((this.MyEvent != null)) { this.MyEvent(this, EventArgs.Empty); }
+    }
+}", @"Imports System
+
+Friend Class TestClass
+    Private Event MyEvent As EventHandler
+
+    Private Sub TestMethod()
+        RaiseEvent MyEvent(Me, EventArgs.Empty)
+    End Sub
+End Class");
+        }
+
+        /// <summary>
+        /// Intentionally unknown type used to ensure imperfect compilation errs towards common case
+        /// </summary>
         [Fact]
         public void IfStatementSimilarToRaiseEvent()
         {
@@ -147,7 +248,7 @@ End Class");
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then DrawImage()
     End Sub
-End Class");
+End Class", expectCompilationErrors: true);
             // regression test:
             TestConversionCSharpToVisualBasic(
                 @"class TestClass
@@ -160,7 +261,7 @@ End Class");
     Private Sub TestMethod()
         If FullImage IsNot Nothing Then e.DrawImage()
     End Sub
-End Class");
+End Class", expectCompilationErrors: true);
             // with braces:
             TestConversionCSharpToVisualBasic(
                 @"class TestClass
@@ -175,7 +276,7 @@ End Class");
             DrawImage()
         End If
     End Sub
-End Class");
+End Class", expectCompilationErrors: true);
             TestConversionCSharpToVisualBasic(
                 @"class TestClass
 {
@@ -189,7 +290,7 @@ End Class");
             e.DrawImage()
         End If
     End Sub
-End Class");
+End Class", expectCompilationErrors: true);
             // another bug related to the IfStatement code:
             TestConversionCSharpToVisualBasic(
                 @"class TestClass
@@ -207,7 +308,7 @@ End Class");
             Next
         End If
     End Sub
-End Class");
+End Class", expectCompilationErrors: true);
         }
 
         /// <summary>


### PR DESCRIPTION
* Fixes #220

The code and tests used to be tailored based on syntax alone which meant there were lots of false positives and negatives for detecting events. I've changed the code to use the semantic model to inform the conversion, and changed the tests to have valid compiling inputs/outputs.

It generally errs on the side of assuming something isn't an event, which will cause a change in behaviour "for the worse" in some cases that were specifically targeted by the old code. It's hard enough to get the right conversion when all information *is* available, so I'd rather focus on that, then make very explicit separate handling for cases of incomplete information that are *only* triggered when the semantic model comes up empty. Those cases will be prioritized based on user requests.