### PR TITLE
Add parenthesis if necessary for binary expressions

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1183,7 +1183,20 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private static bool PrecedenceCouldChange(VBasic.VisualBasicSyntaxNode node)
             {
-                return node.Parent is VBSyntax.ExpressionSyntax && !(node.Parent is VBSyntax.ArgumentSyntax);
+                bool parentIsSameBinaryKind = node is VBSyntax.BinaryExpressionSyntax && node.Parent is VBSyntax.BinaryExpressionSyntax parent && parent.Kind() == node.Kind();
+                bool parentIsReturn = node.Parent is VBSyntax.ReturnStatementSyntax;
+                bool parentIsLambda = node.Parent is VBSyntax.LambdaExpressionSyntax;
+                bool parentIsNonArgumentExpression = node.Parent is VBSyntax.ExpressionSyntax && !(node.Parent is VBSyntax.ArgumentSyntax);
+                bool parentIsParenthesis = node.Parent is VBSyntax.ParenthesizedExpressionSyntax;
+
+                // Could be a full C# precendence table - this is just a common case
+                bool parentIsAndOr = node.Parent.IsKind(VBasic.SyntaxKind.AndAlsoExpression, VBasic.SyntaxKind.OrElseExpression);
+                bool nodeIsRelationalOrEqual = node.IsKind(VBasic.SyntaxKind.EqualsExpression, VBasic.SyntaxKind.NotEqualsExpression,
+                                                           VBasic.SyntaxKind.LessThanExpression, VBasic.SyntaxKind.LessThanOrEqualExpression,
+                                                           VBasic.SyntaxKind.GreaterThanExpression, VBasic.SyntaxKind.GreaterThanOrEqualExpression);
+                bool csharpPrecedenceSame = parentIsAndOr && nodeIsRelationalOrEqual;
+
+                return parentIsNonArgumentExpression && !parentIsSameBinaryKind && !parentIsReturn && !parentIsLambda && !parentIsParenthesis && !csharpPrecedenceSame;
             }
 
             public override CSharpSyntaxNode VisitLiteralExpression(VBSyntax.LiteralExpressionSyntax node)
@@ -1617,7 +1630,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 var kind = VBasic.VisualBasicExtensions.Kind(node).ConvertToken(TokenContext.Local);
                 var op = SyntaxFactory.Token(CSharpUtil.GetExpressionOperatorTokenKind(kind));
-                return SyntaxFactory.BinaryExpression(kind, lhs, op, rhs);
+
+                return ParenthesizeIfPrecedenceCouldChange(node, SyntaxFactory.BinaryExpression(kind, lhs, op, rhs));
             }
 
             public override CSharpSyntaxNode VisitInvocationExpression(VBSyntax.InvocationExpressionSyntax node)

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -328,6 +328,22 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void StringConcatPrecedence()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class Class1
+    Sub Foo()
+        Dim x = ""x "" & 5 - 4 & "" y""
+    End Sub
+End Class", @"public class Class1
+{
+    public void Foo()
+    {
+        var x = ""x "" + (5 - 4) + "" y"";
+    }
+}");
+        }
+
+        [Fact]
         public void IntegerArithmetic()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass
@@ -345,7 +361,7 @@ class TestClass
 {
     private void TestMethod()
     {
-        var x = Math.Pow(7, 6) % 5 / 4 + 3 * 2;
+        var x = (Math.Pow(7, 6) % (5 / 4)) + (3 * 2);
         x += 1;
         x -= 2;
         x *= 3;

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1033,7 +1033,7 @@ class TestClass
         var loopTo = 10 - stringValue.Length;
         for (int i = 1; i <= loopTo; i++)
         {
-            stringValue = stringValue + "" "" + System.Convert.ToString(i);
+            stringValue = stringValue + ("" "" + System.Convert.ToString(i));
             Console.WriteLine(stringValue);
         }
     }
@@ -1308,7 +1308,7 @@ End Class", @"public class TestClass
 
             case object _ when daysAgo > 0:
                 {
-                    return daysAgo / 7 + "" weeks ago"";
+                    return (daysAgo / 7) + "" weeks ago"";
                 }
 
             default:
@@ -1353,7 +1353,7 @@ public class TestClass2
     {
         switch (true)
         {
-            case object _ when DateTime.Today.DayOfWeek == DayOfWeek.Saturday | DateTime.Today.DayOfWeek == DayOfWeek.Sunday:
+            case object _ when (DateTime.Today.DayOfWeek == DayOfWeek.Saturday) | (DateTime.Today.DayOfWeek == DayOfWeek.Sunday):
                 {
                     // we do not work on weekends
                     return false;


### PR DESCRIPTION
Closes #262 

### Problem

Parenthesis are sometimes missing for binary expressions, causing compilation errors

### Solution

Add parenthesis for binary expressions. Special case some easy examples where they are definitely not required. We would need a full precedence table to work around that.

* [x] At least one test covering the code changed
* [x] All tests pass

