### PR TITLE
Miscellaneous fixes

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1474,7 +1474,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 bool isUsing = symbolInfo?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax()?.Parent?.Parent?.IsKind(VBasic.SyntaxKind.UsingStatement) == true;
 
                 var typeInfo = _semanticModel.GetTypeInfo(node.Expression);
-                bool isTypeMismatch = !typeInfo.Type.Equals(typeInfo.ConvertedType);
+                bool isTypeMismatch = typeInfo.Type == null || !typeInfo.Type.Equals(typeInfo.ConvertedType);
 
                 return (!isIdentifier && !isMemberAccess) || isProperty || isTypeMismatch || isUsing;
             }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -105,6 +105,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                 }
                 return TypeConversionKind.Implicit;
             }
+            else if (csConversion.IsExplicit && csConversion.IsEnumeration)
+            {
+                return TypeConversionKind.Implicit;
+            }
             else if (csConversion.IsExplicit && vbConversion.IsNumeric && vbType.TypeKind != TypeKind.Enum)
             {
                 return TypeConversionKind.Explicit;

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -408,6 +408,34 @@ public class Class1
         }
 
         [Fact]
+        public void IntToEnumArg()
+        {
+            TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1
+    Sub Foo(ByVal arg As TriState)
+    End Sub
+
+    Sub Main()
+        Foo(0)
+    End Sub
+End Class",
+@"using Microsoft.VisualBasic;
+
+public class Class1
+{
+    public void Foo(TriState arg)
+    {
+    }
+
+    public void Main()
+    {
+        Foo((TriState)0);
+    }
+}");
+        }
+
+
+
+        [Fact]
         public void EnumSwitch()
         {
             TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -230,6 +230,10 @@ End Class", @"public class Class1
         End If
     End Sub
 
+    Sub Foo5()
+        Bar(Nothing)
+    End Sub
+
     Sub Bar(ByRef b As Boolean)
     End Sub
 
@@ -288,6 +292,12 @@ End Class", @"public class Class1
             var argb1 = true == false;
             Bar(ref argb1);
         }
+    }
+
+    public void Foo5()
+    {
+        var argb = default(bool);
+        Bar(ref argb);
     }
 
     public void Bar(ref bool b)


### PR DESCRIPTION
Fixes a couple of issues from previous PRs.

### Problem
* Exception when `Nothing` is passed as a `ByRef` parameter
* Exception when `Integer` parameter is passed where an enum type is expected

### Solution
* Handle missing case for enum conversions
* Handle lack of type info for `ByRef` parameters

* [x] At least one test covering the code changed
* [x] All tests pass

