### PR TITLE
Support more complex ByRef arguments

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/AdditionalLocal.cs
+++ b/ICSharpCode.CodeConverter/CSharp/AdditionalLocal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -7,19 +8,63 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
-    public class AdditionalLocal
+    public class AdditionalLocals : IEnumerable<KeyValuePair<string, AdditionalLocals.AdditionalLocal>>
     {
         public static SyntaxAnnotation Annotation = new SyntaxAnnotation("CodeconverterAdditionalLocal");
 
-        public string Prefix { get; private set; }
-        public string ID { get; private set; }
-        public ExpressionSyntax Initializer { get; private set; }
-        
-        public AdditionalLocal(string prefix, ExpressionSyntax initializer)
+        private readonly Stack<Dictionary<string, AdditionalLocal>> _additionalLocals;
+
+        public AdditionalLocals()
         {
-            Prefix = prefix;
-            ID = $"ph{Guid.NewGuid().ToString("N")}";
-            Initializer = initializer;
+            _additionalLocals = new Stack<Dictionary<string, AdditionalLocal>>();
+        }
+
+        public void PushScope()
+        {
+            _additionalLocals.Push(new Dictionary<string, AdditionalLocal>());
+        }
+
+        public void PopScope()
+        {
+            _additionalLocals.Pop();
+        }
+
+        public AdditionalLocal AddAdditionalLocal(string prefix, ExpressionSyntax initializer)
+        {
+            var local = new AdditionalLocal(prefix, initializer);
+            _additionalLocals.Peek().Add(local.ID, local);
+            return local;
+        }
+
+        public IEnumerator<KeyValuePair<string, AdditionalLocal>> GetEnumerator()
+        {
+            return _additionalLocals.Peek().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _additionalLocals.Peek().GetEnumerator();
+        }
+
+        public AdditionalLocal this[string id] {
+            get {
+                return _additionalLocals.Peek()[id];
+            }
+        }
+
+        public class AdditionalLocal
+        {
+            public string Prefix { get; private set; }
+            public string ID { get; private set; }
+            public ExpressionSyntax Initializer { get; private set; }
+
+            public AdditionalLocal(string prefix, ExpressionSyntax initializer)
+            {
+                Prefix = prefix;
+                ID = $"ph{Guid.NewGuid().ToString("N")}";
+                Initializer = initializer;
+            }
         }
     }
+
 }

--- a/ICSharpCode.CodeConverter/CSharp/AdditionalLocal.cs
+++ b/ICSharpCode.CodeConverter/CSharp/AdditionalLocal.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public class AdditionalLocal
+    {
+        public static SyntaxAnnotation Annotation = new SyntaxAnnotation("CodeconverterAdditionalLocal");
+
+        public string Prefix { get; private set; }
+        public string ID { get; private set; }
+        public ExpressionSyntax Initializer { get; private set; }
+        
+        public AdditionalLocal(string prefix, ExpressionSyntax initializer)
+        {
+            Prefix = prefix;
+            ID = $"ph{Guid.NewGuid().ToString("N")}";
+            Initializer = initializer;
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/CSharp/ByRefParameterVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ByRefParameterVisitor.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Linq;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public partial class VisualBasicConverter
+    {
+        public class ByRefParameterVisitor : VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>>
+        {
+            private readonly VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> _wrappedVisitor;
+            private readonly AdditionalLocals _additionalLocals;
+            private readonly SemanticModel _semanticModel;
+            private readonly HashSet<string> _generatedNames = new HashSet<string>();
+
+            public ByRefParameterVisitor(VBasic.VisualBasicSyntaxVisitor<SyntaxList<StatementSyntax>> wrappedVisitor, AdditionalLocals additionalLocals,
+                SemanticModel semanticModel, HashSet<string> generatedNames)
+            {
+                _wrappedVisitor = wrappedVisitor;
+                _additionalLocals = additionalLocals;
+                _semanticModel = semanticModel;
+                _generatedNames = generatedNames;
+            }
+
+            public override SyntaxList<StatementSyntax> DefaultVisit(SyntaxNode node)
+            {
+                // If we don't insert the new variables in the right place, don't insert them at all
+                _additionalLocals.PopScope();
+
+                throw new NotImplementedException($"Conversion for {VBasic.VisualBasicExtensions.Kind(node)} not implemented, please report this issue")
+                    .WithNodeInformation(node);
+            }
+
+            private SyntaxList<StatementSyntax> AddLocalVariables(VBasic.VisualBasicSyntaxNode node)
+            {
+                _additionalLocals.PushScope();
+                IEnumerable<SyntaxNode> csNodes = _wrappedVisitor.Visit(node);
+                
+                var additionalDeclarations = new List<StatementSyntax>();
+
+                if (_additionalLocals.Count() > 0) {
+                    var newNames = new Dictionary<string, string>();
+                    csNodes = csNodes.Select(csNode => csNode.ReplaceNodes(csNode.GetAnnotatedNodes(AdditionalLocals.Annotation), (an, _) => {
+                        var id = (an as IdentifierNameSyntax).Identifier.ValueText;
+                        newNames[id] = NameGenerator.GetUniqueVariableNameInScope(_semanticModel, _generatedNames, node, _additionalLocals[id].Prefix);
+                        return SyntaxFactory.IdentifierName(newNames[id]);
+                    })).ToList();
+
+                    foreach (var additionalLocal in _additionalLocals) {
+                        var decl = CommonConversions.CreateVariableDeclarationAndAssignment(newNames[additionalLocal.Key], additionalLocal.Value.Initializer);
+                        additionalDeclarations.Add(SyntaxFactory.LocalDeclarationStatement(decl));
+                    }
+                }
+                _additionalLocals.PopScope();
+
+                return SyntaxFactory.List(additionalDeclarations.Concat(csNodes));
+            }
+
+            public override SyntaxList<StatementSyntax> VisitAddRemoveHandlerStatement(VBSyntax.AddRemoveHandlerStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitAssignmentStatement(VBSyntax.AssignmentStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitCallStatement(VBSyntax.CallStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitContinueStatement(VBSyntax.ContinueStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitDoLoopBlock(VBSyntax.DoLoopBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitEraseStatement(VBSyntax.EraseStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitErrorStatement(VBSyntax.ErrorStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitExitStatement(VBSyntax.ExitStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitExpressionStatement(VBSyntax.ExpressionStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitForBlock(VBSyntax.ForBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitForEachBlock(VBSyntax.ForEachBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitGoToStatement(VBSyntax.GoToStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitLabelStatement(VBSyntax.LabelStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitMultiLineIfBlock(VBSyntax.MultiLineIfBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitOnErrorGoToStatement(VBSyntax.OnErrorGoToStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitOnErrorResumeNextStatement(VBSyntax.OnErrorResumeNextStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitPrintStatement(VBSyntax.PrintStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitRaiseEventStatement(VBSyntax.RaiseEventStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitReDimStatement(VBSyntax.ReDimStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitResumeStatement(VBSyntax.ResumeStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitReturnStatement(VBSyntax.ReturnStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitSelectBlock(VBSyntax.SelectBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitSingleLineIfStatement(VBSyntax.SingleLineIfStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitSyncLockBlock(VBSyntax.SyncLockBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitThrowStatement(VBSyntax.ThrowStatementSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitTryBlock(VBSyntax.TryBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitUsingBlock(VBSyntax.UsingBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitWhileBlock(VBSyntax.WhileBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitWithBlock(VBSyntax.WithBlockSyntax node) => AddLocalVariables(node);
+            public override SyntaxList<StatementSyntax> VisitYieldStatement(VBSyntax.YieldStatementSyntax node) => AddLocalVariables(node);
+
+            // RedimClause is implemented in MethodBodyVisitor, but is not an executable statement
+            public override SyntaxList<StatementSyntax> VisitRedimClause(VBSyntax.RedimClauseSyntax node) => _wrappedVisitor.Visit(node);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -654,6 +654,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var csReturnVariableOrNull = GetRetVariableNameOrNull(node);
                 var visualBasicSyntaxVisitor = CreateMethodBodyVisitor(node, IsIterator(node), csReturnVariableOrNull);
                 var convertedStatements = ConvertStatements(node.Statements, visualBasicSyntaxVisitor);
+                if (_additionalLocals.Count > 0)
+                    throw new Exception("Failed to convert method with call to method with ByRef parameters");
                 var body = WithImplicitReturnStatements(node, convertedStatements, csReturnVariableOrNull);
 
                 return methodBlock.WithBody(body);

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -429,7 +429,43 @@ namespace ICSharpCode.CodeConverter.CSharp
                                 convertedModifiers, SyntaxFactory.List(attributes), _methodsWithHandles);
                             declarations.AddRange(fieldDecls);
                         } else {
-                            var baseFieldDeclarationSyntax = SyntaxFactory.FieldDeclaration(SyntaxFactory.List(attributes), convertedModifiers, decl);
+                            FieldDeclarationSyntax baseFieldDeclarationSyntax;
+                            if (_additionalLocals.Count() > 0) {
+                                if (decl.Variables.Count > 1) {
+                                    // Currently no way to tell which _additionalLocals would apply to which initializer
+                                    throw new NotImplementedException("Fields with multiple declarations and initializers with ByRef parameters not currently supported");
+                                }
+                                var v = decl.Variables.First();
+                                if (v.Initializer.Value.DescendantNodes().OfType<InvocationExpressionSyntax>().Count() > 1) {
+                                    throw new NotImplementedException("Field initializers with nested method calls not currently supported");
+                                }
+                                var calledMethodName = v.Initializer.Value.DescendantNodesAndSelf().OfType<InvocationExpressionSyntax>().First().DescendantNodes().OfType<IdentifierNameSyntax>().First();
+                                var newMethodName = $"{calledMethodName.Identifier.ValueText}_{v.Identifier.ValueText}";
+                                var localVars = _additionalLocals.Values
+                                    .Select(al => SyntaxFactory.LocalDeclarationStatement(CommonConversions.CreateVariableDeclarationAndAssignment(al.Prefix, al.Initializer)))
+                                    .Cast<StatementSyntax>().ToList();
+                                var newInitializer = v.Initializer.Value.ReplaceNodes(v.Initializer.Value.GetAnnotatedNodes(AdditionalLocal.Annotation), (an, _) => {
+                                    // This should probably use a unique name like in MethodBodyVisitor - a collision is far less likely here
+                                    var id = (an as IdentifierNameSyntax).Identifier.ValueText;
+                                    return SyntaxFactory.IdentifierName(_additionalLocals[id].Prefix);
+                                });
+                                _additionalLocals.Clear();
+                                var body = SyntaxFactory.Block(localVars.Concat(SyntaxFactory.SingletonList(SyntaxFactory.ReturnStatement(newInitializer))));
+                                var methodAttrs = SyntaxFactory.List<AttributeListSyntax>();
+                                // Method calls in initializers must be static in C# - Supporting this is #281
+                                var modifiers = SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
+                                var typeConstraints = SyntaxFactory.List<TypeParameterConstraintClauseSyntax>();
+                                var parameterList = SyntaxFactory.ParameterList();
+                                var methodDecl = SyntaxFactory.MethodDeclaration(methodAttrs, modifiers, decl.Type, null, SyntaxFactory.Identifier(newMethodName), null, parameterList, typeConstraints, body, null);
+                                declarations.Add(methodDecl);
+
+                                var newVar = v.WithInitializer(SyntaxFactory.EqualsValueClause(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(newMethodName))));
+                                var newVarDecl = SyntaxFactory.VariableDeclaration(decl.Type, SyntaxFactory.SingletonSeparatedList(newVar));
+
+                                baseFieldDeclarationSyntax = SyntaxFactory.FieldDeclaration(SyntaxFactory.List(attributes), convertedModifiers, newVarDecl);
+                            } else {
+                                baseFieldDeclarationSyntax = SyntaxFactory.FieldDeclaration(SyntaxFactory.List(attributes), convertedModifiers, decl);
+                            }
                             declarations.Add(baseFieldDeclarationSyntax);
                         }
                     }
@@ -680,7 +716,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                     Func<ISymbol, bool> equalsMethodName = s => s.IsKind(SymbolKind.Local) && s.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase);
                     var flow = _semanticModel.AnalyzeDataFlow(node.Statements.First(), node.Statements.Last());
 
-                    assignsToMethodNameVariable = flow.ReadInside.Any(equalsMethodName) || flow.WrittenInside.Any(equalsMethodName);
+                    if (flow.Succeeded) {
+                        assignsToMethodNameVariable = flow.ReadInside.Any(equalsMethodName) || flow.WrittenInside.Any(equalsMethodName);
+                    }
                 }
 
                 IdentifierNameSyntax csReturnVariable = null;

--- a/ICSharpCode.CodeConverter/Util/NameGenerator.cs
+++ b/ICSharpCode.CodeConverter/Util/NameGenerator.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -161,6 +162,21 @@ namespace ICSharpCode.CodeConverter.Util
             if (!token.IsKind(Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.IdentifierToken))
                 return "[" + name + "]";
             return name;
+        }
+
+        public static string GetUniqueVariableNameInScope(Microsoft.CodeAnalysis.SemanticModel semanticModel, HashSet<string> generatedNames,
+            Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode node, string variableNameBase)
+        {
+            // Need to check not just the symbols this node has access to, but whether there are any nested blocks which have access to this node and contain a conflicting name
+            var scopeStarts = node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
+                    .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
+            string uniqueName = GenerateUniqueName(variableNameBase, string.Empty,
+                n => {
+                    var matchingSymbols = scopeStarts.SelectMany(scopeStart => semanticModel.LookupSymbols(scopeStart, name: n));
+                    return !generatedNames.Contains(n) && !matchingSymbols.Any();
+                });
+            generatedNames.Add(uniqueName);
+            return uniqueName;
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/NameGenerator.cs
+++ b/ICSharpCode.CodeConverter/Util/NameGenerator.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -164,19 +163,5 @@ namespace ICSharpCode.CodeConverter.Util
             return name;
         }
 
-        public static string GetUniqueVariableNameInScope(Microsoft.CodeAnalysis.SemanticModel semanticModel, HashSet<string> generatedNames,
-            Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode node, string variableNameBase)
-        {
-            // Need to check not just the symbols this node has access to, but whether there are any nested blocks which have access to this node and contain a conflicting name
-            var scopeStarts = node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
-                    .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
-            string uniqueName = GenerateUniqueName(variableNameBase, string.Empty,
-                n => {
-                    var matchingSymbols = scopeStarts.SelectMany(scopeStart => semanticModel.LookupSymbols(scopeStart, name: n));
-                    return !generatedNames.Contains(n) && !matchingSymbols.Any();
-                });
-            generatedNames.Add(uniqueName);
-            return uniqueName;
-        }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/NameGenerator.cs
+++ b/ICSharpCode.CodeConverter/Util/NameGenerator.cs
@@ -3,6 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
+using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -163,5 +166,18 @@ namespace ICSharpCode.CodeConverter.Util
             return name;
         }
 
+        public static string GetUniqueVariableNameInScope(SemanticModel semanticModel, HashSet<string> generatedNames, VBasic.VisualBasicSyntaxNode node, string variableNameBase)
+        {
+            // Need to check not just the symbols this node has access to, but whether there are any nested blocks which have access to this node and contain a conflicting name
+            var scopeStarts = node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
+                        .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
+            string uniqueName = NameGenerator.GenerateUniqueName(variableNameBase, string.Empty,
+                n => {
+                    var matchingSymbols = scopeStarts.SelectMany(scopeStart => semanticModel.LookupSymbols(scopeStart, name: n));
+                    return !generatedNames.Contains(n) && !matchingSymbols.Any();
+                });
+            generatedNames.Add(uniqueName);
+            return uniqueName;
+        }
     }
 }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -230,6 +230,38 @@ End Class", @"public class Class1
         }
 
         [Fact]
+        public void RefArgumentUsing()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Imports System.Data.SqlClient
+
+Public Class Class1
+    Sub Foo()
+        Using x = New SqlConnection
+            Bar(x)
+        End Using
+    End Sub
+    Sub Bar(ByRef x As SqlConnection)
+
+    End Sub
+End Class", @"using System.Data.SqlClient;
+
+public class Class1
+{
+    public void Foo()
+    {
+        using (var x = new SqlConnection())
+        {
+            var argx = x;
+            Bar(ref argx);
+        }
+    }
+    public void Bar(ref SqlConnection x)
+    {
+    }
+}");
+        }
+
+        [Fact]
         public void MethodCallWithImplicitConversion()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -212,6 +212,10 @@ End Class", @"public class Class1
         Bar(x = True)
     End Sub
 
+    Sub Foo2()
+        Return Bar(True = False)
+    End Sub
+
     Sub Bar(ByRef b As Boolean)
     End Sub
 End Class", @"public class Class1
@@ -221,6 +225,12 @@ End Class", @"public class Class1
         var x = true;
         var argb = x == true;
         Bar(ref argb);
+    }
+
+    public void Foo2()
+    {
+        var argb = true == false;
+        return Bar(ref argb);
     }
 
     public void Bar(ref bool b)

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -262,6 +262,31 @@ public class Class1
         }
 
         [Fact]
+        public void RefArgumentPropertyInitializer()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Private _p1 As Class1 = Foo(New Class1)
+    Public Shared Function Foo(ByRef c1 As Class1) As Class1
+        Return c1
+    End Function
+End Class", @"public class Class1
+{
+    static Class1 Foo__p1()
+    {
+        var argc1 = new Class1();
+        return Foo(ref argc1);
+    }
+
+    private Class1 _p1 = Foo__p1();
+
+    public static Class1 Foo(ref Class1 c1)
+    {
+        return c1;
+    }
+}");
+        }
+
+        [Fact]
         public void MethodCallWithImplicitConversion()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -156,6 +156,54 @@ class TestClass
         }
 
         [Fact]
+        public void RefArgumentRValue()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Private Property C1 As Class1
+    Private _c2 As Class1
+    Private _o1 As Object
+
+    Sub Foo()
+        Bar(New Class1)
+        Bar(C1)
+        Bar(Me.C1)
+        Bar(_c2)
+        Bar(Me._c2)
+        Bar(_o1)
+        Bar(Me._o1)
+    End Sub
+
+    Sub Bar(ByRef class1)
+    End Sub
+End Class", @"public class Class1
+{
+    private Class1 C1 { get; set; }
+    private Class1 _c2;
+    private object _o1;
+
+    public void Foo()
+    {
+        var argclass1 = (object)new Class1();
+        var argclass11 = (object)C1;
+        var argclass12 = (object)this.C1;
+        var argclass13 = (object)_c2;
+        var argclass14 = (object)this._c2;
+        Bar(ref argclass1);
+        Bar(ref argclass11);
+        Bar(ref argclass12);
+        Bar(ref argclass13);
+        Bar(ref argclass14);
+        Bar(ref _o1);
+        Bar(ref this._o1);
+    }
+
+    public void Bar(ref object class1)
+    {
+    }
+}");
+        }
+
+        [Fact]
         public void MethodCallWithImplicitConversion()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -184,20 +184,46 @@ End Class", @"public class Class1
     public void Foo()
     {
         var argclass1 = (object)new Class1();
-        var argclass11 = (object)C1;
-        var argclass12 = (object)this.C1;
-        var argclass13 = (object)_c2;
-        var argclass14 = (object)this._c2;
         Bar(ref argclass1);
+        var argclass11 = (object)C1;
         Bar(ref argclass11);
+        var argclass12 = (object)this.C1;
         Bar(ref argclass12);
+        var argclass13 = (object)_c2;
         Bar(ref argclass13);
+        var argclass14 = (object)this._c2;
         Bar(ref argclass14);
         Bar(ref _o1);
         Bar(ref this._o1);
     }
 
     public void Bar(ref object class1)
+    {
+    }
+}");
+        }
+
+        [Fact]
+        public void RefArgumentRValue2()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Foo()
+        Dim x = True
+        Bar(x = True)
+    End Sub
+
+    Sub Bar(ByRef b As Boolean)
+    End Sub
+End Class", @"public class Class1
+{
+    public void Foo()
+    {
+        var x = true;
+        var argb = x == true;
+        Bar(ref argb);
+    }
+
+    public void Bar(ref bool b)
     {
     }
 }");

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -216,8 +216,34 @@ End Class", @"public class Class1
         Return Bar(True = False)
     End Sub
 
+    Sub Foo3()
+        If Bar(True = False) Then Bar(True = False)
+    End Sub
+
+    Sub Foo4()
+        If Bar(True = False) Then
+            Bar(True = False)
+        ElseIf Bar(True = False) Then
+            Bar(True = False)
+        Else
+            Bar(True = False)
+        End If
+    End Sub
+
     Sub Bar(ByRef b As Boolean)
     End Sub
+
+    Function Bar2(ByRef c1 As Class1) As Integer
+        If c1 IsNot Nothing AndAlso Len(Bar3(Me)) <> 0 Then
+            Return 1
+        End If
+        Return 0
+    End Function
+
+    Function Bar3(ByRef c1 As Class1) As String
+        Return """"
+    End Function
+
 End Class", @"public class Class1
 {
     public void Foo()
@@ -233,8 +259,52 @@ End Class", @"public class Class1
         return Bar(ref argb);
     }
 
+    public void Foo3()
+    {
+        var argb1 = true == false;
+        if (Bar(ref argb1))
+        {
+            var argb = true == false;
+            Bar(ref argb);
+        }
+    }
+
+    public void Foo4()
+    {
+        var argb3 = true == false;
+        var argb4 = true == false;
+        if (Bar(ref argb3))
+        {
+            var argb = true == false;
+            Bar(ref argb);
+        }
+        else if (Bar(ref argb4))
+        {
+            var argb2 = true == false;
+            Bar(ref argb2);
+        }
+        else
+        {
+            var argb1 = true == false;
+            Bar(ref argb1);
+        }
+    }
+
     public void Bar(ref bool b)
     {
+    }
+
+    public int Bar2(ref Class1 c1)
+    {
+        var argc1 = this;
+        if (c1 != null && Microsoft.VisualBasic.Strings.Len(Bar3(ref argc1)) != 0)
+            return 1;
+        return 0;
+    }
+
+    public string Bar3(ref Class1 c1)
+    {
+        return """";
     }
 }");
         }


### PR DESCRIPTION
References #264

Add support for more complicated arguments to methods with ByRef parameters.

Takes a different approach to #204.

### Problem

VB supports passing anything as a ByRef parameter, where C# requires something it can take the address of.

### Solution

 * When generating arguments, if the parameter is `ByRef`, create an identifier with a random name, annotate it (with `AdditionalLocal.Annotation`), and add an `AdditionalLocal`
 * When visiting an expression statement, generate a sensible unique variable name, insert additional local declarations, and update the name of the argument.
 * When calling a method with `ByRef` parameters in a field initializer, generate a method without `ByRef` to call instead
 * We only handle the easiest of cases for field initializers - a lot of the functionality needs to overlap with #281. We throw errors for some (not all) of the more complex cases. The rest should fail to compile in the generated C# anyway.
 * Add some additional type conversion support, for explicit upcasting. VB supports `ByRef` for mismatching types - we need to insert an explicit cast (and therefore, an additional local variable).

* [x] At least one test covering the code changed
* [x] All tests pass

