### PR TITLE
Change for issue #373. Multiple declaration with implicit type.

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             foreach (var name in declarator.Names) {
                 var declaredSymbol = _semanticModel.GetDeclaredSymbol(name);
                 var declaredSymbolType = declaredSymbol.GetSymbolType();
-                var requireExplicitType = requireExplicitTypeForAll || vbInitializerType != null && !Equals(declaredSymbolType, vbInitializerType);
+                var requireExplicitType = requireExplicitTypeForAll || vbInitializerType != null && !Equals(declaredSymbolType, vbInitializerType) || declarator.Names.Count>1 && name.SpanStart == declarator.SpanStart;
                 var csTypeSyntax = (TypeSyntax)GetTypeSyntax(declaredSymbolType);
 
                 bool isField = declarator.Parent.IsKind(SyntaxKind.FieldDeclaration);

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -927,7 +927,29 @@ internal partial class Test
     }
 }");
         }
+        [Fact]
+        public async Task DeclarationStatementTwoVariables()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(
+@"Class Test
+    Private Sub TestMethod()
+        Dim x, y As Date
+        Console.WriteLine(x)
+        Console.WriteLine(y)
+    End Sub
+End Class", @"using System;
 
+internal partial class Test
+{
+    private void TestMethod()
+    {
+        DateTime x = default(DateTime), y = default(DateTime);
+        Console.WriteLine(x);
+        Console.WriteLine(y);
+    }
+}");
+        }
+        
         [Theory]
         [InlineData("Sub", "", "void")]
         [InlineData("Function", " As Long", "long")]
@@ -1334,7 +1356,7 @@ End Class", @"internal partial class TestClass
 {
     private void TestMethod(int end)
     {
-        var b = default(int[]), s = default(int[]);
+        int[] b = default(int[]), s = default(int[]);
         for (int i = 0, loopTo = end; i <= loopTo; i++)
             b[i] = s[i];
     }
@@ -1410,7 +1432,7 @@ End Class", @"internal partial class TestClass
 {
     private void TestMethod(int end)
     {
-        var b = default(int[]), s = default(int[]);
+        int[] b = default(int[]), s = default(int[]);
         for (int i = 0, loopTo = end - 1; i <= loopTo; i++)
             b[i] = s[i];
     }


### PR DESCRIPTION
Link to issue(s) this covers
closes issue #373 .
### Problem
Current conversion uses var for declarations with multiple variables but C# issues message that multiple declaration requires an explicit type.

### Solution
I made a change in SplitVariableDeclarations to requireExplicitType for the first declaration when multiple declarations are involved.

Added test `DeclarationStatementTwoVariables` to confirm correction.  Modified two affected tests after confirming they conform to the same pattern.  Changed `ForWithBlock` and `ForWithSingleStatement`
* [X] At least one test covering the code changed
* [X] All tests pass

