### PR TITLE
Use class name to access shared variables

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1253,17 +1253,24 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 var simpleNameSyntax = (SimpleNameSyntax)node.Name.Accept(TriviaConvertingVisitor);
 
+                var symbolInfo = _semanticModel.GetSymbolInfo(node.Name);
                 ExpressionSyntax left = null;
                 if (node.Expression is VBSyntax.MyClassExpressionSyntax) {
-                    var symbolInfo = _semanticModel.GetSymbolInfo(node.Name);
                     if (symbolInfo.Symbol.IsStatic) {
                         var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
-                        left = SyntaxFactory.IdentifierName(typeInfo.Type.Name);
+                        left = CommonConversions.ToCsTypeSyntax(typeInfo.Type, node);
                     } else {
                         left = SyntaxFactory.ThisExpression();
                         if (symbolInfo.Symbol.IsVirtual && !symbolInfo.Symbol.IsAbstract) {
                             simpleNameSyntax = SyntaxFactory.IdentifierName($"MyClass{ConvertIdentifier(node.Name.Identifier).ValueText}");
                         }
+                    }
+                }
+                if (left == null && symbolInfo.Symbol?.IsStatic == true) {
+                    var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
+                    var symbol = _semanticModel.GetSymbolInfo(node.Expression);
+                    if (typeInfo.Type != null && !symbol.Symbol.IsType()) {
+                        left = CommonConversions.ToCsTypeSyntax(typeInfo.Type, node);
                     }
                 }
                 if (left == null) {

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -219,6 +219,28 @@ class TestClass
         }
 
         [Fact]
+        public void AccessSharedThroughInstance()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class A
+    Public Shared x As Integer = 2
+    Public Sub Test()
+        Dim tmp = Me
+        Dim y = Me.x
+        Dim z = tmp.x
+    End Sub
+End Class", @"public class A
+{
+    public static int x = 2;
+    public void Test()
+    {
+        var tmp = this;
+        var y = A.x;
+        var z = A.x;
+    }
+}");
+        }
+
+        [Fact]
         public void UnknownTypeInvocation()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass


### PR DESCRIPTION
Closes #280 

### Problem

Access to shared variables through instances is allowed in VB (though it does not evaluate the LHS).

### Solution

When converting to C#, use the type name, rather than accessing through an instance.

* [x] At least one test covering the code changed
* [x] All tests pass

