### PR TITLE
Ensure that local variables are initialized

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             var newDecls = new Dictionary<string, VariableDeclarationSyntax>();
 
-            var method = declarator.Ancestors().OfType<MethodBlockSyntax>().SingleOrDefault();
+            var method = declarator.Ancestors().OfType<MethodBlockBaseSyntax>().SingleOrDefault();
             DataFlowAnalysis dataFlow = null;
             if (method != null) {
                 dataFlow = _semanticModel.AnalyzeDataFlow(method.Statements.First(), method.Statements.Last());
@@ -55,7 +55,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var (type, adjustedInitializer) = AdjustFromName(rawType, name, initializer);
 
                 bool isField = declarator.Parent.IsKind(SyntaxKind.FieldDeclaration);
-                EqualsValueClauseSyntax equalsValueClauseSyntax = null;
+                EqualsValueClauseSyntax equalsValueClauseSyntax;
                 if (adjustedInitializer != null) {
                     equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(adjustedInitializer);
                 } else {

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -254,19 +254,53 @@ End Class", @"class TestClass
         [Fact]
         public void UninitializedVariable()
         {
-            TestConversionVisualBasicToCSharp(@"Public Class Class1
-    Sub Foo()
-        Dim x As Integer
-
-        Dim y = x
+            //TODO: Fix comment to be ported to top of property rather than bottom
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub New()
+        Dim needsInitialization As Integer
+        Dim notUsed As Integer
+        Dim y = needsInitialization
     End Sub
+
+    Sub Foo()
+        Dim needsInitialization As Integer
+        Dim notUsed As Integer
+        Dim y = needsInitialization
+    End Sub
+
+    Public ReadOnly Property State As Integer
+        Get
+            Dim needsInitialization As Integer
+            Dim notUsed As Integer
+            Dim y = needsInitialization
+            Return y
+        End Get
+    End Property
 End Class", @"public class Class1
 {
+    public Class1()
+    {
+        int needsInitialization = default(int);
+        int notUsed;
+        var y = needsInitialization;
+    }
+
     public void Foo()
     {
-        int x = default(int);
+        int needsInitialization = default(int);
+        int notUsed;
+        var y = needsInitialization;
+    }
 
-        var y = x;
+    public int State
+    {
+        get
+        {
+            int needsInitialization = default(int);
+            int notUsed;
+            var y = needsInitialization;
+            return y;
+        }
     }
 }");
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -252,6 +252,26 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void UninitializedVariable()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class Class1
+    Sub Foo()
+        Dim x As Integer
+
+        Dim y = x
+    End Sub
+End Class", @"public class Class1
+{
+    public void Foo()
+    {
+        int x = default(int);
+
+        var y = x;
+    }
+}");
+        }
+
+        [Fact]
         public void ShiftAssignment()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -996,7 +996,7 @@ End Class", @"class TestClass
 {
     private void TestMethod(int end)
     {
-        int[] b, s;
+        int[] b = default(int[]), s = default(int[]);
         var loopTo = end;
         for (var i = 0; i <= loopTo; i++)
             b[i] = s[i];
@@ -1048,7 +1048,7 @@ End Class", @"class TestClass
 {
     private void TestMethod()
     {
-        int[] b, s;
+        int[] b = default(int[]), s = default(int[]);
         var loopTo = end - 1;
         for (var i = 0; i <= loopTo; i++)
             b[i] = s[i];


### PR DESCRIPTION
Closes #263

### Problem
Visual Basic default initialises local variables, where C# does not. When translating we need to add initializers if they are not explicitly specified.

### Solution

Ensure that these are initialized (if required) when converting.

I do some data flow analysis to check if we actually need to initialize the variable or not - this is not strictly required, but makes the output a little nicer.

* [x] At least one test covering the code changed
* [x] All tests pass

