### PR TITLE
Add/remove parenthesis as required for VB -> C#

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1534,10 +1534,14 @@ namespace ICSharpCode.CodeConverter.CSharp
                         SyntaxFactory.BracketedArgumentList(SyntaxFactory.SeparatedList(node.ArgumentList.Arguments.Select(a => (ArgumentSyntax)a.Accept(TriviaConvertingVisitor)))));
                 }
 
-                return SyntaxFactory.InvocationExpression(
-                    (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor),
-                    ConvertArgumentListOrEmpty(node.ArgumentList)
-                );
+                if (symbol != null && symbol.IsKind(SymbolKind.Property)) {
+                    return node.Expression.Accept(TriviaConvertingVisitor);
+                } else {
+                    return SyntaxFactory.InvocationExpression(
+                        (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor),
+                        ConvertArgumentListOrEmpty(node.ArgumentList)
+                    );
+                }
 
                 bool TryGetElementAccessExpressionToConvert(out VBSyntax.ExpressionSyntax toConvert)
                 {
@@ -1727,7 +1731,19 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return !node.Parent.IsKind(VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.QualifiedName, VBasic.SyntaxKind.NameColonEquals, VBasic.SyntaxKind.ImportsStatement, VBasic.SyntaxKind.NamespaceStatement, VBasic.SyntaxKind.NamedFieldInitializer)
                                     || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node
                                     || node.Parent is VBSyntax.QualifiedNameSyntax qns && qns.Left == node
-                    ? QualifyNode(node, identifier) : identifier;
+                    ? AddParenthesis(node, QualifyNode(node, identifier)) : AddParenthesis(node, identifier);
+            }
+
+            private CSharpSyntaxNode AddParenthesis(VBSyntax.IdentifierNameSyntax node, ExpressionSyntax id)
+            {
+                var symbol = GetSymbolInfoInDocument(node);
+                if (symbol != null &&
+                    (symbol.IsOrdinaryMethod() || symbol.IsExtensionMethod()) &&
+                    !node.Parent.IsKind(VBasic.SyntaxKind.InvocationExpression, VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.AddressOfExpression)) {
+                    return SyntaxFactory.InvocationExpression(id);
+                }
+
+                return id;
             }
 
             private ExpressionSyntax QualifyNode(SyntaxNode node, SimpleNameSyntax left)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1732,10 +1732,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                                                     || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node
                                                     || node.Parent is VBSyntax.QualifiedNameSyntax qns && qns.Left == node
                     ? QualifyNode(node, identifier) : identifier;
-                return AddParenthesis(node, qualifiedIdentifier);
+                return AddEmptyArgumentListIfImplicit(node, qualifiedIdentifier);
             }
 
-            private CSharpSyntaxNode AddParenthesis(VBSyntax.IdentifierNameSyntax node, ExpressionSyntax id)
+            private CSharpSyntaxNode AddEmptyArgumentListIfImplicit(VBSyntax.IdentifierNameSyntax node, ExpressionSyntax id)
             {
                 var symbol = GetSymbolInfoInDocument(node);
                 if (symbol != null &&

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1728,10 +1728,11 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var identifier = SyntaxFactory.IdentifierName(ConvertIdentifier(node.Identifier, node.GetAncestor<VBSyntax.AttributeSyntax>() != null));
 
-                return !node.Parent.IsKind(VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.QualifiedName, VBasic.SyntaxKind.NameColonEquals, VBasic.SyntaxKind.ImportsStatement, VBasic.SyntaxKind.NamespaceStatement, VBasic.SyntaxKind.NamedFieldInitializer)
-                                    || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node
-                                    || node.Parent is VBSyntax.QualifiedNameSyntax qns && qns.Left == node
-                    ? AddParenthesis(node, QualifyNode(node, identifier)) : AddParenthesis(node, identifier);
+                var qualifiedIdentifier = !node.Parent.IsKind(VBasic.SyntaxKind.SimpleMemberAccessExpression, VBasic.SyntaxKind.QualifiedName, VBasic.SyntaxKind.NameColonEquals, VBasic.SyntaxKind.ImportsStatement, VBasic.SyntaxKind.NamespaceStatement, VBasic.SyntaxKind.NamedFieldInitializer)
+                                                    || node.Parent is VBSyntax.MemberAccessExpressionSyntax maes && maes.Expression == node
+                                                    || node.Parent is VBSyntax.QualifiedNameSyntax qns && qns.Left == node
+                    ? QualifyNode(node, identifier) : identifier;
+                return AddParenthesis(node, qualifiedIdentifier);
             }
 
             private CSharpSyntaxNode AddParenthesis(VBSyntax.IdentifierNameSyntax node, ExpressionSyntax id)

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -151,6 +151,40 @@ class TestClass
 }");
         }
 
+
+        [Fact]
+        public void MethodCallWithoutParens()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Foo()
+        Dim w = Bar
+        Dim x = Me.Bar
+        Dim y = Baz()
+        Dim z = Me.Baz()
+    End Sub
+
+    Function Bar() As Integer
+        Return 1
+    End Function
+    Property Baz As Integer
+End Class", @"public class Class1
+{
+    public void Foo()
+    {
+        var w = Bar();
+        var x = this.Bar();
+        var y = Baz;
+        var z = this.Baz;
+    }
+
+    public int Bar()
+    {
+        return 1;
+    }
+    public int Baz { get; set; }
+}");
+        }
+
         [Fact]
         public void ConversionOfCTypeUsesParensIfNeeded()
         {


### PR DESCRIPTION
Closes #265

### Problem

VB allows for parenthesis to be omitted or added for methods and properties - these need to be added or removed when converting to C#.

### Solution

Added handling in two places for this:

 * When we encounter `InvocationExpression` on a property
 * When we encounter a lone `IdentifierName` which doesn't already have specific `()` handling

* [x] At least one test covering the code changed
* [x] All tests pass

I think whitespace messed up again here, so this will probably conclict with #283.
