### PR TITLE
Add support for VB's assign to method name return syntax

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -456,5 +456,17 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             return SyntaxFactory.AttributeArgumentList(SyntaxFactory.SeparatedList(attributeArgumentSyntaxs));
         }
+
+        public static VariableDeclarationSyntax CreateVariableDeclarationAndAssignment(string variableName,
+            ExpressionSyntax initValue, TypeSyntax explicitType = null)
+        {
+            var variableDeclaratorSyntax = SyntaxFactory.VariableDeclarator(
+                SyntaxFactory.Identifier(variableName), null,
+                SyntaxFactory.EqualsValueClause(initValue));
+            var variableDeclarationSyntax = SyntaxFactory.VariableDeclaration(
+                explicitType ?? SyntaxFactory.IdentifierName("var"),
+                SyntaxFactory.SingletonSeparatedList(variableDeclaratorSyntax));
+            return variableDeclarationSyntax;
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -31,11 +31,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public bool IsIterator { get; set; }
             public string ReturnVariable { get; set; }
-            public bool HasReturnVariable {
-                get {
-                    return !string.IsNullOrEmpty(ReturnVariable);
-                }
-            }
+            public bool HasReturnVariable => !string.IsNullOrEmpty(ReturnVariable);
             public VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> CommentConvertingVisitor { get; }
 
             private CommonConversions CommonConversions { get; }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -30,8 +30,8 @@ namespace ICSharpCode.CodeConverter.CSharp
             private readonly HashSet<string> _generatedNames = new HashSet<string>();
 
             public bool IsIterator { get; set; }
-            public string ReturnVariable { get; set; }
-            public bool HasReturnVariable => !string.IsNullOrEmpty(ReturnVariable);
+            public IdentifierNameSyntax ReturnVariable { get; set; }
+            public bool HasReturnVariable => ReturnVariable != null;
             public VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> CommentConvertingVisitor { get; }
 
             private CommonConversions CommonConversions { get; }
@@ -125,7 +125,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     _methodNode is VBSyntax.MethodBlockSyntax mb &&
                     HasReturnVariable &&
                     id.Identifier.ValueText.Equals(mb.SubOrFunctionStatement.Identifier.ValueText, StringComparison.OrdinalIgnoreCase)) {
-                    lhs = SyntaxFactory.ParseName(ReturnVariable);
+                    lhs = ReturnVariable;
                 }
 
                 if (node.IsKind(VBasic.SyntaxKind.ExponentiateAssignmentStatement)) {
@@ -323,7 +323,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         );
                         ExpressionSyntax expr;
                         if (HasReturnVariable)
-                            expr = SyntaxFactory.ParseName(ReturnVariable);
+                            expr = ReturnVariable;
                         else if (info == null)
                             expr = null;
                         else if (info.IsReferenceType)

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -231,7 +231,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private ForStatementSyntax CreateForZeroToValueLoop(SimpleNameSyntax loopVariableIdentifier, StatementSyntax loopStatement, ExpressionSyntax inclusiveLoopUpperBound)
             {
-                var loopVariableAssignment = CreateVariableDeclarationAndAssignment(loopVariableIdentifier.Identifier.Text, CommonConversions.Literal(0));
+                var loopVariableAssignment = CommonConversions.CreateVariableDeclarationAndAssignment(loopVariableIdentifier.Identifier.Text, CommonConversions.Literal(0));
                 var lessThanSourceBounds = SyntaxFactory.BinaryExpression(SyntaxKind.LessThanOrEqualExpression,
                     loopVariableIdentifier, inclusiveLoopUpperBound);
                 var incrementors = SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(
@@ -407,7 +407,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     id = (ExpressionSyntax)stmt.ControlVariable.Accept(_nodesVisitor);
                     var symbol = _semanticModel.GetSymbolInfo(stmt.ControlVariable).Symbol;
                     if (!_semanticModel.LookupSymbols(node.FullSpan.Start, name: symbol.Name).Any()) {
-                        declaration = CreateVariableDeclarationAndAssignment(symbol.Name, startValue);
+                        declaration = CommonConversions.CreateVariableDeclarationAndAssignment(symbol.Name, startValue);
                     } else {
                         startValue = SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, id, startValue);
                     }
@@ -423,7 +423,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var csToValue = (ExpressionSyntax)stmt.ToValue.Accept(_nodesVisitor);
                 if (!_semanticModel.GetConstantValue(stmt.ToValue).HasValue) {
                     var loopToVariableName = GetUniqueVariableNameInScope(node, "loopTo");
-                    var loopEndDeclaration = SyntaxFactory.LocalDeclarationStatement(CreateVariableDeclarationAndAssignment(loopToVariableName, csToValue));
+                    var loopEndDeclaration = SyntaxFactory.LocalDeclarationStatement(CommonConversions.CreateVariableDeclarationAndAssignment(loopToVariableName, csToValue));
                     // Does not do anything about porting newline trivia upwards to maintain spacing above the loop
                     preLoopStatements.Add(loopEndDeclaration);
                     csToValue = SyntaxFactory.IdentifierName(loopToVariableName);
@@ -448,18 +448,6 @@ namespace ICSharpCode.CodeConverter.CSharp
                     SyntaxFactory.SingletonSeparatedList(step),
                     block.UnpackNonNestedBlock());
                 return SyntaxFactory.List(preLoopStatements.Concat(new[] {forStatementSyntax}));
-            }
-
-            private static VariableDeclarationSyntax CreateVariableDeclarationAndAssignment(string variableName,
-                ExpressionSyntax initValue)
-            {
-                var variableDeclaratorSyntax = SyntaxFactory.VariableDeclarator(
-                    SyntaxFactory.Identifier(variableName), null,
-                    SyntaxFactory.EqualsValueClause(initValue));
-                var variableDeclarationSyntax = SyntaxFactory.VariableDeclaration(
-                    SyntaxFactory.IdentifierName("var"),
-                    SyntaxFactory.SingletonSeparatedList(variableDeclaratorSyntax));
-                return variableDeclarationSyntax;
             }
 
             public override SyntaxList<StatementSyntax> VisitForEachBlock(VBSyntax.ForEachBlockSyntax node)
@@ -569,7 +557,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private LocalDeclarationStatementSyntax CreateLocalVariableDeclarationAndAssignment(string variableName, ExpressionSyntax initValue)
             {
-                return SyntaxFactory.LocalDeclarationStatement(CreateVariableDeclarationAndAssignment(variableName, initValue));
+                return SyntaxFactory.LocalDeclarationStatement(CommonConversions.CreateVariableDeclarationAndAssignment(variableName, initValue));
             }
 
             private string GetUniqueVariableNameInScope(VBasic.VisualBasicSyntaxNode node, string variableNameBase)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -512,9 +512,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var csIdentifier = ConvertIdentifier(node.Identifier);
                     if (accessedThroughMyClass) {
                         var csIndentifierName = "MyClass" + csIdentifier.ValueText;
-                        var getReturn = SyntaxFactory.Block(SyntaxFactory.ParseStatement($"return this.{csIndentifierName};"));
+                        ExpressionSyntax thisDotIdentifier = SyntaxFactory.ParseExpression($"this.{csIndentifierName}");
+                        var getReturn = SyntaxFactory.Block(SyntaxFactory.ReturnStatement(thisDotIdentifier));
                         var getAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration, getReturn);
-                        var setValue = SyntaxFactory.Block(SyntaxFactory.ParseStatement($"this.{csIndentifierName} = value;"));
+                        var setValue = SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(SyntaxFactory.AssignmentExpression(SyntaxKind.SimpleAssignmentExpression, thisDotIdentifier, SyntaxFactory.IdentifierName("value"))));
                         var setAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, setValue);
                         var realAccessors = SyntaxFactory.AccessorList(SyntaxFactory.List(new[] {getAccessor, setAccessor}));
                         var realDecl = SyntaxFactory.PropertyDeclaration(

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -604,11 +604,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                 }
 
                 bool isIterator = node.SubOrFunctionStatement.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.IteratorKeyword));
-                //TODO Implement for iterator functions
-                var shouldAddImplicitReturnStatements = !isIterator && node.IsKind(VBasic.SyntaxKind.FunctionBlock);
-                IdentifierNameSyntax csReturnVariableOrNull = shouldAddImplicitReturnStatements ? GetRetVariableNameOrNull(node, isIterator) : null;
+                var allowsImplicitReturn = !isIterator && node.IsKind(VBasic.SyntaxKind.FunctionBlock);
+                IdentifierNameSyntax csReturnVariableOrNull = allowsImplicitReturn ? GetRetVariableNameOrNull(node, isIterator) : null;
                 var convertedStatements = ConvertStatements(node.Statements, CreateMethodBodyVisitor(node, isIterator, csReturnVariableOrNull));
-                var body = shouldAddImplicitReturnStatements ? AddImplicitReturnStatements(node, convertedStatements, csReturnVariableOrNull) : convertedStatements;
+                var body = allowsImplicitReturn ? AddImplicitReturnStatements(node, convertedStatements, csReturnVariableOrNull) : convertedStatements;
 
                 return methodBlock.WithBody(body);
             }

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -627,8 +627,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 if (referencesSelf) {
                     var csReturnVariableName = CommonConversions.ConvertIdentifier(node.SubOrFunctionStatement.Identifier).ValueText + "Ret";
                     csReturnVariable = SyntaxFactory.IdentifierName(csReturnVariableName);
-                    var retVariable = SyntaxFactory.ParseStatement($"{returnType} {csReturnVariableName} = default({returnType});{Environment.NewLine}");
-                    preBodyStatements.Add(retVariable);
+                    var retVariable = CommonConversions.CreateVariableDeclarationAndAssignment(csReturnVariableName, SyntaxFactory.DefaultExpression(returnType), returnType);
+                    preBodyStatements.Add(SyntaxFactory.LocalDeclarationStatement(retVariable));
                 }
 
                 ControlFlowAnalysis controlFlowAnalysis = null;

--- a/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/Form1.Designer.cs
+++ b/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/Form1.Designer.cs
@@ -35,6 +35,7 @@ namespace WindowsAppVb
 
         public static bool TestSub(ref bool IsDefault = false)
         {
+            return default(bool);
         }
     }
 }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -86,6 +86,57 @@ class TestClass
         }
 
         [Fact]
+        public void TestMethodAssignmentReturn()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Class Class1
+    Function TestMethod(x As Integer) As Integer
+        If x = 1 Then
+            TestMethod = 1
+        ElseIf x = 2 Then
+            TestMethod = 2
+            Exit Function
+        ElseIf x = 3 Then
+            TestMethod = TestMethod(1)
+        End If
+    End Function
+End Class", @"class Class1
+{
+    public int TestMethod(int x)
+    {
+        int TestMethodRet = default(int);
+        if (x == 1)
+            TestMethodRet = 1;
+        else if (x == 2)
+        {
+            TestMethodRet = 2;
+            return TestMethodRet;
+        }
+        else if (x == 3)
+            TestMethodRet = TestMethod(1);
+        return TestMethodRet;
+    }
+}");
+        }
+
+        [Fact]
+        public void TestMethodMissingReturn()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Class Class1
+    Function TestMethod() As Integer
+
+    End Function
+End Class", @"class Class1
+{
+    public int TestMethod()
+    {
+        return default(int);
+    }
+}");
+        }
+
+        [Fact]
         public void TestMethodXmlDoc()
         {
             TestConversionVisualBasicToCSharp(

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -119,6 +119,41 @@ End Class", @"class Class1
 }");
         }
 
+
+        [Fact]
+        public void TestMethodAssignmentAdditionReturn()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Class Class1
+    Function TestMethod(x As Integer) As Integer
+        If x = 1 Then
+            TestMethod += 1
+        ElseIf x = 2 Then
+            TestMethod -= 2
+            Exit Function
+        ElseIf x = 3 Then
+            TestMethod *= TestMethod(1)
+        End If
+    End Function
+End Class", @"class Class1
+{
+    public int TestMethod(int x)
+    {
+        int TestMethodRet = default(int);
+        if (x == 1)
+            TestMethodRet += 1;
+        else if (x == 2)
+        {
+            TestMethodRet -= 2;
+            return TestMethodRet;
+        }
+        else if (x == 3)
+            TestMethodRet *= TestMethod(1);
+        return TestMethodRet;
+    }
+}");
+        }
+
         [Fact]
         public void TestMethodMissingReturn()
         {


### PR DESCRIPTION
Closes #103

### Problem
Currently, we don't convert VB's alternative return syntax (assigning to an implicit return variable).

### Solution

This adds support for assigning to the name of the method for `FunctionBlock` methods. It covers all the basic cases I can think of, I might have missed an edge case though.

* [x] At least one test covering the code changed
* [x] All tests pass

