### PR TITLE
Convert short literals in ternary expressions [#363]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the code converter will be documented here.
 * Improvements to implicit enum -> int conversion (#361)
 * Convert expressions in constants (#329)
 * Convert implicit `ElementAtOrDefault` (#362)
+* Convert types in ternary expressions (#363)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -43,7 +43,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         private uint _failedMemberConversionMarkerCount;
         private readonly HashSet<string> _extraUsingDirectives = new HashSet<string>();
         private readonly VisualBasicEqualityComparison _visualBasicEqualityComparison;
-        private static HashSet<string> _accessedThroughMyClass;
+        private HashSet<string> _accessedThroughMyClass;
         public CommentConvertingNodesVisitor TriviaConvertingVisitor { get; }
         private readonly CommentConvertingVisitorWrapper<CSharpSyntaxNode> _triviaConvertingExpressionVisitor;
         private readonly ExpressionNodeVisitor _expressionNodeVisitor;
@@ -837,7 +837,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return SyntaxFactory.Block(await statements.SelectManyAsync(async s => (IEnumerable<StatementSyntax>) await s.Accept(methodBodyVisitor)));
         }
 
-        private static bool IsAccessedThroughMyClass(SyntaxNode node, SyntaxToken identifier, ISymbol symbolOrNull)
+        private bool IsAccessedThroughMyClass(SyntaxNode node, SyntaxToken identifier, ISymbol symbolOrNull)
         {
             bool accessedThroughMyClass = false;
             if (symbolOrNull != null && symbolOrNull.IsVirtual && !symbolOrNull.IsAbstract) {

--- a/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -478,11 +478,16 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public override async Task<CSharpSyntaxNode> VisitTernaryConditionalExpression(VBasic.Syntax.TernaryConditionalExpressionSyntax node)
         {
-            var expr = SyntaxFactory.ConditionalExpression(
-                (ExpressionSyntax) await node.Condition.AcceptAsync(TriviaConvertingVisitor),
-                (ExpressionSyntax) await node.WhenTrue.AcceptAsync(TriviaConvertingVisitor),
-                (ExpressionSyntax) await node.WhenFalse.AcceptAsync(TriviaConvertingVisitor)
-            );
+            var condition = (ExpressionSyntax)await node.Condition.AcceptAsync(TriviaConvertingVisitor);
+
+            var whenTrue = (ExpressionSyntax)await node.WhenTrue.AcceptAsync(TriviaConvertingVisitor);
+            whenTrue = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.WhenTrue, whenTrue);
+
+            var whenFalse = (ExpressionSyntax)await node.WhenFalse.AcceptAsync(TriviaConvertingVisitor);
+            whenFalse = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.WhenFalse, whenFalse);
+
+            var expr = SyntaxFactory.ConditionalExpression(condition, whenTrue, whenFalse);
+
 
             if (node.Parent.IsKind(VBasic.SyntaxKind.Interpolation) || VbSyntaxNodeExtensions.PrecedenceCouldChange(node))
                 return SyntaxFactory.ParenthesizedExpression(expr);

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -2198,6 +2198,25 @@ End Class", @"public partial class Class1
         }
 
         [Fact]
+        public async Task TernaryConversionIssue363()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(@"Module Module1
+    Sub Main()
+        Dim x As Short = If(True, CShort(50), 100S)
+    End Sub
+End Module", @"using Microsoft.VisualBasic.CompilerServices;
+
+internal static partial class Module1
+{
+    public static void Main()
+    {
+        short x = true ? Conversions.ToShort(50) : Conversions.ToShort(100);
+    }
+}
+");
+        }
+
+        [Fact]
         public async Task MemberAccessCasing()
         {
             await TestConversionVisualBasicToCSharpWithoutComments(@"Public Class Class1


### PR DESCRIPTION
 * Add explicit conversions for both branches of a ternary expression
 * Add conversions for short literals

Fixes #363

### Problem

Short literals in ternary expressions were not converted.

### Solution

There were a couple of things here - we need to add conversions for each branch of the ternary opeartor. We could probably be more clever about this, but just adding the conversion is easy enough.

The other thing is the conversion of VB short literals. I added a case to the conversion analysis code to handle this - another (more invasive) approach would be to add an explicit case whenever we convert a VB literal that has an explicit suffix.

* [x] At least one test covering the code changed

