### PR TITLE
Override VisitXmlElement to support xml element conversion from vb to…

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -78,6 +78,23 @@ namespace ICSharpCode.CodeConverter.CSharp
                     .WithNodeInformation(node);
             }
 
+            public override CSharpSyntaxNode VisitXmlElement(VBSyntax.XmlElementSyntax node)
+            {
+                _extraUsingDirectives.Add("System.Xml.Linq");
+                var aggregatedContent = node.Content.Select(n => n.ToString()).Aggregate(string.Empty, (a, b) => a + b);
+                var xmlAsString = $"{node.StartTag}{aggregatedContent}{node.EndTag}".Trim();
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("XElement"),
+                        SyntaxFactory.IdentifierName("Parse")))
+                .WithArgumentList(
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(
+                            SyntaxFactory.Argument(
+                                SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(xmlAsString))))));
+            }
+
             public override CSharpSyntaxNode VisitGetTypeExpression(VBSyntax.GetTypeExpressionSyntax node)
             {
                 return SyntaxFactory.TypeOfExpression((TypeSyntax)node.Type.Accept(TriviaConvertingVisitor));

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -90,6 +90,26 @@ End Class", @"class TestClass
         }
 
         [Fact]
+        public void AssignmentStatementWithXmlElement()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod()
+        Dim b = <someXmlTag></someXmlTag>
+        Dim c = <someXmlTag><bla>tata</bla><someContent>tata</someContent></someXmlTag>
+    End Sub
+End Class", @"using System.Xml.Linq;
+
+class TestClass
+{
+    private void TestMethod()
+    {
+        var b = XElement.Parse(""<someXmlTag></someXmlTag>"");
+        var c = XElement.Parse(""<someXmlTag><bla>tata</bla><someContent>tata</someContent></someXmlTag>"");
+    }
+}");
+        }
+
+        [Fact]
         public void ObjectInitializationStatement()
         {
             TestConversionVisualBasicToCSharp(@"Class TestClass


### PR DESCRIPTION
Fixes #337 

### Problem
XmlElement literals conversion from VB to C# are not supported.

### Solution
* There is no such thing as xml element literals in C#, therefore I coded the following expression: XElement.Parse("someXml")

* [x] At least one test covering the code changed
* [x] All tests pass

