### PR TITLE
Add a reference to Microsoft.VisualBasic for VB -> C#

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
+++ b/ICSharpCode.CodeConverter/CSharp/VBToCSConversion.cs
@@ -11,6 +11,7 @@ using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using SyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Text.RegularExpressions;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
@@ -62,6 +63,10 @@ namespace ICSharpCode.CodeConverter.CSharp
         public string PostTransformProjectFile(string s)
         {
             s = ProjectFileTextEditor.WithUpdatedDefaultItemExcludes(s, "cs", "vb");
+
+            if (!Regex.IsMatch(s, @"<Reference\s+Include=""Microsoft.VisualBasic""\s*/>")) {
+                s = Regex.Replace(s, @"(<Reference\s+Include=""System""\s*/>)", "<Reference Include=\"Microsoft.VisualBasic\" />\r\n    $1");
+            }
 
             // TODO Find API to, or parse project file sections to remove "<DefineDebug>true</DefineDebug>" + "<DefineTrace>true</DefineTrace>"
             // Then add them to the define constants in the same section, or create one if necessary.

--- a/TestData/VBToCSCharacterization/ConvertSingleProject/EmptyVb/VisualBasicLibrary.csproj
+++ b/TestData/VBToCSCharacterization/ConvertSingleProject/EmptyVb/VisualBasicLibrary.csproj
@@ -45,6 +45,7 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/TestData/VBToCSCharacterization/ConvertSolution/ConsoleApp1/VisualBasicConsoleApp.csproj
+++ b/TestData/VBToCSCharacterization/ConvertSolution/ConsoleApp1/VisualBasicConsoleApp.csproj
@@ -48,6 +48,7 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />

--- a/TestData/VBToCSCharacterization/ConvertSolution/EmptyVb/VisualBasicLibrary.csproj
+++ b/TestData/VBToCSCharacterization/ConvertSolution/EmptyVb/VisualBasicLibrary.csproj
@@ -45,6 +45,7 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />

--- a/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/WindowsAppVb.csproj
+++ b/TestData/VBToCSCharacterization/ConvertSolution/WindowsAppVb/WindowsAppVb.csproj
@@ -48,6 +48,7 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />


### PR DESCRIPTION
Closes #292

### Problem

Converting from VB to C# uses things from the `Microsoft.VisualBasic` namespace. We need to add a reference to the assembly so this does not error.

### Solution

Adds an extra bit of regex to add in the reference if it is not already there. Doesn't seem like the nicest solution, but it seems like regex is used for the rest of the `.csproj` conversion, so this is probably fine.

* [x] At least one test covering the code changed
* [x] All tests pass

