### PR TITLE
Conversion for array index assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the code converter will be documented here.
 ### Vsix
 * Load extension only when menu item clicked (multi-project conversion menu not present until project loaded)
 
+### VB -> C#
+* Convert implicit object->string cast correctly (#365)
+
+### C# -> VB
+
+
 # 7.2.0 13/10/2019
 * Parallelize multi-file conversion
 * Make snippet conversion (ConvertText method) make classes partial by default since context isn't known (#379)

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -86,9 +86,8 @@ namespace ICSharpCode.CodeConverter.CSharp
         public TypeConversionKind AnalyzeConversion(Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax vbNode, bool alwaysExplicit = false)
         {
             var typeInfo = ModelExtensions.GetTypeInfo(_semanticModel, vbNode);
-            var vbType = typeInfo.Type; 
+            var vbType = typeInfo.Type;
             var vbConvertedType = typeInfo.ConvertedType;
-
             if (vbType is null || vbConvertedType is null)
             {
                 return TypeConversionKind.Unknown;
@@ -181,11 +180,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (vbConversion.IsNumeric && (vbType.IsEnumType() || vbConvertedType.IsEnumType())) {
                 return TypeConversionKind.NonDestructiveCast;
             }
-            //TODO: Conversion for implicit object to string conversion handle case vbTYpe="Error ?"
             if (alwaysExplicit) {
                 return vbConversion.IsNarrowing ? TypeConversionKind.NonDestructiveCast : TypeConversionKind.DestructiveCast;
             }
-       
 
             return TypeConversionKind.Unknown;
         }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -86,8 +86,9 @@ namespace ICSharpCode.CodeConverter.CSharp
         public TypeConversionKind AnalyzeConversion(Microsoft.CodeAnalysis.VisualBasic.Syntax.ExpressionSyntax vbNode, bool alwaysExplicit = false)
         {
             var typeInfo = ModelExtensions.GetTypeInfo(_semanticModel, vbNode);
-            var vbType = typeInfo.Type;
+            var vbType = typeInfo.Type; 
             var vbConvertedType = typeInfo.ConvertedType;
+
             if (vbType is null || vbConvertedType is null)
             {
                 return TypeConversionKind.Unknown;
@@ -177,10 +178,11 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (vbConversion.IsNumeric && (vbType.IsEnumType() || vbConvertedType.IsEnumType())) {
                 return TypeConversionKind.NonDestructiveCast;
             }
-
+            //TODO: Conversion for implicit object to string conversion handle case vbTYpe="Error ?"
             if (alwaysExplicit) {
                 return vbConversion.IsNarrowing ? TypeConversionKind.NonDestructiveCast : TypeConversionKind.DestructiveCast;
             }
+       
 
             return TypeConversionKind.Unknown;
         }

--- a/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -126,7 +126,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var csConversion = _csCompilation.ClassifyConversion(csType, csConvertedType);
 
             bool isConvertToString =
-                        vbConversion.IsString && vbConvertedType.SpecialType == SpecialType.System_String;
+                        (vbConversion.IsString || vbConversion.IsReference && vbConversion.IsNarrowing)  && vbConvertedType.SpecialType == SpecialType.System_String;
             bool isArithmetic = vbNode.IsKind(Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.AddExpression,
                 Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.SubtractExpression,
                 Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.MultiplyExpression,
@@ -162,6 +162,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                     typeConversionKind = TypeConversionKind.Conversion;
                     return true;
                 }
+            } else if (isConvertToString && vbType.SpecialType ==  SpecialType.System_Object) {
+                typeConversionKind = TypeConversionKind.Conversion;
+                return true;
             }
 
             typeConversionKind = TypeConversionKind.Unknown;

--- a/ICSharpCode.CodeConverter/Util/VisualBasicCompiler.cs
+++ b/ICSharpCode.CodeConverter/Util/VisualBasicCompiler.cs
@@ -55,6 +55,7 @@ namespace ICSharpCode.CodeConverter.Util
             var compilationOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithGlobalImports(GlobalImport.Parse(
                     "System",
+                    "System.Collections",
                     "System.Collections.Generic",
                     "System.Diagnostics",
                     "System.Globalization",

--- a/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
+++ b/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
@@ -38,7 +38,6 @@ End Class", @"internal partial class TestClass
     End Function
 
 End Class", @"public partial class Class1
-using System.Collections;
 {
     public void Foo()
     {
@@ -95,7 +94,6 @@ Public Class OutParameterWithNonCompilingType
         End If
     End Sub
 End Class", @"using System.Collections.Generic;
-using System.Collections;
 
 public partial class OutParameterWithMissingType
 {
@@ -163,7 +161,6 @@ public partial class OutParameterWithNonCompilingType
     End Function
 End Class",
 @"using Microsoft.VisualBasic;
-using System.Collections;
 using Microsoft.VisualBasic.CompilerServices;
 
 public partial class EnumAndValTest

--- a/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
+++ b/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
@@ -38,6 +38,7 @@ End Class", @"internal partial class TestClass
     End Function
 
 End Class", @"public partial class Class1
+using System.Collections;
 {
     public void Foo()
     {
@@ -94,6 +95,7 @@ Public Class OutParameterWithNonCompilingType
         End If
     End Sub
 End Class", @"using System.Collections.Generic;
+using System.Collections;
 
 public partial class OutParameterWithMissingType
 {
@@ -161,6 +163,7 @@ public partial class OutParameterWithNonCompilingType
     End Function
 End Class",
 @"using Microsoft.VisualBasic;
+using System.Collections;
 using Microsoft.VisualBasic.CompilerServices;
 
 public partial class EnumAndValTest

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -98,8 +98,31 @@ internal partial class Class1
         Dim xs(1) As String
 
         xs(0) = x(0)
+    End Sub
+End Class" + Environment.NewLine, @"using System.Collections;
+using Microsoft.VisualBasic.CompilerServices;
 
+internal partial class Class1
+{
+    private void Test()
+    {
+        var x = new ArrayList();
+        x.Add(""a"");
 
+        var xs = new string[2];
+
+        xs[0] = Conversions.ToString(x[0]);
+    }
+}" + Environment.NewLine);
+        }
+        [Fact]
+        public async Task ImplicitCastObjecStringToString()
+        {
+            await TestConversionVisualBasicToCSharp(
+@"Class Class1
+    Private Sub Test()
+        Dim o As Object = ""Test""
+        Dim s As String = o
     End Sub
 End Class" + Environment.NewLine, @"using Microsoft.VisualBasic.CompilerServices;
 
@@ -107,13 +130,9 @@ internal partial class Class1
 {
     private void Test()
     {
-        ArrayList x = new ArrayList();
-            x.Add(""a"");
-
-            string[] xs = new string[2];
-
-            xs[0] = Conversions.ToString(x[0]);
-        }
+        object o = ""Test"";
+        string s = Conversions.ToString(o);
+    }
 }" + Environment.NewLine);
         }
         [Fact]

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -66,7 +66,56 @@ internal partial class Class1
     }
 }" + Environment.NewLine);
         }
+        [Fact]
+        public async Task ImplicitCastObjectToString()
+        {
+            await TestConversionVisualBasicToCSharp(
+@"Class Class1
+    Private Sub Test()
+        Dim o As Object = ""Test""
+        Dim s As String = o
+    End Sub
+End Class" + Environment.NewLine, @"using Microsoft.VisualBasic.CompilerServices;
 
+internal partial class Class1
+{
+    private void Test()
+    {
+        object o = ""Test"";
+        string s = Conversions.ToString(o);
+    }
+}" + Environment.NewLine);
+        }
+        [Fact]
+        public async Task CastArrayListAssignmentToString()
+        {
+            await TestConversionVisualBasicToCSharp(
+@"Class Class1
+    Private Sub Test()
+        Dim x As New ArrayList
+        x.Add(""a"")
+
+        Dim xs(1) As String
+
+        xs(0) = x(0)
+
+
+    End Sub
+End Class" + Environment.NewLine, @"using Microsoft.VisualBasic.CompilerServices;
+
+internal partial class Class1
+{
+    private void Test()
+    {
+        ArrayList x = new ArrayList();
+            x.Add(""a"");
+
+            string[] xs = new string[2];
+
+            xs[0] = Conversions.ToString(x[0]);
+        }
+}" + Environment.NewLine);
+        }
         [Fact]
         public async Task CTypeDoubleToInt()
         {


### PR DESCRIPTION
Link to issue(s) this covers
Closes Issue #365 
### Problem
Narrowing conversion from Object to string needed explicit ToString conversion added.

### Solution
* Added System.Collections to compilation options.  In second commit.  Can do separate PR if needed.
* Changed test to var declaration in C# instead of string declaration because it appears the converter prefers the var declaration.
* Added test case for simple object to string and more complex ListArray to string array assignment.

