### PR TITLE
Add initial support for VB MyClass expressions [#260]

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -274,7 +274,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return value.ToString();
         }
 
-        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false, bool updateCase = true)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false)
         {
             string text = id.ValueText;
 
@@ -285,7 +285,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (id.SyntaxTree == _semanticModel.SyntaxTree) {
                 var symbol = _semanticModel.GetSymbolInfo(id.Parent).Symbol;
                 if (symbol != null && !string.IsNullOrWhiteSpace(symbol.Name)) {
-                    if (updateCase && text.Equals(symbol.Name, StringComparison.OrdinalIgnoreCase)) {
+                    if (text.Equals(symbol.Name, StringComparison.OrdinalIgnoreCase)) {
                         text = symbol.Name;
                     }
 

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -274,7 +274,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return value.ToString();
         }
 
-        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false, bool updateCase = false)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false, bool updateCase = true)
         {
             string text = id.ValueText;
 

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1390,7 +1390,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return _queryConverter.ConvertClauses(node.Clauses);
             }
 
-            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false, bool updateCase = false)
+            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false, bool updateCase = true)
             {
                 return CommonConversions.ConvertIdentifier(identifierIdentifier, isAttribute, updateCase);
             }

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -649,12 +649,12 @@ namespace ICSharpCode.CodeConverter.CSharp
                     }
                     SplitTypeParameters(node.TypeParameterList, out var typeParameters, out var constraints);
 
-                    var identifier = node.Identifier;
+                    var csIdentifier = ConvertIdentifier(node.Identifier);
                     // If the method is virtual, and there is a MyClass.SomeMethod() call,
                     // we need to emit a non-virtual method for it to call
                     if (accessedThroughMyClass)
                     {
-                        var identifierName = "MyClass" + node.Identifier.ValueText;
+                        var identifierName = "MyClass" + csIdentifier.ValueText;
                         var arrowClause = SyntaxFactory.ArrowExpressionClause(
                             SyntaxFactory.ParseExpression($"this.{identifierName}();\n")
                         );
@@ -672,9 +672,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                         );
 
                         var declNode = (VBSyntax.StatementSyntax)node.Parent;
-                        _additionalDeclarations.Add(declNode, new[] { realDecl });
+                        _additionalDeclarations.Add(declNode, new MemberDeclarationSyntax[] { realDecl });
                         convertedModifiers = convertedModifiers.Remove(convertedModifiers.Single(m => m.IsKind(SyntaxKind.VirtualKeyword)));
-                        identifier = SyntaxFactory.Identifier(identifierName);
+                        csIdentifier = SyntaxFactory.Identifier(identifierName);
                     }
 
                     var decl = SyntaxFactory.MethodDeclaration(
@@ -682,7 +682,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         convertedModifiers,
                         (TypeSyntax)node.AsClause?.Type?.Accept(TriviaConvertingVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                         null,
-                        ConvertIdentifier(identifier),
+                        csIdentifier,
                         typeParameters,
                         (ParameterListSyntax)node.ParameterList?.Accept(TriviaConvertingVisitor) ?? SyntaxFactory.ParameterList(),
                         constraints,
@@ -1160,7 +1160,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     } else {
                         left = SyntaxFactory.ThisExpression();
                         if (symbolInfo.Symbol.IsVirtual && !symbolInfo.Symbol.IsAbstract) {
-                            simpleNameSyntax = SyntaxFactory.IdentifierName($"MyClass{node.Name.Identifier.ValueText}");
+                            simpleNameSyntax = SyntaxFactory.IdentifierName($"MyClass{ConvertIdentifier(node.Name.Identifier).ValueText}");
                         }
                     }
                 }

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1390,9 +1390,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return _queryConverter.ConvertClauses(node.Clauses);
             }
 
-            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false, bool updateCase = true)
+            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false)
             {
-                return CommonConversions.ConvertIdentifier(identifierIdentifier, isAttribute, updateCase);
+                return CommonConversions.ConvertIdentifier(identifierIdentifier, isAttribute);
             }
 
             public override CSharpSyntaxNode VisitOrdering(VBSyntax.OrderingSyntax node)
@@ -1722,7 +1722,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitIdentifierName(VBSyntax.IdentifierNameSyntax node)
             {
-                var identifier = SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, node.GetAncestor<VBSyntax.AttributeSyntax>() != null, updateCase: true));
+                var identifier = SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, node.GetAncestor<VBSyntax.AttributeSyntax>() != null));
 
                 return !node.Parent.IsKind(VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.QualifiedName, VBasic.SyntaxKind.NameColonEquals, VBasic.SyntaxKind.ImportsStatement, VBasic.SyntaxKind.NamespaceStatement, VBasic.SyntaxKind.NamedFieldInitializer)
                                     || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node

--- a/TestData/SelfVerifyingTests/VBToCS/ExpressionTests.vb
+++ b/TestData/SelfVerifyingTests/VBToCS/ExpressionTests.vb
@@ -46,6 +46,71 @@ Module Program
             Dim areEqual As Boolean = s = Nothing
             Assert.True(areEqual)
         End Sub
+
+        <Fact()>
+        Public Sub MyClassInheritance()
+            Dim x As A = New B
+            Assert.True(x.TestMethod())
+        End Sub
     End Class
+
+    Public Class A
+        Overridable Function F1() As Integer
+            Return 1
+        End Function
+
+        Function F2() As Integer
+            Return 2
+        End Function
+
+        Shared Function F3() As Integer
+            Return 3
+        End Function
+
+        Overridable ReadOnly Property P1 As Integer = 1
+        Property P2 As Integer = 2
+        Shared Property P3 As Integer = 3
+
+        Public Function TestMethod() As Boolean
+            Dim virtualMethodGood1 = MyClass.F1() = 1
+            Dim virtualMethodGood2 = Me.F1() = 11
+            Dim nonVirtualMethodGood1 = MyClass.F2() = 2
+            Dim nonVirtualMethodGood2 = Me.F2() = 2
+            Dim sharedMethodGood1 = MyClass.F3() = 3
+            Dim sharedMethodGood2 = A.F3() = 3
+
+            Dim virtualPropertyGood1 = MyClass.P1 = 1
+            Dim virtualPropertyGood2 = Me.P1 = 11
+            Dim nonVirtualPropertyGood1 = MyClass.P2 = 2
+            Dim nonVirtualPropertyGood2 = Me.P2 = 2
+            Dim sharedPropertyGood1 = MyClass.P3 = 3
+            Dim sharedPropertyGood2 = A.P3 = 3
+
+            Dim methodsGood = virtualMethodGood1 AndAlso virtualMethodGood2 AndAlso
+                              nonVirtualMethodGood1 AndAlso nonVirtualMethodGood2 AndAlso
+                              sharedMethodGood1 AndAlso sharedMethodGood2
+
+            Dim propertiesGood = virtualPropertyGood1 AndAlso virtualPropertyGood2 AndAlso
+                                 nonVirtualPropertyGood1 AndAlso nonVirtualPropertyGood2 AndAlso
+                                 sharedPropertyGood1 AndAlso sharedPropertyGood2
+
+            Return methodsGood AndAlso propertiesGood
+        End Function
+    End Class
+
+
+    Public Class B
+        Inherits A
+        Public Overrides Function F1() As Integer
+            Return 11
+        End Function
+
+        Public Overrides ReadOnly Property P1 As Integer
+            Get
+                Return 11
+            End Get
+        End Property
+    End Class
+
 
 End Module

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -9,6 +9,27 @@ namespace CodeConverter.Tests.CSharp
     public class ExpressionTests : ConverterTestBase
     {
         [Fact]
+        public void MyClassExpr()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class TestClass
+    Sub TestMethod()
+        MyClass.Val = 6
+    End Sub
+
+    Shared Val As Integer
+End Class", @"public class TestClass
+{
+    public void TestMethod()
+    {
+        TestClass.Val = 6;
+    }
+
+    private static int Val;
+}");
+
+        }
+
+        [Fact]
         public void MultilineString()
         {
             // Don't auto-test comments, otherwise it tries to put a comment in the middle of the string, which obviously isn't a valid place for it

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -379,7 +379,7 @@ End Class",
     Overridable Property P1() As Integer = 1
     MustOverride Property P2() As Integer
     Public Sub TestMethod() 
-        Dim w = MyClass.P1
+        Dim w = MyClass.p1
         Dim x = Me.P1
         Dim y = MyClass.P2
         Dim z = Me.P2

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -337,5 +337,81 @@ public class Bar<x> where x : Foo, new()
 {
 }");
         }
+
+        [Fact]
+        public void MyClassVirtualCallMethod()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class A
+    Overridable Function F1() As Integer
+        Return 1
+    End Function
+    MustOverride Function F2() As Integer
+    Public Sub TestMethod() 
+        Dim w = MyClass.F1()
+        Dim x = Me.F1()
+        Dim y = MyClass.F2()
+        Dim z = Me.F2()
+    End Sub
+End Class",
+                @"public class A
+{
+    public int MyClassF1()
+    {
+        return 1;
+    }
+
+    public virtual int F1() => this.MyClassF1();
+    public abstract int F2();
+    public void TestMethod()
+    {
+        var w = this.MyClassF1();
+        var x = this.F1();
+        var y = this.F2();
+        var z = this.F2();
+    }
+}");
+        }
+
+        [Fact]
+        public void MyClassVirtualCallProperty()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class A
+    Overridable Property P1() As Integer = 1
+    MustOverride Property P2() As Integer
+    Public Sub TestMethod() 
+        Dim w = MyClass.P1
+        Dim x = Me.P1
+        Dim y = MyClass.P2
+        Dim z = Me.P2
+    End Sub
+End Class",
+                @"public class A
+{
+    public int MyClassP1 { get; set; } = 1;
+
+    public virtual int P1
+    {
+        get
+        {
+            return this.MyClassP1;
+        }
+
+        set
+        {
+            this.MyClassP1 = value;
+        }
+    }
+
+    public abstract int P2 { get; set; }
+    public void TestMethod()
+    {
+        var w = this.MyClassP1;
+        var x = this.P1;
+        var y = this.P2;
+        var z = this.P2;
+    }
+}");
+        }
+
     }
 }


### PR DESCRIPTION
Closes #260

This should implement the majority of `MyClass` support for VB -> C#. There is one case (that I'm aware of) that is missing - that should throw an exception.