### PR TITLE
Enum implicit cast support

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -30,6 +30,7 @@ namespace ICSharpCode.CodeConverter.CSharp
     {
         private readonly SemanticModel _semanticModel;
         private readonly VisualBasicSyntaxVisitor<CSharpSyntaxNode> _nodesVisitor;
+        public TypeConversionAnalyzer TypeConversionAnalyzer { get; set; }
 
         public CommonConversions(SemanticModel semanticModel, VisualBasicSyntaxVisitor<CSharpSyntaxNode> nodesVisitor)
         {
@@ -51,7 +52,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                 bool isField = declarator.Parent.IsKind(SyntaxKind.FieldDeclaration);
                 EqualsValueClauseSyntax equalsValueClauseSyntax;
                 if (adjustedInitializer != null) {
-                    equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(adjustedInitializer);
+                    var vbInitializer = declarator.Initializer?.Value;
+                    var convertedInitializer = vbInitializer == null ? adjustedInitializer : TypeConversionAnalyzer.AddExplicitConversion(vbInitializer, adjustedInitializer);
+                    equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(convertedInitializer);
                 } else if (isField || _semanticModel.IsDefinitelyAssignedBeforeRead(declarator, name)) {
                     equalsValueClauseSyntax = null;
                 } else {

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -118,7 +118,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var typeInf = _semanticModel.GetTypeInfo(declarator.Initializer.Value);
             if (typeInf.ConvertedType == null) return CreateVarTypeName();
 
-            return _semanticModel.ToCsTypeSyntax(typeInf.ConvertedType, declarator);
+            return _semanticModel.GetCsTypeSyntax(typeInf.ConvertedType, declarator);
         }
 
         private static TypeSyntax CreateVarTypeName()

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -56,10 +56,12 @@ namespace ICSharpCode.CodeConverter.CSharp
     {
         private readonly SemanticModel _semanticModel;
         private readonly VisualBasicSyntaxVisitor<CSharpSyntaxNode> _nodesVisitor;
-        public TypeConversionAnalyzer TypeConversionAnalyzer { get; set; }
+        public TypeConversionAnalyzer TypeConversionAnalyzer { get; }
 
-        public CommonConversions(SemanticModel semanticModel, VisualBasicSyntaxVisitor<CSharpSyntaxNode> nodesVisitor)
+        public CommonConversions(SemanticModel semanticModel, VisualBasicSyntaxVisitor<CSharpSyntaxNode> nodesVisitor,
+            TypeConversionAnalyzer typeConversionAnalyzer)
         {
+            TypeConversionAnalyzer = typeConversionAnalyzer;
             _semanticModel = semanticModel;
             _nodesVisitor = nodesVisitor;
         }

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -116,7 +116,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var typeInf = _semanticModel.GetTypeInfo(declarator.Initializer.Value);
             if (typeInf.ConvertedType == null) return CreateVarTypeName();
 
-            return SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, typeInf.ConvertedType, declarator);
+            return _semanticModel.ToCsTypeSyntax(typeInf.ConvertedType, declarator);
         }
 
         private static TypeSyntax CreateVarTypeName()

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -53,6 +53,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 EqualsValueClauseSyntax equalsValueClauseSyntax;
                 if (adjustedInitializer != null) {
                     var vbInitializer = declarator.Initializer?.Value;
+                    // Explicit conversions are never needed for AsClause, since the type is inferred from the RHS
                     var convertedInitializer = vbInitializer == null ? adjustedInitializer : TypeConversionAnalyzer.AddExplicitConversion(vbInitializer, adjustedInitializer);
                     equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(convertedInitializer);
                 } else if (isField || _semanticModel.IsDefinitelyAssignedBeforeRead(declarator, name)) {

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -37,7 +37,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private CommonConversions CommonConversions { get; }
 
-            public MethodBodyVisitor(VBasic.VisualBasicSyntaxNode methodNode, SemanticModel semanticModel,
+            public MethodBodyVisitor(VBasic.VisualBasicSyntaxNode methodNode, SemanticModel semanticModel, CSharpCompilation csCompilation,
                 VBasic.VisualBasicSyntaxVisitor<CSharpSyntaxNode> nodesVisitor,
                 Stack<string> withBlockTempVariableNames, HashSet<string> extraUsingDirectives,
                 TriviaConverter triviaConverter)
@@ -49,6 +49,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 _extraUsingDirectives = extraUsingDirectives;
                 CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter);
                 CommonConversions = new CommonConversions(semanticModel, _nodesVisitor);
+                CommonConversions.TypeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, CommonConversions, extraUsingDirectives);
             }
 
             public override SyntaxList<StatementSyntax> DefaultVisit(SyntaxNode node)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -909,7 +909,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> CreateMethodBodyVisitor(VBasic.VisualBasicSyntaxNode node, bool isIterator = false, IdentifierNameSyntax csReturnVariable = null)
             {
-                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, TriviaConvertingVisitor, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
+                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, _csCompilation, TriviaConvertingVisitor, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
                     IsIterator = isIterator,
                     ReturnVariable = csReturnVariable,
                 };

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -641,7 +641,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var postBodyStatements = new List<StatementSyntax>();
 
                 var functionSym = _semanticModel.GetDeclaredSymbol(node);
-                var returnType = _semanticModel.ToCsTypeSyntax(functionSym.GetReturnType(), node);
+                var returnType = _semanticModel.GetCsTypeSyntax(functionSym.GetReturnType(), node);
 
                 if (csReturnVariableOrNull != null)
                 {
@@ -1194,7 +1194,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                                 SyntaxFactory.Comment("/* TODO Change to default(_) if this is not a reference type */"));
                     }
 
-                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(_semanticModel.ToCsTypeSyntax(type, node)) : CommonConversions.Literal(null);
+                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(_semanticModel.GetCsTypeSyntax(type, node)) : CommonConversions.Literal(null);
                 }
                 return CommonConversions.Literal(node.Token.Value, node.Token.Text);
             }
@@ -1257,7 +1257,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 if (node.Expression is VBSyntax.MyClassExpressionSyntax) {
                     if (symbolInfo.Symbol.IsStatic) {
                         var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
-                        left = _semanticModel.ToCsTypeSyntax(typeInfo.Type, node);
+                        left = _semanticModel.GetCsTypeSyntax(typeInfo.Type, node);
                     } else {
                         left = SyntaxFactory.ThisExpression();
                         if (symbolInfo.Symbol.IsVirtual && !symbolInfo.Symbol.IsAbstract) {
@@ -1269,7 +1269,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
                     var symbol = _semanticModel.GetSymbolInfo(node.Expression);
                     if (typeInfo.Type != null && !symbol.Symbol.IsType()) {
-                        left = _semanticModel.ToCsTypeSyntax(typeInfo.Type, node);
+                        left = _semanticModel.GetCsTypeSyntax(typeInfo.Type, node);
                     }
                 }
                 if (left == null) {

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -45,8 +45,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 this._csCompilation = csCompilation;
                 TriviaConvertingVisitor = new CommentConvertingNodesVisitor(this);
                 _createConvertMethodsLookupByReturnType = CreateConvertMethodsLookupByReturnType(semanticModel);
-                CommonConversions = new CommonConversions(semanticModel, TriviaConvertingVisitor);
-                _typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, CommonConversions, _extraUsingDirectives);
+                _typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, _extraUsingDirectives);
+                CommonConversions = new CommonConversions(semanticModel, TriviaConvertingVisitor, _typeConversionAnalyzer);
                 _queryConverter = new QueryConverter(CommonConversions, TriviaConvertingVisitor);
                 _additionalInitializers = new AdditionalInitializers();
             }
@@ -909,7 +909,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> CreateMethodBodyVisitor(VBasic.VisualBasicSyntaxNode node, bool isIterator = false, IdentifierNameSyntax csReturnVariable = null)
             {
-                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, _csCompilation, TriviaConvertingVisitor, _typeConversionAnalyzer, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
+                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, TriviaConvertingVisitor, CommonConversions, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
                     IsIterator = isIterator,
                     ReturnVariable = csReturnVariable,
                 };

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -909,7 +909,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> CreateMethodBodyVisitor(VBasic.VisualBasicSyntaxNode node, bool isIterator = false, IdentifierNameSyntax csReturnVariable = null)
             {
-                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, _csCompilation, TriviaConvertingVisitor, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
+                var methodBodyVisitor = new MethodBodyVisitor(node, _semanticModel, _csCompilation, TriviaConvertingVisitor, _typeConversionAnalyzer, _withBlockTempVariableNames, _extraUsingDirectives, TriviaConvertingVisitor.TriviaConverter) {
                     IsIterator = isIterator,
                     ReturnVariable = csReturnVariable,
                 };

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -641,7 +641,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var postBodyStatements = new List<StatementSyntax>();
 
                 var functionSym = _semanticModel.GetDeclaredSymbol(node);
-                var returnType = CommonConversions.ToCsTypeSyntax(functionSym.GetReturnType(), node);
+                var returnType = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, functionSym.GetReturnType(), node);
 
                 if (csReturnVariableOrNull != null)
                 {
@@ -1177,7 +1177,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             public override CSharpSyntaxNode VisitTryCastExpression(VBSyntax.TryCastExpressionSyntax node)
             {
-                return CommonConversions.ParenthesizeIfPrecedenceCouldChange(node, SyntaxFactory.BinaryExpression(
+                return VbSyntaxNodeExtensions.ParenthesizeIfPrecedenceCouldChange(node, SyntaxFactory.BinaryExpression(
                     SyntaxKind.AsExpression,
                     (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor),
                     (TypeSyntax)node.Type.Accept(TriviaConvertingVisitor)
@@ -1193,7 +1193,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                             .WithTrailingTrivia(
                                 SyntaxFactory.Comment("/* TODO Change to default(_) if this is not a reference type */"));
                     }
-                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(CommonConversions.ToCsTypeSyntax(type, node)) : CommonConversions.Literal(null);
+
+                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, type, node)) : CommonConversions.Literal(null);
                 }
                 return CommonConversions.Literal(node.Token.Value, node.Token.Text);
             }
@@ -1256,7 +1257,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 if (node.Expression is VBSyntax.MyClassExpressionSyntax) {
                     if (symbolInfo.Symbol.IsStatic) {
                         var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
-                        left = CommonConversions.ToCsTypeSyntax(typeInfo.Type, node);
+                        left = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, typeInfo.Type, node);
                     } else {
                         left = SyntaxFactory.ThisExpression();
                         if (symbolInfo.Symbol.IsVirtual && !symbolInfo.Symbol.IsAbstract) {
@@ -1268,7 +1269,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
                     var symbol = _semanticModel.GetSymbolInfo(node.Expression);
                     if (typeInfo.Type != null && !symbol.Symbol.IsType()) {
-                        left = CommonConversions.ToCsTypeSyntax(typeInfo.Type, node);
+                        left = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, typeInfo.Type, node);
                     }
                 }
                 if (left == null) {
@@ -1545,7 +1546,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     (ExpressionSyntax)node.WhenFalse.Accept(TriviaConvertingVisitor)
                 );
 
-                if (node.Parent.IsKind(VBasic.SyntaxKind.Interpolation) || CommonConversions.PrecedenceCouldChange(node))
+                if (node.Parent.IsKind(VBasic.SyntaxKind.Interpolation) || VbSyntaxNodeExtensions.PrecedenceCouldChange(node))
                     return SyntaxFactory.ParenthesizedExpression(expr);
 
                 return expr;

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -641,7 +641,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var postBodyStatements = new List<StatementSyntax>();
 
                 var functionSym = _semanticModel.GetDeclaredSymbol(node);
-                var returnType = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, functionSym.GetReturnType(), node);
+                var returnType = _semanticModel.ToCsTypeSyntax(functionSym.GetReturnType(), node);
 
                 if (csReturnVariableOrNull != null)
                 {
@@ -1194,7 +1194,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                                 SyntaxFactory.Comment("/* TODO Change to default(_) if this is not a reference type */"));
                     }
 
-                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, type, node)) : CommonConversions.Literal(null);
+                    return !type.IsReferenceType ? SyntaxFactory.DefaultExpression(_semanticModel.ToCsTypeSyntax(type, node)) : CommonConversions.Literal(null);
                 }
                 return CommonConversions.Literal(node.Token.Value, node.Token.Text);
             }
@@ -1257,7 +1257,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 if (node.Expression is VBSyntax.MyClassExpressionSyntax) {
                     if (symbolInfo.Symbol.IsStatic) {
                         var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
-                        left = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, typeInfo.Type, node);
+                        left = _semanticModel.ToCsTypeSyntax(typeInfo.Type, node);
                     } else {
                         left = SyntaxFactory.ThisExpression();
                         if (symbolInfo.Symbol.IsVirtual && !symbolInfo.Symbol.IsAbstract) {
@@ -1269,7 +1269,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
                     var symbol = _semanticModel.GetSymbolInfo(node.Expression);
                     if (typeInfo.Type != null && !symbol.Symbol.IsType()) {
-                        left = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, typeInfo.Type, node);
+                        left = _semanticModel.ToCsTypeSyntax(typeInfo.Type, node);
                     }
                 }
                 if (left == null) {

--- a/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
@@ -41,9 +41,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             return alwaysAssigned && !writtenInside || !readInside;
         }
 
-        public static TypeSyntax ToCsTypeSyntax(this SemanticModel vbSemanticModel, ITypeSymbol typeSymbol, VisualBasicSyntaxNode contextNode)
+        public static TypeSyntax GetCsTypeSyntax(this SemanticModel vbSemanticModel, ITypeSymbol typeSymbol, VisualBasicSyntaxNode contextNode)
         {
-            if (typeSymbol.IsNullable()) return SyntaxFactory.NullableType(ToCsTypeSyntax(vbSemanticModel, typeSymbol.GetNullableUnderlyingType(), contextNode));
+            if (typeSymbol.IsNullable()) return SyntaxFactory.NullableType(GetCsTypeSyntax(vbSemanticModel, typeSymbol.GetNullableUnderlyingType(), contextNode));
             var predefined = typeSymbol.SpecialType.GetPredefinedKeywordKind();
             if (predefined != Microsoft.CodeAnalysis.CSharp.SyntaxKind.None)
             {

--- a/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/SemanticModelExtensions.cs
@@ -23,7 +23,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             // Find the first and second statements in the method (property, constructor, etc.) which contain the identifier
             // This may overshoot where there are multiple identifiers with the same name - this is ok, it just means we could output an initializer where one is not needed
             var statements = localDeclarator.GetAncestor<MethodBlockBaseSyntax>().Statements.Where(s =>
-                s.DescendantTokens().Any(id => VisualBasicExtensions.IsKind((SyntaxToken) id, SyntaxKind.IdentifierToken) && equalsId(id.ValueText))
+                s.DescendantTokens().Any(id => ((SyntaxToken) id).IsKind(SyntaxKind.IdentifierToken) && equalsId(id.ValueText))
             ).Take(2).ToList();
             var first = statements.First();
             var second = statements.Last();
@@ -41,7 +41,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return alwaysAssigned && !writtenInside || !readInside;
         }
 
-        public static TypeSyntax ToCsTypeSyntax(SemanticModel vbSemanticModel, ITypeSymbol typeSymbol, VisualBasicSyntaxNode contextNode)
+        public static TypeSyntax ToCsTypeSyntax(this SemanticModel vbSemanticModel, ITypeSymbol typeSymbol, VisualBasicSyntaxNode contextNode)
         {
             if (typeSymbol.IsNullable()) return SyntaxFactory.NullableType(ToCsTypeSyntax(vbSemanticModel, typeSymbol.GetNullableUnderlyingType(), contextNode));
             var predefined = typeSymbol.SpecialType.GetPredefinedKeywordKind();

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -61,6 +61,16 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return TypeConversionKind.Unknown;
             }
 
+            if (vbType.IsEnumType()) {
+                if (vbConvertedType.IsNumericType()) {
+                    return TypeConversionKind.Implicit;
+                } else if (vbType.Equals(vbConvertedType) || vbConvertedType.SpecialType == SpecialType.System_Object) {
+                    return TypeConversionKind.Identity;
+                } else {
+                    return TypeConversionKind.Explicit;
+                }
+            }
+
             var vbCompilation = _semanticModel.Compilation as Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation;
             var vbConversion = vbCompilation.ClassifyConversion(vbType, vbConvertedType);
 

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -64,7 +64,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (vbType.IsEnumType()) {
                 if (vbConvertedType.IsNumericType()) {
                     return TypeConversionKind.Implicit;
-                } else if (vbType.Equals(vbConvertedType) || vbConvertedType.SpecialType == SpecialType.System_Object) {
+                } else if (vbType.Equals(vbConvertedType) ||
+                            (vbConvertedType.IsNullable() && vbType.Equals(vbConvertedType.GetNullableUnderlyingType())) ||
+                            vbConvertedType.SpecialType == SpecialType.System_Object) {
                     return TypeConversionKind.Identity;
                 } else {
                     return TypeConversionKind.Explicit;

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var conversionKind = AnalyzeConversion(vbNode, csNode, out var vbConvertedType);
             csNode = addParenthesisIfNeeded && conversionKind == TypeConversionKind.Implicit
-                ? CommonConversions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode)
+                ? VbSyntaxNodeExtensions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode)
                 : csNode;
             return AddExplicitConversion(vbNode, csNode, vbConvertedType, conversionKind, addParenthesisIfNeeded);
         }
@@ -41,9 +41,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             {
                 case TypeConversionKind.Unknown:
                 case TypeConversionKind.Identity:
-                    return addParenthesisIfNeeded ? CommonConversions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode) : csNode;
+                    return addParenthesisIfNeeded ? VbSyntaxNodeExtensions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode) : csNode;
                 case TypeConversionKind.Implicit:
-                    return SyntaxFactory.CastExpression(CommonConversions.ToCsTypeSyntax(vbConvertedType, vbNode), csNode);
+                    return SyntaxFactory.CastExpression(SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, vbConvertedType, vbNode), csNode);
                 case TypeConversionKind.Explicit:
                     return AddExplicitConvertTo(vbNode, csNode, vbConvertedType);
                 default:
@@ -101,7 +101,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 // Safe overapproximation: A cast is really only needed to help resolve the overload for the operator/method used.
                 // e.g. When VB "&" changes to C# "+", there are lots more overloads available that implicit casts could match.
                 // e.g. sbyte * ulong uses the decimal * operator in VB. In C# it's ambiguous - see ExpressionTests.vb "TestMul".
-                var typeName = CommonConversions.ToCsTypeSyntax(vbConvertedType, vbNode);
+                var typeName = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, vbConvertedType, vbNode);
                 if (csNode is CastExpressionSyntax cast && cast.Type.IsEquivalentTo(typeName)) {
                     return TypeConversionKind.Identity;
                 }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -20,6 +20,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             _csCompilation = csCompilation;
             _extraUsingDirectives = extraUsingDirectives;
             CommonConversions = commonConversions;
+            commonConversions.TypeConversionAnalyzer = this;
         }
 
         private CommonConversions CommonConversions { get; }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -38,7 +38,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 case TypeConversionKind.Identity:
                     return addParenthesisIfNeeded ? VbSyntaxNodeExtensions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode) : csNode;
                 case TypeConversionKind.Implicit:
-                    return SyntaxFactory.CastExpression(_semanticModel.ToCsTypeSyntax(vbConvertedType, vbNode), csNode);
+                    return SyntaxFactory.CastExpression(_semanticModel.GetCsTypeSyntax(vbConvertedType, vbNode), csNode);
                 case TypeConversionKind.Explicit:
                     return AddExplicitConvertTo(vbNode, csNode, vbConvertedType);
                 default:
@@ -96,7 +96,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 // Safe overapproximation: A cast is really only needed to help resolve the overload for the operator/method used.
                 // e.g. When VB "&" changes to C# "+", there are lots more overloads available that implicit casts could match.
                 // e.g. sbyte * ulong uses the decimal * operator in VB. In C# it's ambiguous - see ExpressionTests.vb "TestMul".
-                var typeName = _semanticModel.ToCsTypeSyntax(vbConvertedType, vbNode);
+                var typeName = _semanticModel.GetCsTypeSyntax(vbConvertedType, vbNode);
                 if (csNode is CastExpressionSyntax cast && cast.Type.IsEquivalentTo(typeName)) {
                     return TypeConversionKind.Identity;
                 }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 case TypeConversionKind.Identity:
                     return addParenthesisIfNeeded ? VbSyntaxNodeExtensions.ParenthesizeIfPrecedenceCouldChange(vbNode, csNode) : csNode;
                 case TypeConversionKind.Implicit:
-                    return SyntaxFactory.CastExpression(SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, vbConvertedType, vbNode), csNode);
+                    return SyntaxFactory.CastExpression(_semanticModel.ToCsTypeSyntax(vbConvertedType, vbNode), csNode);
                 case TypeConversionKind.Explicit:
                     return AddExplicitConvertTo(vbNode, csNode, vbConvertedType);
                 default:
@@ -101,7 +101,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 // Safe overapproximation: A cast is really only needed to help resolve the overload for the operator/method used.
                 // e.g. When VB "&" changes to C# "+", there are lots more overloads available that implicit casts could match.
                 // e.g. sbyte * ulong uses the decimal * operator in VB. In C# it's ambiguous - see ExpressionTests.vb "TestMul".
-                var typeName = SemanticModelExtensions.ToCsTypeSyntax(_semanticModel, vbConvertedType, vbNode);
+                var typeName = _semanticModel.ToCsTypeSyntax(vbConvertedType, vbNode);
                 if (csNode is CastExpressionSyntax cast && cast.Type.IsEquivalentTo(typeName)) {
                     return TypeConversionKind.Identity;
                 }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -13,17 +13,12 @@ namespace ICSharpCode.CodeConverter.CSharp
         private readonly SemanticModel _semanticModel;
         private readonly HashSet<string> _extraUsingDirectives;
 
-        public TypeConversionAnalyzer(SemanticModel semanticModel, CSharpCompilation csCompilation,
-            CommonConversions commonConversions, HashSet<string> extraUsingDirectives)
+        public TypeConversionAnalyzer(SemanticModel semanticModel, CSharpCompilation csCompilation, HashSet<string> extraUsingDirectives)
         {
             _semanticModel = semanticModel;
             _csCompilation = csCompilation;
             _extraUsingDirectives = extraUsingDirectives;
-            CommonConversions = commonConversions;
-            commonConversions.TypeConversionAnalyzer = this;
         }
-
-        private CommonConversions CommonConversions { get; }
 
         public ExpressionSyntax AddExplicitConversion(Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax vbNode, ExpressionSyntax csNode, bool addParenthesisIfNeeded = false)
         {

--- a/ICSharpCode.CodeConverter/Shared/SolutionConverter.cs
+++ b/ICSharpCode.CodeConverter/Shared/SolutionConverter.cs
@@ -94,7 +94,7 @@ namespace ICSharpCode.CodeConverter.Shared
             var projectTypeGuidMappings = _languageConversion.GetProjectTypeGuidMappings();
             var projectTypeReplacements = _projectsToConvert.SelectMany(project => GetProjectTypeReplacement(project, projectTypeGuidMappings)).ToList();
             
-            var convertedSolutionContents = TextReplacementConverter.Replace(_sourceSolutionContents, _projectReferenceReplacements.Concat(projectTypeReplacements));
+            var convertedSolutionContents = _sourceSolutionContents.Replace(_projectReferenceReplacements.Concat(projectTypeReplacements));
             return new ConversionResult(convertedSolutionContents) {
                 SourcePathOrNull = _solutionFilePath,
                 TargetPathOrNull = _solutionFilePath

--- a/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -699,8 +699,8 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsKind(this SyntaxToken token, SyntaxKind kind1, SyntaxKind kind2)
         {
-            return CSharpExtensions.Kind(token) == kind1
-                || CSharpExtensions.Kind(token) == kind2;
+            return token.Kind() == kind1
+                || token.Kind() == kind2;
         }
 
         public static bool IsKind(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind1, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind2)
@@ -711,9 +711,9 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsKind(this SyntaxToken token, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3)
         {
-            return CSharpExtensions.Kind(token) == kind1
-                || CSharpExtensions.Kind(token) == kind2
-                || CSharpExtensions.Kind(token) == kind3;
+            return token.Kind() == kind1
+                || token.Kind() == kind2
+                || token.Kind() == kind3;
         }
 
         public static bool IsKind(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind1, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind2, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind3)
@@ -725,7 +725,7 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsKind(this SyntaxToken token, params SyntaxKind[] kinds)
         {
-            return kinds.Contains(CSharpExtensions.Kind(token));
+            return kinds.Contains(token.Kind());
         }
 
         public static bool IsKind(this SyntaxToken token, params Microsoft.CodeAnalysis.VisualBasic.SyntaxKind[] kinds)

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -412,7 +412,7 @@ namespace ICSharpCode.CodeConverter.VB
                 block = SyntaxFactory.List<StatementSyntax>();
             }
             var id = _commonConversions.ConvertIdentifier(node.Identifier);
-            var methodInfo = ModelExtensions.GetDeclaredSymbol(_semanticModel, node);
+            var methodInfo = _semanticModel.GetDeclaredSymbol(node);
             var containingType = methodInfo?.ContainingType;
             var attributes = SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(TriviaConvertingVisitor)));
             var parameterList = (ParameterListSyntax)node.ParameterList?.Accept(TriviaConvertingVisitor);
@@ -581,7 +581,7 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitEventFieldDeclaration(CSS.EventFieldDeclarationSyntax node)
         {
             var decl = node.Declaration.Variables.Single();
-            var id = SyntaxFactory.Identifier(decl.Identifier.ValueText, SyntaxFacts.IsKeywordKind(VisualBasicExtensions.Kind(decl.Identifier)), decl.Identifier.GetIdentifierText(), TypeCharacter.None);
+            var id = SyntaxFactory.Identifier(decl.Identifier.ValueText, SyntaxFacts.IsKeywordKind(decl.Identifier.Kind()), decl.Identifier.GetIdentifierText(), TypeCharacter.None);
             ConvertAndSplitAttributes(node.AttributeLists, out SyntaxList<AttributeListSyntax> attributes, out SyntaxList<AttributeListSyntax> returnAttributes);
             return SyntaxFactory.EventStatement(attributes, CommonConversions.ConvertModifiers(node.Modifiers, GetMemberContext(node)), id, null, SyntaxFactory.SimpleAsClause(returnAttributes, (TypeSyntax)node.Declaration.Type.Accept(TriviaConvertingVisitor)), null);
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -496,8 +496,8 @@ class TestClass
 {
     private void TestMethod()
     {
-        double x = 1;
-        decimal y = 2;
+        double x = (double)1;
+        decimal y = (decimal)2;
         int i1 = 1;
         int i2 = 2;
         var d1 = (double)i1 / (double)i2;

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -187,6 +187,58 @@ public class Class1
         }
 
         [Fact]
+        public void EnumSwitch()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Enum E
+        A
+    End Enum
+
+    Sub Main()
+        Dim e1 = E.A
+        Dim e2 As Integer
+        Select Case e1
+            Case 0
+        End Select
+
+        Select Case e2
+            Case E.A
+        End Select
+
+    End Sub
+End Class",
+@"public class Class1
+{
+    enum E
+    {
+        A
+    }
+
+    public void Main()
+    {
+        var e1 = E.A;
+        int e2 = default(int);
+        switch (e1)
+        {
+            case 0:
+                {
+                    break;
+                }
+        }
+
+        switch (e2)
+        {
+            case var @case when @case == (int)E.A:
+                {
+                    break;
+                }
+        }
+    }
+}");
+        }
+
+
+        [Fact]
         public void MethodCallWithoutParens()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -360,6 +360,34 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void EnumNullableConversion()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Main()
+        Dim x = DayOfWeek.Monday
+        Foo(x)
+    End Sub
+
+    Sub Foo(x As DayOfWeek?)
+
+    End Sub
+End Class", @"using System;
+
+public class Class1
+{
+    public void Main()
+    {
+        var x = DayOfWeek.Monday;
+        Foo(x);
+    }
+
+    public void Foo(DayOfWeek? x)
+    {
+    }
+}");
+        }
+
+        [Fact]
         public void UninitializedVariable()
         {
             //TODO: Fix comment to be ported to top of property rather than bottom

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -321,6 +321,313 @@ End Class",
         }
 
         [Fact]
+        public void EnumConversion()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Enum ESByte As SByte
+    M1 = 0
+End Enum
+Enum EByte As Byte
+    M1 = 0
+End Enum
+Enum EShort As Short
+    M1 = 0
+End Enum
+Enum EUShort As UShort
+    M1 = 0
+End Enum
+Enum EInteger As Integer
+    M1 = 0
+End Enum
+Enum EUInteger As UInteger
+    M1 = 0
+End Enum
+Enum ELong As Long
+    M1 = 0
+End Enum
+Enum EULong As ULong
+    M1 = 0
+End Enum
+
+Module Module1
+    Sub Main()
+        Dim vBooleanSByte As Boolean = ESByte.M1
+        Dim vBooleanByte As Boolean = EByte.M1
+        Dim vBooleanShort As Boolean = EShort.M1
+        Dim vBooleanUShort As Boolean = EUShort.M1
+        Dim vBooleanInteger As Boolean = EInteger.M1
+        Dim vBooleanUInteger As Boolean = EUInteger.M1
+        Dim vBooleanLong As Boolean = ELong.M1
+        Dim vBooleanULong As Boolean = EULong.M1
+        Dim vSByteSByte As SByte = ESByte.M1
+        Dim vSByteByte As SByte = EByte.M1
+        Dim vSByteShort As SByte = EShort.M1
+        Dim vSByteUShort As SByte = EUShort.M1
+        Dim vSByteInteger As SByte = EInteger.M1
+        Dim vSByteUInteger As SByte = EUInteger.M1
+        Dim vSByteLong As SByte = ELong.M1
+        Dim vSByteULong As SByte = EULong.M1
+        Dim vByteSByte As Byte = ESByte.M1
+        Dim vByteByte As Byte = EByte.M1
+        Dim vByteShort As Byte = EShort.M1
+        Dim vByteUShort As Byte = EUShort.M1
+        Dim vByteInteger As Byte = EInteger.M1
+        Dim vByteUInteger As Byte = EUInteger.M1
+        Dim vByteLong As Byte = ELong.M1
+        Dim vByteULong As Byte = EULong.M1
+        Dim vShortSByte As Short = ESByte.M1
+        Dim vShortByte As Short = EByte.M1
+        Dim vShortShort As Short = EShort.M1
+        Dim vShortUShort As Short = EUShort.M1
+        Dim vShortInteger As Short = EInteger.M1
+        Dim vShortUInteger As Short = EUInteger.M1
+        Dim vShortLong As Short = ELong.M1
+        Dim vShortULong As Short = EULong.M1
+        Dim vUShortSByte As UShort = ESByte.M1
+        Dim vUShortByte As UShort = EByte.M1
+        Dim vUShortShort As UShort = EShort.M1
+        Dim vUShortUShort As UShort = EUShort.M1
+        Dim vUShortInteger As UShort = EInteger.M1
+        Dim vUShortUInteger As UShort = EUInteger.M1
+        Dim vUShortLong As UShort = ELong.M1
+        Dim vUShortULong As UShort = EULong.M1
+        Dim vIntegerSByte As Integer = ESByte.M1
+        Dim vIntegerByte As Integer = EByte.M1
+        Dim vIntegerShort As Integer = EShort.M1
+        Dim vIntegerUShort As Integer = EUShort.M1
+        Dim vIntegerInteger As Integer = EInteger.M1
+        Dim vIntegerUInteger As Integer = EUInteger.M1
+        Dim vIntegerLong As Integer = ELong.M1
+        Dim vIntegerULong As Integer = EULong.M1
+        Dim vUIntegerSByte As UInteger = ESByte.M1
+        Dim vUIntegerByte As UInteger = EByte.M1
+        Dim vUIntegerShort As UInteger = EShort.M1
+        Dim vUIntegerUShort As UInteger = EUShort.M1
+        Dim vUIntegerInteger As UInteger = EInteger.M1
+        Dim vUIntegerUInteger As UInteger = EUInteger.M1
+        Dim vUIntegerLong As UInteger = ELong.M1
+        Dim vUIntegerULong As UInteger = EULong.M1
+        Dim vLongSByte As Long = ESByte.M1
+        Dim vLongByte As Long = EByte.M1
+        Dim vLongShort As Long = EShort.M1
+        Dim vLongUShort As Long = EUShort.M1
+        Dim vLongInteger As Long = EInteger.M1
+        Dim vLongUInteger As Long = EUInteger.M1
+        Dim vLongLong As Long = ELong.M1
+        Dim vLongULong As Long = EULong.M1
+        Dim vULongSByte As ULong = ESByte.M1
+        Dim vULongByte As ULong = EByte.M1
+        Dim vULongShort As ULong = EShort.M1
+        Dim vULongUShort As ULong = EUShort.M1
+        Dim vULongInteger As ULong = EInteger.M1
+        Dim vULongUInteger As ULong = EUInteger.M1
+        Dim vULongLong As ULong = ELong.M1
+        Dim vULongULong As ULong = EULong.M1
+        Dim vDecimalSByte As Decimal = ESByte.M1
+        Dim vDecimalByte As Decimal = EByte.M1
+        Dim vDecimalShort As Decimal = EShort.M1
+        Dim vDecimalUShort As Decimal = EUShort.M1
+        Dim vDecimalInteger As Decimal = EInteger.M1
+        Dim vDecimalUInteger As Decimal = EUInteger.M1
+        Dim vDecimalLong As Decimal = ELong.M1
+        Dim vDecimalULong As Decimal = EULong.M1
+        Dim vSingleSByte As Single = ESByte.M1
+        Dim vSingleByte As Single = EByte.M1
+        Dim vSingleShort As Single = EShort.M1
+        Dim vSingleUShort As Single = EUShort.M1
+        Dim vSingleInteger As Single = EInteger.M1
+        Dim vSingleUInteger As Single = EUInteger.M1
+        Dim vSingleLong As Single = ELong.M1
+        Dim vSingleULong As Single = EULong.M1
+        Dim vDoubleSByte As Double = ESByte.M1
+        Dim vDoubleByte As Double = EByte.M1
+        Dim vDoubleShort As Double = EShort.M1
+        Dim vDoubleUShort As Double = EUShort.M1
+        Dim vDoubleInteger As Double = EInteger.M1
+        Dim vDoubleUInteger As Double = EUInteger.M1
+        Dim vDoubleLong As Double = ELong.M1
+        Dim vDoubleULong As Double = EULong.M1
+        Dim vStringSByte As String = ESByte.M1
+        Dim vStringByte As String = EByte.M1
+        Dim vStringShort As String = EShort.M1
+        Dim vStringUShort As String = EUShort.M1
+        Dim vStringInteger As String = EInteger.M1
+        Dim vStringUInteger As String = EUInteger.M1
+        Dim vStringLong As String = ELong.M1
+        Dim vStringULong As String = EULong.M1
+        Dim vObjectSByte As Object = ESByte.M1
+        Dim vObjectByte As Object = EByte.M1
+        Dim vObjectShort As Object = EShort.M1
+        Dim vObjectUShort As Object = EUShort.M1
+        Dim vObjectInteger As Object = EInteger.M1
+        Dim vObjectUInteger As Object = EUInteger.M1
+        Dim vObjectLong As Object = ELong.M1
+        Dim vObjectULong As Object = EULong.M1
+    End Sub
+
+End Module", @"using Microsoft.VisualBasic.CompilerServices;
+
+enum ESByte : sbyte
+{
+    M1 = 0
+}
+
+enum EByte : byte
+{
+    M1 = 0
+}
+
+enum EShort : short
+{
+    M1 = 0
+}
+
+enum EUShort : ushort
+{
+    M1 = 0
+}
+
+enum EInteger : int
+{
+    M1 = 0
+}
+
+enum EUInteger : uint
+{
+    M1 = 0
+}
+
+enum ELong : long
+{
+    M1 = 0
+}
+
+enum EULong : ulong
+{
+    M1 = 0
+}
+
+static class Module1
+{
+    public static void Main()
+    {
+        bool vBooleanSByte = Conversions.ToBoolean(ESByte.M1);
+        bool vBooleanByte = Conversions.ToBoolean(EByte.M1);
+        bool vBooleanShort = Conversions.ToBoolean(EShort.M1);
+        bool vBooleanUShort = Conversions.ToBoolean(EUShort.M1);
+        bool vBooleanInteger = Conversions.ToBoolean(EInteger.M1);
+        bool vBooleanUInteger = Conversions.ToBoolean(EUInteger.M1);
+        bool vBooleanLong = Conversions.ToBoolean(ELong.M1);
+        bool vBooleanULong = Conversions.ToBoolean(EULong.M1);
+        sbyte vSByteSByte = (sbyte)ESByte.M1;
+        sbyte vSByteByte = (sbyte)EByte.M1;
+        sbyte vSByteShort = (sbyte)EShort.M1;
+        sbyte vSByteUShort = (sbyte)EUShort.M1;
+        sbyte vSByteInteger = (sbyte)EInteger.M1;
+        sbyte vSByteUInteger = (sbyte)EUInteger.M1;
+        sbyte vSByteLong = (sbyte)ELong.M1;
+        sbyte vSByteULong = (sbyte)EULong.M1;
+        byte vByteSByte = (byte)ESByte.M1;
+        byte vByteByte = (byte)EByte.M1;
+        byte vByteShort = (byte)EShort.M1;
+        byte vByteUShort = (byte)EUShort.M1;
+        byte vByteInteger = (byte)EInteger.M1;
+        byte vByteUInteger = (byte)EUInteger.M1;
+        byte vByteLong = (byte)ELong.M1;
+        byte vByteULong = (byte)EULong.M1;
+        short vShortSByte = (short)ESByte.M1;
+        short vShortByte = (short)EByte.M1;
+        short vShortShort = (short)EShort.M1;
+        short vShortUShort = (short)EUShort.M1;
+        short vShortInteger = (short)EInteger.M1;
+        short vShortUInteger = (short)EUInteger.M1;
+        short vShortLong = (short)ELong.M1;
+        short vShortULong = (short)EULong.M1;
+        ushort vUShortSByte = (ushort)ESByte.M1;
+        ushort vUShortByte = (ushort)EByte.M1;
+        ushort vUShortShort = (ushort)EShort.M1;
+        ushort vUShortUShort = (ushort)EUShort.M1;
+        ushort vUShortInteger = (ushort)EInteger.M1;
+        ushort vUShortUInteger = (ushort)EUInteger.M1;
+        ushort vUShortLong = (ushort)ELong.M1;
+        ushort vUShortULong = (ushort)EULong.M1;
+        int vIntegerSByte = (int)ESByte.M1;
+        int vIntegerByte = (int)EByte.M1;
+        int vIntegerShort = (int)EShort.M1;
+        int vIntegerUShort = (int)EUShort.M1;
+        int vIntegerInteger = (int)EInteger.M1;
+        int vIntegerUInteger = (int)EUInteger.M1;
+        int vIntegerLong = (int)ELong.M1;
+        int vIntegerULong = (int)EULong.M1;
+        uint vUIntegerSByte = (uint)ESByte.M1;
+        uint vUIntegerByte = (uint)EByte.M1;
+        uint vUIntegerShort = (uint)EShort.M1;
+        uint vUIntegerUShort = (uint)EUShort.M1;
+        uint vUIntegerInteger = (uint)EInteger.M1;
+        uint vUIntegerUInteger = (uint)EUInteger.M1;
+        uint vUIntegerLong = (uint)ELong.M1;
+        uint vUIntegerULong = (uint)EULong.M1;
+        long vLongSByte = (long)ESByte.M1;
+        long vLongByte = (long)EByte.M1;
+        long vLongShort = (long)EShort.M1;
+        long vLongUShort = (long)EUShort.M1;
+        long vLongInteger = (long)EInteger.M1;
+        long vLongUInteger = (long)EUInteger.M1;
+        long vLongLong = (long)ELong.M1;
+        long vLongULong = (long)EULong.M1;
+        ulong vULongSByte = (ulong)ESByte.M1;
+        ulong vULongByte = (ulong)EByte.M1;
+        ulong vULongShort = (ulong)EShort.M1;
+        ulong vULongUShort = (ulong)EUShort.M1;
+        ulong vULongInteger = (ulong)EInteger.M1;
+        ulong vULongUInteger = (ulong)EUInteger.M1;
+        ulong vULongLong = (ulong)ELong.M1;
+        ulong vULongULong = (ulong)EULong.M1;
+        decimal vDecimalSByte = (decimal)ESByte.M1;
+        decimal vDecimalByte = (decimal)EByte.M1;
+        decimal vDecimalShort = (decimal)EShort.M1;
+        decimal vDecimalUShort = (decimal)EUShort.M1;
+        decimal vDecimalInteger = (decimal)EInteger.M1;
+        decimal vDecimalUInteger = (decimal)EUInteger.M1;
+        decimal vDecimalLong = (decimal)ELong.M1;
+        decimal vDecimalULong = (decimal)EULong.M1;
+        float vSingleSByte = (float)ESByte.M1;
+        float vSingleByte = (float)EByte.M1;
+        float vSingleShort = (float)EShort.M1;
+        float vSingleUShort = (float)EUShort.M1;
+        float vSingleInteger = (float)EInteger.M1;
+        float vSingleUInteger = (float)EUInteger.M1;
+        float vSingleLong = (float)ELong.M1;
+        float vSingleULong = (float)EULong.M1;
+        double vDoubleSByte = (double)ESByte.M1;
+        double vDoubleByte = (double)EByte.M1;
+        double vDoubleShort = (double)EShort.M1;
+        double vDoubleUShort = (double)EUShort.M1;
+        double vDoubleInteger = (double)EInteger.M1;
+        double vDoubleUInteger = (double)EUInteger.M1;
+        double vDoubleLong = (double)ELong.M1;
+        double vDoubleULong = (double)EULong.M1;
+        string vStringSByte = Conversions.ToString(ESByte.M1);
+        string vStringByte = Conversions.ToString(EByte.M1);
+        string vStringShort = Conversions.ToString(EShort.M1);
+        string vStringUShort = Conversions.ToString(EUShort.M1);
+        string vStringInteger = Conversions.ToString(EInteger.M1);
+        string vStringUInteger = Conversions.ToString(EUInteger.M1);
+        string vStringLong = Conversions.ToString(ELong.M1);
+        string vStringULong = Conversions.ToString(EULong.M1);
+        object vObjectSByte = ESByte.M1;
+        object vObjectByte = EByte.M1;
+        object vObjectShort = EShort.M1;
+        object vObjectUShort = EUShort.M1;
+        object vObjectInteger = EInteger.M1;
+        object vObjectUInteger = EUInteger.M1;
+        object vObjectLong = ELong.M1;
+        object vObjectULong = EULong.M1;
+    }
+}");
+
+        }
+
+        [Fact]
         public void NewConstraintLast()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Interface Foo

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1403,7 +1403,7 @@ public class TestClass2
     {
         switch (true)
         {
-            case object _ when (DateAndTime.Today.DayOfWeek == DayOfWeek.Saturday) | (DateAndTime.Today.DayOfWeek == DayOfWeek.Sunday):
+            case object _ when ((int)DateAndTime.Today.DayOfWeek == (int)DayOfWeek.Saturday) | ((int)DateAndTime.Today.DayOfWeek == (int)DayOfWeek.Sunday):
                 {
                     // we do not work on weekends
                     return false;


### PR DESCRIPTION
Closes #180

### Problem

We currently don't handle implicit enum conversions. This adds support for them

### Solution

 * Add support for explicit conversions in variable declarations. This is a little verbose for eg. floating point equals integer literal.
 * Add support for enum -> integer conversions. This is a little verbose for eg. Binary equals. We could special case this in `VisitBinaryExpression()` to give nicer output, I opted not to do that here - happy to change it though.
 * Not sure about how I got the `TypeConversionAnalyzer` into `CommonConversions` - I tried a few ways and they all seemed kinda ugly.

* [x] At least one test covering the code changed
* [x] All tests pass

