### PR TITLE
Automatically fix the casing of identifiers where possible

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -274,7 +274,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return value.ToString();
         }
 
-        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false, bool updateCase = false)
         {
             string text = id.ValueText;
 
@@ -285,6 +285,10 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (id.SyntaxTree == _semanticModel.SyntaxTree) {
                 var symbol = _semanticModel.GetSymbolInfo(id.Parent).Symbol;
                 if (symbol != null && !string.IsNullOrWhiteSpace(symbol.Name)) {
+                    if (updateCase && text.Equals(symbol.Name, StringComparison.OrdinalIgnoreCase)) {
+                        text = symbol.Name;
+                    }
+
                     if (symbol.IsConstructor() && isAttribute) {
                         text = symbol.ContainingType.Name;
                         if (text.EndsWith("Attribute", StringComparison.OrdinalIgnoreCase))

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1298,9 +1298,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return _queryConverter.ConvertClauses(node.Clauses);
             }
 
-            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false)
+            private SyntaxToken ConvertIdentifier(SyntaxToken identifierIdentifier, bool isAttribute = false, bool updateCase = false)
             {
-                return CommonConversions.ConvertIdentifier(identifierIdentifier, isAttribute);
+                return CommonConversions.ConvertIdentifier(identifierIdentifier, isAttribute, updateCase);
             }
 
             public override CSharpSyntaxNode VisitOrdering(VBSyntax.OrderingSyntax node)
@@ -1630,7 +1630,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitIdentifierName(VBSyntax.IdentifierNameSyntax node)
             {
-                var identifier = SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, node.GetAncestor<VBSyntax.AttributeSyntax>() != null));
+                var identifier = SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, node.GetAncestor<VBSyntax.AttributeSyntax>() != null, updateCase: true));
 
                 return !node.Parent.IsKind(VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.QualifiedName, VBasic.SyntaxKind.NameColonEquals, VBasic.SyntaxKind.ImportsStatement, VBasic.SyntaxKind.NamespaceStatement, VBasic.SyntaxKind.NamedFieldInitializer)
                                     || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node

--- a/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/My Project/Application.Designer.cs
+++ b/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/My Project/Application.Designer.cs
@@ -16,7 +16,7 @@ namespace WindowsAppVb
                 this.IsSingleInstance = false;
                 this.EnableVisualStyles = true;
                 this.SaveMySettingsOnExit = true;
-                this.ShutDownStyle = global::Microsoft.VisualBasic.ApplicationServices.ShutdownMode.AfterMainFormCloses;
+                this.ShutdownStyle = global::Microsoft.VisualBasic.ApplicationServices.ShutdownMode.AfterMainFormCloses;
             }
 
             [global::System.Diagnostics.DebuggerStepThrough()]

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -1105,5 +1105,32 @@ End Class", @"public class Class1
     }
 }");
         }
+
+        [Fact]
+        public void MemberAccessCasing()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Bar()
+
+    End Sub
+
+    Sub Foo()
+        bar()
+        me.bar()
+    End Sub
+End Class", @"public class Class1
+{
+    public void Bar()
+    {
+    }
+
+    public void Foo()
+    {
+        Bar();
+        this.Bar();
+    }
+}");
+        }
+
     }
 }

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -624,13 +624,14 @@ End Class", @"class Test
         {
             // Intentionally uses a type name with a different casing as the loop variable, i.e. "process" to test name resolution
             TestConversionVisualBasicToCSharp($@"Imports System.Diagnostics
+Imports System.Threading
 
 Public Class AcmeClass
     Private Declare {vbMethodDecl} SetForegroundWindow Lib ""user32"" (ByVal hwnd As Int32){vbType}
 
     Public Shared Sub Main()
-        For Each process In Process.GetProcesses().Where(Function(p) Not String.IsNullOrEmpty(p.MainWindowTitle))
-            SetForegroundWindow(process.MainWindowHandle.ToInt32())
+        For Each proc In Process.GetProcesses().Where(Function(p) Not String.IsNullOrEmpty(p.MainWindowTitle))
+            SetForegroundWindow(proc.MainWindowHandle.ToInt32())
             Thread.Sleep(1000)
         Next
     End Sub
@@ -638,6 +639,7 @@ End Class"
                 , $@"using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 
 public class AcmeClass
 {{
@@ -646,9 +648,9 @@ public class AcmeClass
 
     public static void Main()
     {{
-        foreach (var process in Process.GetProcesses().Where(p => !string.IsNullOrEmpty(p.MainWindowTitle)))
+        foreach (var proc in Process.GetProcesses().Where(p => !string.IsNullOrEmpty(p.MainWindowTitle)))
         {{
-            SetForegroundWindow(process.MainWindowHandle.ToInt32());
+            SetForegroundWindow(proc.MainWindowHandle.ToInt32());
             Thread.Sleep(1000);
         }}
     }}


### PR DESCRIPTION
Closes #258 

### Problem

VB allows calling methods using any casing/capitalization, where C# does not. Attempt to fix the casing where possible.

### Solution
* When converting identifiers, fix-up the casing
* This might be needed in other places too, but this fixes the original bug

* [x] At least one test covering the code changed
* [x] All tests pass

