### PR TITLE
Do not output private get/set for interfaces

### DIFF
--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -322,6 +322,20 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void TestReadWriteOnlyInterfaceProperty()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Public Interface Foo
+    ReadOnly Property P1() As String
+    WriteOnly Property P2() As String
+End Interface", @"public interface Foo
+{
+    string P1 { get; }
+    string P2 { set; }
+}");
+        }
+
+        [Fact]
         public void TestConstructor()
         {
             TestConversionVisualBasicToCSharp(
@@ -1259,7 +1273,7 @@ End Class", @"class TestClass
     WriteOnly Property Items As Integer()
 End Interface", @"interface TestInterface
 {
-    int[] Items { private get; set; }
+    int[] Items { set; }
 }");
         }
 


### PR DESCRIPTION
Closes #270 

### Problem

When converting read only or write only properties in interfaces, we should not output the get or set.

### Solution

Special case the output of bodiless get/set for properties in interfaces.

* [x] At least one test covering the code changed
* [x] All tests pass

