### PR TITLE
fixed #325: 

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1741,7 +1741,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return csEquivalent;
                 }
 
-                var convertedExpression = ConvertExpression(out var shouldBeElementAccess);
+                // VB doesn't have a specialized node for element access because the syntax is ambiguous. Instead, it just uses an invocation expression or dictionary access expression, then figures out using the semantic model which one is most likely intended.
+                // https://github.com/dotnet/roslyn/blob/master/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb#L768
+                var convertedExpression = ConvertInvocationSubExpression(out var shouldBeElementAccess);
                 if (shouldBeElementAccess) {
                     return SyntaxFactory.ElementAccessExpression(
                         convertedExpression,
@@ -1761,7 +1763,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 return SyntaxFactory.InvocationExpression(convertedExpression, ConvertArgumentListOrEmpty(node.ArgumentList));
 
-                ExpressionSyntax ConvertExpression(out bool isElementAccess)
+                ExpressionSyntax ConvertInvocationSubExpression(out bool isElementAccess)
                 {
                     isElementAccess = IsPropertyElementAccess(operation, out bool isDefault) ||
                                       IsArrayElementAccess(operation) ||

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1784,7 +1784,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                         converted = (ExpressionSyntax)toConvert.Accept(TriviaConvertingVisitor);
                     }
 
-                    // is (1) a method and (2) returns array type and (3) array index is specified as invocation parameter in round brackets?
+                    // If ambiguous, method(0) is treated as passing 0 to the method, rather than calling method with no parameters and indexing into the result.
+                    // VB doesn't have a specialized node for element access because the syntax is ambiguous. Instead, it just uses an invocation expression or dictionary access expression, then figures out using the semantic model which one is most likely intended. 
+                    // https://github.com/dotnet/roslyn/blob/master/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb#L768
                     if (symbol?.Kind == SymbolKind.Method &&
                         symbolReturnType?.Kind == SymbolKind.ArrayType && 
                         node.ArgumentList.Arguments.Count == ((IArrayTypeSymbol)symbolReturnType).Rank &&

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1785,7 +1785,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             /// </summary>
             private static bool ProbablyNotAMethodCall(VBSyntax.InvocationExpressionSyntax node, ISymbol symbol, ITypeSymbol symbolReturnType)
             {
-                return !(symbol is IMethodSymbol) && symbolReturnType.IsErrorType() && node.Expression is VBSyntax.IdentifierNameSyntax;
+                return !(symbol is IMethodSymbol) && symbolReturnType.IsErrorType() && node.Expression is VBSyntax.IdentifierNameSyntax && node.ArgumentList.Arguments.Any();
             }
 
             private ArgumentListSyntax ConvertArgumentListOrEmpty(VBSyntax.ArgumentListSyntax argumentListSyntax)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1789,8 +1789,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     // https://github.com/dotnet/roslyn/blob/master/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb#L768
                     if (symbol?.Kind == SymbolKind.Method &&
                         symbolReturnType?.Kind == SymbolKind.ArrayType && 
-                        node.ArgumentList.Arguments.Count == ((IArrayTypeSymbol)symbolReturnType).Rank &&
-                        node.HasTrailingTrivia) {
+                        node.ArgumentList.Arguments.Count == ((IArrayTypeSymbol)symbolReturnType).Rank) {
 
                         // assume expression is already an invocation, as in: GetStrings()(1)
                         converted = (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor);

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1796,8 +1796,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                             node.Expression.RawKind == (ushort)Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.SimpleMemberAccessExpression) {
                             // expression consists of just a method name, as in: GetStrings(1)
                             // append method call brackets, but only if method has no arguments, otherwise back off
-                            var symbArgCount = ((IMethodSymbol)symbol).Parameters.Length;
-                            if (symbArgCount == 0) {
+                            if (((IMethodSymbol)symbol).Parameters.Length == 0) {
                                 converted = SyntaxFactory.InvocationExpression(converted);
                             } else {
                                 // do not convert function call with parameter to array indexer

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1987,11 +1987,9 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             private CSharpSyntaxNode AddEmptyArgumentListIfImplicit(VBSyntax.IdentifierNameSyntax node, ExpressionSyntax id)
             {
-                if (_semanticModel.GetOperation(node)?.Kind == OperationKind.Invocation) {
-                    return SyntaxFactory.InvocationExpression(id, SyntaxFactory.ArgumentList());
-                }
-
-                return id;
+                return _semanticModel.GetOperation(node)?.Kind == OperationKind.Invocation 
+                    ? SyntaxFactory.InvocationExpression(id, SyntaxFactory.ArgumentList())
+                    : id;
             }
 
             private ExpressionSyntax QualifyNode(SyntaxNode node, SimpleNameSyntax left)

--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
@@ -37,10 +37,12 @@
     <EmbeddedResource Include="Shared\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.6.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -577,42 +577,75 @@ End Class", @"public class A
         public void MethodCallArrayIndexerBrackets()
         {
             TestConversionVisualBasicToCSharp(@"Public Class A
-  Public Sub Test()
-    Dim str1 = Me.GetStrings(0)
-    str1 = GetStrings(0)
-    Dim str2 = GetStrings()(1)
-    Dim str3 = Me.GetStrings2(""abc"")
-    str3 = GetStrings2(""abc"")
-    Dim str4 = GetStrings2(""abc"")(1)
-  End Sub
+    Public Sub Test()
+        Dim str1 = Me.GetStringFromNone(0)
+        str1 = GetStringFromNone(0)
+        Dim str2 = GetStringFromNone()(1)
+        Dim str3 = Me.GetStringsFromString(""abc"")
+        str3 = GetStringsFromString(""abc"")
+        Dim str4 = GetStringsFromString(""abc"")(1)
+        Dim fromStr3 = GetMoreStringsFromString(""bc"")(1)(0)
+        Dim explicitNoParameter = GetStringsFromAmbiguous()(0)(1)
+        Dim usesParameter1 = GetStringsFromAmbiguous(0)(1)(2)
+    End Sub
 
-  Function GetStrings() As String()
-    Return New String() { ""A"", ""B"", ""C""}
-  End Function
+    Function GetStringFromNone() As String()
+        Return New String() { ""A"", ""B"", ""C""}
+    End Function
 
-  Function GetStrings2(parm As String) As String()
-    Return New String() { ""1"", ""2"", ""3""}
-  End Function
+    Function GetStringsFromString(parm As String) As String()
+        Return New String() { ""1"", ""2"", ""3""}
+    End Function
+
+    Function GetMoreStringsFromString(parm As String) As String()()
+        Return New String()() { New String() { ""1"" }}
+    End Function
+
+    Function GetStringsFromAmbiguous() As String()()
+        Return New String()() { New String() { ""1"" }}
+    End Function
+
+    Function GetStringsFromAmbiguous(amb As Integer) As String()()
+        Return New String()() { New String() { ""1"" }}
+    End Function
 End Class", @"public class A
 {
     public void Test()
     {
-        var str1 = this.GetStrings()[0];
-        str1 = GetStrings()[0];
-        var str2 = GetStrings()[1];
-        var str3 = this.GetStrings2(""abc"");
-        str3 = GetStrings2(""abc"");
-        var str4 = GetStrings2(""abc"")[1];
+        var str1 = this.GetStringFromNone()[0];
+        str1 = GetStringFromNone()[0];
+        var str2 = GetStringFromNone()[1];
+        var str3 = this.GetStringsFromString(""abc"");
+        str3 = GetStringsFromString(""abc"");
+        var str4 = GetStringsFromString(""abc"")[1];
+        var fromStr3 = GetMoreStringsFromString(""bc"")[1][0];
+        var explicitNoParameter = GetStringsFromAmbiguous()[0][1];
+        var usesParameter1 = GetStringsFromAmbiguous(0)[1][2];
     }
 
-    public string[] GetStrings()
+    public string[] GetStringFromNone()
     {
         return new string[] { ""A"", ""B"", ""C"" };
     }
 
-    public string[] GetStrings2(string parm)
+    public string[] GetStringsFromString(string parm)
     {
         return new string[] { ""1"", ""2"", ""3"" };
+    }
+
+    public string[][] GetMoreStringsFromString(string parm)
+    {
+        return new string[][] { new string[] { ""1"" } };
+    }
+
+    public string[][] GetStringsFromAmbiguous()
+    {
+        return new string[][] { new string[] { ""1"" } };
+    }
+
+    public string[][] GetStringsFromAmbiguous(int amb)
+    {
+        return new string[][] { new string[] { ""1"" } };
     }
 }");
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -574,6 +574,50 @@ End Class", @"public class A
         }
 
         [Fact]
+        public void MethodCallArrayIndexerBrackets()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class A
+  Public Sub Test()
+    Dim str1 = Me.GetStrings(0)
+    str1 = GetStrings(0)
+    Dim str2 = GetStrings()(1)
+    Dim str3 = Me.GetStrings2(""abc"")
+    str3 = GetStrings2(""abc"")
+    Dim str4 = GetStrings2(""abc"")(1)
+  End Sub
+
+  Function GetStrings() As String()
+    Return New String() { ""A"", ""B"", ""C""}
+  End Function
+
+  Function GetStrings2(parm As String) As String()
+    Return New String() { ""1"", ""2"", ""3""}
+  End Function
+End Class", @"public class A
+{
+    public void Test()
+    {
+        var str1 = this.GetStrings()[0];
+        str1 = GetStrings()[0];
+        var str2 = GetStrings()[1];
+        var str3 = this.GetStrings2(""abc"");
+        str3 = GetStrings2(""abc"");
+        var str4 = GetStrings2(""abc"")[1];
+    }
+
+    public string[] GetStrings()
+    {
+        return new string[] { ""A"", ""B"", ""C"" };
+    }
+
+    public string[] GetStrings2(string parm)
+    {
+        return new string[] { ""1"", ""2"", ""3"" };
+    }
+}");
+        }
+
+        [Fact]
         public void UnknownTypeInvocation()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using CodeConverter.Tests.TestRunners;
@@ -612,12 +613,39 @@ End Class", @"public class A
         Dim dict = New Dictionary(Of String, String) From {{""a"", ""AAA""}, {""b"", ""bbb""}}
         Dim v = dict?.Item(""a"")
     End Sub
-End Class", @"public class A
+End Class", @"using System.Collections.Generic;
+
+public class A
 {
     public void Test()
     {
         var dict = new Dictionary<string, string>() { { ""a"", ""AAA"" }, { ""b"", ""bbb"" } };
         var v = dict?[""a""];
+    }
+}");
+        }
+
+        [Fact]
+        public void IndexerWithParameter()
+        {
+            TestConversionVisualBasicToCSharp(@"Imports System.Data
+
+Public Class A
+    Public Function ReadDataSet(myData As DataSet) As String
+        With myData.Tables(0).Rows(0)
+            Return .Item(""MY_COLUMN_NAME"").ToString()
+        End With
+    End Function
+End Class", @"using System.Data;
+
+public class A
+{
+    public string ReadDataSet(DataSet myData)
+    {
+        {
+            var withBlock = myData.Tables[0].Rows[0];
+            return withBlock[""MY_COLUMN_NAME""].ToString();
+        }
     }
 }");
         }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -605,6 +605,24 @@ End Class", @"public class A
         }
 
         [Fact]
+        public void MethodCallDictionaryAccessConditional()
+        {
+            TestConversionVisualBasicToCSharp(@"Public Class A
+    Public Sub Test()
+        Dim dict = New Dictionary(Of String, String) From {{""a"", ""AAA""}, {""b"", ""bbb""}}
+        Dim v = dict?.Item(""a"")
+    End Sub
+End Class", @"public class A
+{
+    public void Test()
+    {
+        var dict = new Dictionary<string, string>() { { ""a"", ""AAA"" }, { ""b"", ""bbb"" } };
+        var v = dict?[""a""];
+    }
+}");
+        }
+
+        [Fact]
         public void MethodCallArrayIndexerBrackets()
         {
             TestConversionVisualBasicToCSharp(@"Public Class A

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -628,7 +628,8 @@ public class A
         [Fact]
         public void IndexerWithParameter()
         {
-            TestConversionVisualBasicToCSharp(@"Imports System.Data
+            //BUG Semicolon ends up on newline after comment instead of before it
+            TestConversionVisualBasicToCSharpWithoutComments(@"Imports System.Data
 
 Public Class A
     Public Function ReadDataSet(myData As DataSet) As String

--- a/Tests/CSharp/LinqExpressionTests.cs
+++ b/Tests/CSharp/LinqExpressionTests.cs
@@ -69,6 +69,11 @@ End Sub",
 End Class
 
 Class Test
+
+    Public Function GetProductList As Product()
+        Return Nothing
+    End Function
+
     Public Sub Linq102()
         Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
         Dim products As Product() = GetProductList()
@@ -90,6 +95,11 @@ class Product
 
 class Test
 {
+    public Product[] GetProductList()
+    {
+        return null;
+    }
+
     public void Linq102()
     {
         string[] categories = new string[] { ""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood"" };
@@ -107,32 +117,60 @@ class Test
         [Fact]
         public void Linq4()
         {
-            TestConversionVisualBasicToCSharp(@"Public Sub Linq103()
-    Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
-    Dim products = GetProductList()
-    Dim q = From c In categories Group Join p In products On c Equals p.Category Into ps = Group Select New With {Key .Category = c, Key .Products = ps}
+            TestConversionVisualBasicToCSharpWithoutComments(@"Class Product
+    Public Category As String
+    Public ProductName As String
+End Class
 
-    For Each v In q
-        Console.WriteLine(v.Category & "":"")
+Class Test
+    Public Function GetProductList As Product()
+        Return Nothing
+    End Function
 
-        For Each p In v.Products
-            Console.WriteLine(""   "" & p.ProductName)
+    Public Sub Linq103()
+        Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
+        Dim products = GetProductList()
+        Dim q = From c In categories Group Join p In products On c Equals p.Category Into ps = Group Select New With {Key .Category = c, Key .Products = ps}
+
+        For Each v In q
+            Console.WriteLine(v.Category & "":"")
+
+            For Each p In v.Products
+                Console.WriteLine(""   "" & p.ProductName)
+            Next
         Next
-    Next
-End Sub", @"public void Linq103()
+    End Sub
+End Class", @"using System;
+using System.Linq;
+
+class Product
 {
-    string[] categories = new string[] { ""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood"" };
-    var products = GetProductList();
-    var q = from c in categories
-            join p in products on c equals p.Category into ps
-            select new { Category = c, Products = ps };
+    public string Category;
+    public string ProductName;
+}
 
-    foreach (var v in q)
+class Test
+{
+    public Product[] GetProductList()
     {
-        Console.WriteLine(v.Category + "":"");
+        return null;
+    }
 
-        foreach (var p in v.Products)
-            Console.WriteLine(""   "" + p.ProductName);
+    public void Linq103()
+    {
+        string[] categories = new string[] { ""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood"" };
+        var products = GetProductList();
+        var q = from c in categories
+                join p in products on c equals p.Category into ps
+                select new { Category = c, Products = ps };
+
+        foreach (var v in q)
+        {
+            Console.WriteLine(v.Category + "":"");
+
+            foreach (var p in v.Products)
+                Console.WriteLine(""   "" + p.ProductName);
+        }
     }
 }");
         }

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -100,7 +100,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.6.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.2" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.6.1" />
     <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="15.0.81-pre" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.9.3032">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -87,18 +87,18 @@
       <Version>10.0.3</Version>
     </PackageReference>
     <PackageReference Include="ManagedEsent" Version="1.9.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.0">
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.6.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Elfie" Version="0.10.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.6.1" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.2" />
     <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="15.0.81-pre" />


### PR DESCRIPTION
### Problem

Issue #325 is rooted in the VB.NET language model, which parses (A) array element access as (B) method invocation. Because of this, difficulty of distinguishing between A and B, and rewriting the tree accordingly falls onto converter. 

### Solution
* Fixes #325
* Fixes #328
* Fixes #335 
Fix works upon existing tree rewrite mechanism of method invocation into array element access within VisitInvocationExpression routine. Logic was originally added to rewrite VB's imaginary member .Item() into array access. Issue #325 appears of similar nature. Proposed fix extends utility method  TryGetElementAccessExpressionToConvert with another expression rewrite candidate selection criteria, and lets existing rewrite logic complete the work.

* Added new test MethodCallArrayIndexerBrackets
* All tests pass, except 4 solution/project-related that were failing before 

