### PR TITLE
Do not convert DateAndTime to DateTime

### DIFF
--- a/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/ISymbolExtensions.cs
@@ -11,7 +11,10 @@ namespace ICSharpCode.CodeConverter.Util
 #endif
     static class ISymbolExtensions
     {
-        private static readonly string[] TypesToConvertToDateTime = new[] {"DateTime", "DateAndTime" };
+        // A lot of symbols in DateAndTime do not exist in DateTime, eg. DateSerial(),
+        // and some have different names/arguments, eg. DateAdd(). This needs to be handled properly
+        // as part of #174
+        private static readonly string[] TypesToConvertToDateTime = new[] { "DateTime" };
 
         /// <summary>
         /// Checks if 'symbol' is accessible from within 'within'.

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -1203,6 +1203,24 @@ namespace Global.InnerNamespace
         }
 
         [Fact]
+        public void DateTimeToDateAndTime()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Foo()
+        Dim x = DateAdd(""m"", 5, Now)
+    End Sub
+End Class", @"using Microsoft.VisualBasic;
+
+public class Class1
+{
+    public void Foo()
+    {
+        var x = DateAndTime.DateAdd(""m"", 5, DateAndTime.Now);
+    }
+}");
+        }
+
+        [Fact]
         public void BaseFinalizeRemoved()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1346,6 +1346,7 @@ End Class", @"public class TestClass
         Return True
     End Function
 End Class", @"using System;
+using Microsoft.VisualBasic;
 
 public class TestClass2
 {
@@ -1353,7 +1354,7 @@ public class TestClass2
     {
         switch (true)
         {
-            case object _ when DateTime.Today.DayOfWeek == DayOfWeek.Saturday | DateTime.Today.DayOfWeek == DayOfWeek.Sunday:
+            case object _ when DateAndTime.Today.DayOfWeek == DayOfWeek.Saturday | DateAndTime.Today.DayOfWeek == DayOfWeek.Sunday:
                 {
                     // we do not work on weekends
                     return false;


### PR DESCRIPTION
Closes #261 

### Problem

When converting VB to C#, built in date functions are prefixed with DateTime rather than DateAndTime.

### Solution

When converting to C#, leave DateAndTime methods alone - these should be converted properly as part of #174.

