### PR TITLE
VB -> C#: Fix implicit `ElementAtOrDefault` usage [#362]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the code converter will be documented here.
 * Convert trivia (e.g. comments) at start of file (#333)
 * Improvements to redim conversion (#403, #393)
 * Convert array of arrays initializer (#364)
+* Convert implicit `ElementAtOrDefault` (#362)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -651,7 +651,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return await CreateElementAccess();
             }
 
-            if (expressionSymbol != null && expressionSymbol.IsKind(SymbolKind.Property)) {
+            if (expressionSymbol != null && expressionSymbol.IsKind(SymbolKind.Property) && invocationSymbol.GetParameters().Length == 0) {
                 return convertedExpression; //Parameterless property access
             }
 

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -136,6 +136,33 @@ End Class", @"internal partial class TestClass
         }
 
         [Fact]
+        public async Task DictionaryIndexingIssue362()
+        {
+            await TestConversionVisualBasicToCSharp(@"Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Module1
+    Dim Dict As New Dictionary(Of Integer, String)
+
+    Sub Main()
+        Dim x = Dict.Values(0).Length
+    End Sub
+End Module", @"using System.Collections.Generic;
+using System.Linq;
+
+internal static partial class Module1
+{
+    private static Dictionary<int, string> Dict = new Dictionary<int, string>();
+
+    public static void Main()
+    {
+        int x = Dict.Values.ElementAtOrDefault(0).Length;
+    }
+}");
+        }
+
+        [Fact]
         public async Task DateLiterals()
         {
             await TestConversionVisualBasicToCSharp(@"Class TestClass


### PR DESCRIPTION
Ensure parameterless property access short-circuit only happens when there are no parameters. This allows the existing code for `ElementAtOrDefault` to be triggered correctly.

Fixes #362

### Problem

The shortcut for property access caused the `ElementAtOrDefault` handling to not trigger.

### Solution

Checking the parameter length first allows this to work as expected.

* [x] At least one test covering the code changed

