### PR TITLE
VB -> C#: Convert constant values correctly [#329]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the code converter will be documented here.
 * Convert trivia (e.g. comments) at start of file (#333)
 * Improvements to redim conversion (#403, #393)
 * Convert array of arrays initializer (#364)
+* Convert expressions in constants correctly (#329)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -112,13 +112,15 @@ namespace ICSharpCode.CodeConverter.CSharp
             var csTypeSyntax = GetTypeSyntax(declaredSymbolType);
 
             bool isField = vbDeclarator.Parent.IsKind(SyntaxKind.FieldDeclaration);
+            bool isConst = declaredSymbol is IFieldSymbol fieldSymbol && fieldSymbol.IsConst ||
+                           declaredSymbol is ILocalSymbol localSymbol && localSymbol.IsConst;
 
             EqualsValueClauseSyntax equalsValueClauseSyntax;
             if (await GetInitializerFromNameAndType(declaredSymbolType, vbName, initializerOrMethodDecl) is ExpressionSyntax
                 adjustedInitializerExpr)
             {
                 var convertedInitializer = vbInitValue != null
-                    ? TypeConversionAnalyzer.AddExplicitConversion(vbInitValue, adjustedInitializerExpr)
+                    ? TypeConversionAnalyzer.AddExplicitConversion(vbInitValue, adjustedInitializerExpr, isConst: isConst)
                     : adjustedInitializerExpr;
                 equalsValueClauseSyntax = SyntaxFactory.EqualsValueClause(convertedInitializer);
             }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -1954,6 +1954,53 @@ public partial class test
         }
 
         [Fact]
+        public async Task ConstLiteralConversionIssue329()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(
+                @"Module Module1
+    Const a As Boolean = 1
+    Const b As Char = ChrW(1)
+    Const c As Single = 1
+    Const d As Double = 1
+    Const e As Decimal = 1
+    Const f As SByte = 1
+    Const g As Short = 1
+    Const h As Integer = 1
+    Const i As Long = 1
+    Const j As Byte = 1
+    Const k As UInteger = 1
+    Const l As UShort = 1
+    Const m As ULong = 1
+
+    Sub Main()
+        Const x As SByte = 4
+    End Sub
+End Module", @"internal static partial class Module1
+{
+    private const bool a = true;
+    private const char b = (char)1;
+    private const float c = 1;
+    private const double d = 1;
+    private const decimal e = 1;
+    private const sbyte f = 1;
+    private const short g = 1;
+    private const int h = 1;
+    private const long i = 1;
+    private const byte j = 1;
+    private const uint k = 1;
+    private const ushort l = 1;
+    private const ulong m = 1;
+
+    public static void Main()
+    {
+        const sbyte x = 4;
+    }
+}
+");
+        }
+
+
+        [Fact]
         public async Task StringInterpolationWithConditionalOperator()
         {
             await TestConversionVisualBasicToCSharpWithoutComments(


### PR DESCRIPTION
Add explicit handling for conversion of constant values, since we cannot
directly call the conversion functions at runtime.

Fixes #329

### Problem

Constant values that require conversions would lead to code which fails when converted to C#.

### Solution

Add explicit handling for constant values - call the relevant `Conversions.ToXXX()` method at conversion time, rather than making a runtime call. I couldn't find a Roslyn API for doing this with less code - if there is one I'd be happy to change it.

* [x] At least one test covering the code changed

