### PR TITLE
Add #error directive on conversion error

### DIFF
--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -1732,10 +1732,13 @@ namespace ICSharpCode.CodeConverter.Util
             VisualBasicSyntaxNode sourceNode,
             Exception exception) where T: CSharpSyntaxNode
         {
+            var errorDirective = SyntaxFactory.ParseTrailingTrivia($"#error Cannot convert {sourceNode.GetType().Name} - see comment for details{Environment.NewLine}");
             var errorDescription = sourceNode.DescribeConversionError(exception);
             var commentedText = "/* " + errorDescription + " */";
+            var trailingTrivia = SyntaxFactory.TriviaList(errorDirective.Concat(SyntaxFactory.Comment(commentedText)));
+
             return dummyDestNode
-                .WithTrailingTrivia(SyntaxFactory.Comment(commentedText))
+                .WithTrailingTrivia(trailingTrivia)
                 .WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.ConversionErrorAnnotationKind, exception.ToString()));
         }
 

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -949,6 +949,7 @@ End Class", @"public class AcmeClass
 End Class");
 
             Assert.Contains("Cannot convert", convertedCode);
+            Assert.Contains("#error", convertedCode);
             Assert.Contains("_failedMemberConversionMarker1", convertedCode);
             Assert.Contains("Public Shared Operator ^(i As Integer, ac As AcmeClass) As AcmeClass", convertedCode);
             Assert.Contains("_failedMemberConversionMarker2", convertedCode);


### PR DESCRIPTION
Link to issue(s) this covers

### Problem
When conversion fails, a comment is added, with code not converted. This is an incorrect translation and should cause a compilation error.

### Solution
This adds a `#error`  directive before the comment to make it obvious when conversion has failed.
