### PR TITLE
Convert CDate() correctly

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1126,10 +1126,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var expressionSyntax = (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor);
                 if (SyntaxTokenExtensions.IsKind(node.Keyword, VBasic.SyntaxKind.CDateKeyword)) {
-                    return SyntaxFactory.CastExpression(
-                        SyntaxFactory.ParseTypeName("DateTime"),
-                        expressionSyntax
-                    );
+                    return SyntaxFactory.InvocationExpression(SyntaxFactory.ParseExpression("Microsoft.VisualBasic.CompilerServices.Conversions.ToDate"), SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(expressionSyntax))));
                 }
 
                 var convertMethodForKeywordOrNull = GetConvertMethodForKeywordOrNull(node);

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -140,10 +140,12 @@ End Class", @"class TestClass
         Dim rslt2 = #8/13/2002 12:14 PM#
     End Sub
 End Class", @"using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 class TestClass
 {
-    private void TestMethod([System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(599266080000000000L)] DateTime date)
+    private void TestMethod([Optional, DateTimeConstant(599266080000000000L)] DateTime date)
     {
         var rslt = DateTime.Parse(""1900-01-01"");
         var rslt2 = DateTime.Parse(""2002-08-13 12:14:00"");

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -272,11 +272,13 @@ public class TestClass
     Private Sub TestMethod()
         End
     End Sub
-End Class", @"class TestClass
+End Class", @"using System;
+
+class TestClass
 {
     private void TestMethod()
     {
-        System.Environment.Exit(0);
+        Environment.Exit(0);
     }
 }");
         }
@@ -288,11 +290,13 @@ End Class", @"class TestClass
     Private Sub TestMethod()
         Stop
     End Sub
-End Class", @"class TestClass
+End Class", @"using System.Diagnostics;
+
+class TestClass
 {
     private void TestMethod()
     {
-        System.Diagnostics.Debugger.Break();
+        Debugger.Break();
     }
 }");
         }
@@ -640,10 +644,11 @@ End Class"
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Runtime.InteropServices;
 
 public class AcmeClass
 {{
-    [System.Runtime.InteropServices.DllImport(""user32"")]
+    [DllImport(""user32"")]
     private static extern {csType} SetForegroundWindow(Int32 hwnd);
 
     public static void Main()
@@ -664,9 +669,11 @@ public class AcmeClass
             TestConversionVisualBasicToCSharp(@"Public Class AcmeClass
     Friend Declare Ansi Function GetNumDevices Lib ""CP210xManufacturing.dll"" Alias ""CP210x_GetNumDevices"" (ByRef NumDevices As String) As Integer
 End Class"
-                , @"public class AcmeClass
+                , @"using System.Runtime.InteropServices;
+
+public class AcmeClass
 {
-    [System.Runtime.InteropServices.DllImport(""CP210xManufacturing.dll"", EntryPoint = ""CP210x_GetNumDevices"", CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
+    [DllImport(""CP210xManufacturing.dll"", EntryPoint = ""CP210x_GetNumDevices"", CharSet = CharSet.Ansi)]
     internal static extern int GetNumDevices(ref string NumDevices);
 }");
         }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -32,11 +32,13 @@ End Class" + Environment.NewLine, @"class Class1
 @"Public Class Class1
     Sub Foo()
         Dim x = CDate(""2019-09-04"")
-End Class", @"public class Class1
+End Class", @"using Microsoft.VisualBasic.CompilerServices;
+
+public class Class1
 {
     public void Foo()
     {
-        var x = Microsoft.VisualBasic.CompilerServices.Conversions.ToDate(""2019-09-04"");
+        var x = Conversions.ToDate(""2019-09-04"");
     }
 }");
         }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -26,6 +26,22 @@ End Class" + Environment.NewLine, @"class Class1
         }
 
         [Fact]
+        public void CDate()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Public Class Class1
+    Sub Foo()
+        Dim x = CDate(""2019-09-04"")
+End Class", @"public class Class1
+{
+    public void Foo()
+    {
+        var x = Microsoft.VisualBasic.CompilerServices.Conversions.ToDate(""2019-09-04"");
+    }
+}");
+        }
+
+        [Fact]
         public void CastObjectToString()
         {
             TestConversionVisualBasicToCSharp(


### PR DESCRIPTION
Closes #268

### Problem

When converting `CDate()`, we would previously output a cast, which causes a compile error for `CDate(String)`.

### Solution

VB emits a call to `Microsoft.VisualBasic.CompilerServices.Conversions.ToDate()` - this change does the same.

I do this instead of `Convert.ToDate()`, as there are some differences in implementation which could cause different results.

`Conversions.ToDate()`: https://github.com/Microsoft/referencesource/blob/7f0c570e24e6f0084b3c5794e1a50de9fbe00ca4/Microsoft.VisualBasic/runtime/msvbalib/Helpers/Conversions.vb#L2006-L2079
`Convert.ToDate()`: https://github.com/Microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/mscorlib/system/convert.cs#L1712-L1790

* [x] At least one test covering the code changed
* [x] All tests pass

