### PR TITLE
Handle more cases with VB implicit return

### DIFF
--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -119,6 +119,32 @@ End Class", @"class Class1
 }");
         }
 
+        [Fact]
+        public void TestMethodAssignmentReturn293()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(
+@"Public Class Class1
+    Public Event MyEvent As EventHandler
+    Protected Overrides Function Foo() As String
+        AddHandler MyEvent, AddressOf Foo
+        Foo = Foo & """"
+        Foo += NameOf(Foo)
+    End Function
+End Class", @"using System;
+
+public class Class1
+{
+    public event EventHandler MyEvent;
+    protected override string Foo()
+    {
+        string FooRet = default(string);
+        MyEvent += Foo;
+        FooRet = FooRet + """";
+        FooRet += nameof(Foo);
+        return FooRet;
+    }
+}");
+        }
 
         [Fact]
         public void TestMethodAssignmentAdditionReturn()


### PR DESCRIPTION
Closes #293

### Problem

Some cases were missed when handling VB's assignment return syntax.

### Solution

* Ensure we look at the current node in the assignment case.
* When we have an identifier on the right hand side of an expression, replace it with the return variable, unless it is part of an invocation.

* [x] At least one test covering the code changed
* [x] All tests pass

