### PR TITLE
Ensure base.Finalize() is removed

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -105,6 +105,12 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override SyntaxList<StatementSyntax> VisitExpressionStatement(VBSyntax.ExpressionStatementSyntax node)
             {
+                if (node.Expression is VBSyntax.InvocationExpressionSyntax invoke &&
+                    invoke.Expression is VBSyntax.MemberAccessExpressionSyntax expr &&
+                    expr.Expression is VBSyntax.MyBaseExpressionSyntax &&
+                    expr.Name.Identifier.ValueText.Equals("Finalize", StringComparison.OrdinalIgnoreCase)) {
+                    return new SyntaxList<StatementSyntax>();
+                }
                 return SingleStatement((ExpressionSyntax)node.Expression.Accept(_nodesVisitor));
             }
 

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -1090,5 +1090,20 @@ namespace Global.InnerNamespace
     }
 }");
         }
+
+        [Fact]
+        public void BaseFinalizeRemoved()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Protected Overrides Sub Finalize()
+        MyBase.Finalize()
+    End Sub
+End Class", @"public class Class1
+{
+    ~Class1()
+    {
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
Closes #269 

### Problem

base.Finalize() is not removed when converting from VB to C#

### Solution

I'm not sure this is the right/nicest way of handing this:

 * I don't check that we're actually inside `~Finalize()`
 * It adds an overhead for every expression statement
 * I wasn't sure how to just add a comment, so there's a leading `;` in there. I decided a comment would be useful, since we're removing code - I'm happy to leave nothing there instead though.

* [x] At least one test covering the code changed
* [ ] All tests pass

