### PR TITLE
Re-order constraints when converting from VB to C#

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1608,7 +1608,8 @@ namespace ICSharpCode.CodeConverter.CSharp
             public override CSharpSyntaxNode VisitTypeParameterMultipleConstraintClause(VBSyntax.TypeParameterMultipleConstraintClauseSyntax node)
             {
                 var id = SyntaxFactory.IdentifierName(ConvertIdentifier(((VBSyntax.TypeParameterSyntax)node.Parent).Identifier));
-                return SyntaxFactory.TypeParameterConstraintClause(id, SyntaxFactory.SeparatedList(node.Constraints.Select(c => (TypeParameterConstraintSyntax)c.Accept(TriviaConvertingVisitor))));
+                var constraints = node.Constraints.Select(c => (TypeParameterConstraintSyntax)c.Accept(TriviaConvertingVisitor));
+                return SyntaxFactory.TypeParameterConstraintClause(id, SyntaxFactory.SeparatedList(constraints.OrderBy(c => c.Kind() == SyntaxKind.ConstructorConstraint ? 1 : 0)));
             }
 
             public override CSharpSyntaxNode VisitSpecialConstraint(VBSyntax.SpecialConstraintSyntax node)

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -319,5 +319,23 @@ End Class",
     }
 }");
         }
+
+        [Fact]
+        public void NewConstraintLast()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Interface Foo
+End Interface
+
+Public Class Bar(Of x As {New, Foo})
+
+End Class",
+                @"public interface Foo
+{
+}
+
+public class Bar<x> where x : Foo, new()
+{
+}");
+        }
     }
 }


### PR DESCRIPTION
Closes #271 

### Problem

When converting from VB to C#, new constraints in type parameters need to be the last constraint.

### Solution

Added an OrderBy() to ensure that the new constraint ends up last. I haven't checked that the order of the other constraints remains the same, but I assume it does.

* [x] At least one test covering the code changed
* [x] All tests pass

