### PR TITLE
Implement correct string comparisons for VB

### DIFF
--- a/TestData/SelfVerifyingTests/VBToCS/ExpressionTests.vb
+++ b/TestData/SelfVerifyingTests/VBToCS/ExpressionTests.vb
@@ -25,6 +25,13 @@ Module Program
         End Sub
 
         <Fact>
+        Public Sub TestStringComparison()
+            Dim s1 As String = Nothing
+            Dim s2 As String = ""
+            Assert.True(s1 = s2)
+        End Sub
+
+        <Fact>
         Sub TestCat()
             Dim vBoolean As Boolean = Nothing
             Dim vSByte As SByte = Nothing

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -645,12 +645,24 @@ End Class", @"class TestClass
         [Fact]
         public void StringCompare()
         {
-            TestConversionVisualBasicToCSharp(@"Public Class Class1
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
     Sub Foo()
         Dim s1 As String = Nothing
         Dim s2 As String = """"
         If s1 <> s2 Then
             Throw New Exception()
+        End If
+        If s1 = ""something"" Then
+            Throw New Exception()
+        End If
+        If ""something"" = s1 Then
+            Throw New Exception()
+        End If
+        If s1 = Nothing Then
+            '
+        End If
+        If s1 = """" Then
+            '
         End If
     End Sub
 End Class", @"using System;
@@ -664,11 +676,68 @@ public class Class1
         string s2 = """";
         if (Operators.CompareString(s1, s2, TextCompare: false) != 0)
             throw new Exception();
+        if (s1 == ""something"")
+            throw new Exception();
+        if (""something"" == s1)
+            throw new Exception();
+        if (string.IsNullOrEmpty(s1))
+        {
+        }
+        if (string.IsNullOrEmpty(s1))
+        {
+        }
     }
 }");
         }
 
+        [Fact]
+        public void StringCompareText()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Option Compare Text
+Public Class Class1
+    Sub Foo()
+        Dim s1 As String = Nothing
+        Dim s2 As String = """"
+        If s1 <> s2 Then
+            Throw New Exception()
+        End If
+        If s1 = ""something"" Then
+            Throw New Exception()
+        End If
+        If ""something"" = s1 Then
+            Throw New Exception()
+        End If
+        If s1 = Nothing Then
+            '
+        End If
+        If s1 = """" Then
+            '
+        End If
+    End Sub
+End Class", @"using System;
+using Microsoft.VisualBasic.CompilerServices;
 
+public class Class1
+{
+    public void Foo()
+    {
+        string s1 = null;
+        string s2 = """";
+        if (Operators.CompareString(s1, s2, TextCompare: true) != 0)
+            throw new Exception();
+        if (Operators.CompareString(s1, ""something"", TextCompare: true) == 0)
+            throw new Exception();
+        if (Operators.CompareString(""something"", s1, TextCompare: true) == 0)
+            throw new Exception();
+        if (string.IsNullOrEmpty(s1))
+        {
+        }
+        if (string.IsNullOrEmpty(s1))
+        {
+        }
+    }
+}");
+        }
 
         [Fact]
         public void StringConcatPrecedence()

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -643,6 +643,34 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void StringCompare()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class Class1
+    Sub Foo()
+        Dim s1 As String = Nothing
+        Dim s2 As String = """"
+        If s1 <> s2 Then
+            Throw New Exception()
+        End If
+    End Sub
+End Class", @"using System;
+using Microsoft.VisualBasic.CompilerServices;
+
+public class Class1
+{
+    public void Foo()
+    {
+        string s1 = null;
+        string s2 = """";
+        if (Operators.CompareString(s1, s2, TextCompare: false) != 0)
+            throw new Exception();
+    }
+}");
+        }
+
+
+
+        [Fact]
         public void StringConcatPrecedence()
         {
             TestConversionVisualBasicToCSharp(@"Public Class Class1
@@ -912,7 +940,7 @@ End Class", @"class TestClass
 {
     private void TestMethod(string str)
     {
-        bool result = (str == """") ? true : false;
+        bool result = (string.IsNullOrEmpty(str)) ? true : false;
     }
 }");
         }
@@ -928,7 +956,7 @@ End Class", @"class TestClass
 {
     private void TestMethod(string str)
     {
-        bool result = !((str == """") ? true : false);
+        bool result = !((string.IsNullOrEmpty(str)) ? true : false);
     }
 }");
         }
@@ -944,7 +972,7 @@ End Class", @"class TestClass
 {
     private void TestMethod(string str)
     {
-        int result = 5 - ((str == """") ? 1 : 2);
+        int result = 5 - ((string.IsNullOrEmpty(str)) ? 1 : 2);
     }
 }");
         }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -175,7 +175,7 @@ public class Class1
     {
         set
         {
-            if (value != """")
+            if (!string.IsNullOrEmpty(value))
                 Y = """";
             else
                 _y = """";

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -732,19 +732,21 @@ End Class", @"class TestClass
         Next
         Return -1
     End Function
-End Class", @"class TestClass
+End Class", @"using Microsoft.VisualBasic.CompilerServices;
+
+class TestClass
 {
     public static int FindTextInCol(string w, int pTitleRow, int startCol, string needle)
     {
         var loopTo = w.Length;
         for (int c = startCol; c <= loopTo; c++)
         {
-            if (needle == """")
+            if (string.IsNullOrEmpty(needle))
             {
                 if (string.IsNullOrWhiteSpace(w[c].ToString()))
                     return c;
             }
-            else if (w[c].ToString() == needle)
+            else if (Operators.CompareString(w[c].ToString(), needle, TextCompare: false) == 0)
                 return c;
         }
         return -1;


### PR DESCRIPTION
Closes #308

### Problem

String comparison behaviour for converted VB -> C# code does not match VB's behaviour.

### Solution

Added a special case for string equality. Added a special case to that to produce `string.IsNullOrEmpty()` when we can to produce slightly nicer code.

* [x] At least one test covering the code changed
* [x] All tests pass

