### PR TITLE
Add more missing initialisations for VB to C#

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -52,7 +52,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 EqualsValueClauseSyntax equalsValueClauseSyntax;
                 if (adjustedInitializer != null) {
                     equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(adjustedInitializer);
-                } else if (isField || IsDefinitelyAssignedBeforeRead(declarator, name)) {
+                } else if (isField || _semanticModel.IsDefinitelyAssignedBeforeRead(declarator, name)) {
                     equalsValueClauseSyntax = null;
                 } else {
                     // VB initializes variables to their default
@@ -68,37 +68,6 @@ namespace ICSharpCode.CodeConverter.CSharp
             }
 
             return newDecls;
-        }
-
-        /// <summary>
-        /// This check is entirely to avoid some unnecessary default initializations so the code looks less cluttered and more like the VB did.
-        /// The caller should default to outputting an initializer which is always safe for equivalence/correctness.
-        /// </summary>
-        private bool IsDefinitelyAssignedBeforeRead(VariableDeclaratorSyntax localDeclarator, ModifiedIdentifierSyntax name)
-        {
-            Func<string, bool> equalsId = s => s.Equals(name.Identifier.ValueText, StringComparison.OrdinalIgnoreCase);
-
-            var method = localDeclarator.GetAncestor<MethodBlockBaseSyntax>();
-
-            // Find the first and last statements in the method which contain the identifier
-            // This may overshoot where there are multiple identifiers with the same name - this is ok, it just means we could output an initializer where one is not needed
-            var statements = method.Statements.Where(s =>
-                    s.DescendantTokens().Any(id => id.IsKind(SyntaxKind.IdentifierToken) && equalsId(id.ValueText))
-                ).Take(2).ToList();
-            var first = statements.First();
-            var last = statements.Last();
-
-            // Analyze the data flow in this block to see if initialization is required
-            // If the last statement where the identifier is used is an if block, we look at the condition rather than the whole statement. This is an easy special
-            // case which catches eg. the if (TryParse()) pattern. This could happen for any node which allows multiple statements.
-            var dataFlow = last is MultiLineIfBlockSyntax ifBlock
-                ? _semanticModel.AnalyzeDataFlow(ifBlock.IfStatement.Condition)
-                : _semanticModel.AnalyzeDataFlow(first, last);
-
-            bool alwaysAssigned = dataFlow.AlwaysAssigned.Any(s => equalsId(s.Name));
-            bool readInside = dataFlow.ReadInside.Any(s => equalsId(s.Name));
-            bool writtenInside = dataFlow.WrittenInside.Any(s => equalsId(s.Name));
-            return alwaysAssigned && !writtenInside || !readInside;
         }
 
         private TypeSyntax ConvertDeclaratorType(VariableDeclaratorSyntax declarator, bool preferExplicitType)

--- a/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using VisualBasicExtensions = Microsoft.CodeAnalysis.VisualBasicExtensions;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    internal static class SemanticModelExtensions
+    {
+        /// <summary>
+        /// This check is entirely to avoid some unnecessary default initializations so the code looks less cluttered and more like the VB did.
+        /// The caller should default to outputting an initializer which is always safe for equivalence/correctness.
+        /// </summary>
+        public static bool IsDefinitelyAssignedBeforeRead(this SemanticModel semanticModel, VariableDeclaratorSyntax localDeclarator, ModifiedIdentifierSyntax name)
+        {
+            Func<string, bool> equalsId = s => s.Equals(name.Identifier.ValueText, StringComparison.OrdinalIgnoreCase);
+
+            // Find the first and last statements in the method (property, constructor, etc.) which contain the identifier
+            // This may overshoot where there are multiple identifiers with the same name - this is ok, it just means we could output an initializer where one is not needed
+            var statements = localDeclarator.GetAncestor<MethodBlockBaseSyntax>().Statements.Where(s =>
+                s.DescendantTokens().Any(id => VisualBasicExtensions.IsKind((SyntaxToken) id, SyntaxKind.IdentifierToken) && equalsId(id.ValueText))
+            ).Take(2).ToList();
+            var first = statements.First();
+            var last = statements.Last();
+
+            // Analyze the data flow in this block to see if initialization is required
+            // If the last statement where the identifier is used is an if block, we look at the condition rather than the whole statement. This is an easy special
+            // case which catches eg. the if (TryParse()) pattern. This could happen for any node which allows multiple statements.
+            var dataFlow = last is MultiLineIfBlockSyntax ifBlock
+                ? semanticModel.AnalyzeDataFlow(ifBlock.IfStatement.Condition)
+                : semanticModel.AnalyzeDataFlow(first, last);
+
+            bool alwaysAssigned = dataFlow.AlwaysAssigned.Any(s => equalsId(s.Name));
+            bool readInside = dataFlow.ReadInside.Any(s => equalsId(s.Name));
+            bool writtenInside = dataFlow.WrittenInside.Any(s => equalsId(s.Name));
+            return alwaysAssigned && !writtenInside || !readInside;
+        }
+    }
+}

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -297,6 +297,22 @@ End Class", @"class TestClass
         i += 1
     End Sub
 
+    Sub Bar2()
+        Dim i As Integer, temp As String = String.Empty
+        i = i + 1
+    End Sub
+
+    Sub Bar3()
+        Dim i As Integer, temp As String = String.Empty
+        Dim k As Integer = i + 1
+    End Sub
+
+    Sub Bar4()
+        Dim i As Integer, temp As String = String.Empty
+        Dim k As Integer = i + 1
+        i = 1
+    End Sub
+
     Public ReadOnly Property State As Integer
         Get
             Dim needsInitialization As Integer
@@ -326,6 +342,28 @@ End Class", @"public class Class1
         int i = default(int);
         string temp = string.Empty;
         i += 1;
+    }
+
+    public void Bar2()
+    {
+        int i = default(int);
+        string temp = string.Empty;
+        i = i + 1;
+    }
+
+    public void Bar3()
+    {
+        int i = default(int);
+        string temp = string.Empty;
+        int k = i + 1;
+    }
+
+    public void Bar4()
+    {
+        int i = default(int);
+        string temp = string.Empty;
+        int k = i + 1;
+        i = 1
     }
 
     public int State

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -292,6 +292,11 @@ End Class", @"class TestClass
         Dim y = needsInitialization
     End Sub
 
+    Sub Bar()
+        Dim i As Integer, temp As String = String.Empty
+        i += 1
+    End Sub
+
     Public ReadOnly Property State As Integer
         Get
             Dim needsInitialization As Integer
@@ -314,6 +319,13 @@ End Class", @"public class Class1
         int needsInitialization = default(int);
         int notUsed;
         var y = needsInitialization;
+    }
+
+    public void Bar()
+    {
+        int i = default(int);
+        string temp = string.Empty;
+        i += 1;
     }
 
     public int State
@@ -504,7 +516,7 @@ End Class", @"class TestClass
 {
     public int? Bar(string value)
     {
-        int result;
+        int result = default(int);
         if (int.TryParse(value, out result))
             return result;
         else

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -363,7 +363,7 @@ End Class", @"public class Class1
         int i = default(int);
         string temp = string.Empty;
         int k = i + 1;
-        i = 1
+        i = 1;
     }
 
     public int State
@@ -554,7 +554,7 @@ End Class", @"class TestClass
 {
     public int? Bar(string value)
     {
-        int result = default(int);
+        int result;
         if (int.TryParse(value, out result))
             return result;
         else

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -801,7 +801,7 @@ End Class", @"class TestClass
 {
     private void TestMethod()
     {
-        int charIndex;
+        int charIndex = default(int);
         // allow only digits and letters
         do
             charIndex = rand.Next(48, 123);


### PR DESCRIPTION
Closes #297 

### Problem

Variables are not initialised when convertion from C# to VB when things other than simple assignments are used.

### Solution

The AlwaysAssigned dataflow analysis doesn't handle `+=`. Explicitly check for simple assignments when deciding to leave a variable uninitialised.

Unfortunately it doesn't seem like we can handle the out variable case, as the symbol info doesn't include `out` for VB - so there's a slight regression in output there.

* [x] At least one test covering the code changed
* [x] All tests pass

