### PR TITLE
VB -> C#: Duplicate cases Should be Discarded

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -553,7 +553,6 @@ namespace ICSharpCode.CodeConverter.CSharp
             var exprWithoutTrivia = expr.WithoutTrivia().WithoutAnnotations();
             var usedConstantValues = new HashSet<object>();
             var sections = new List<SwitchSectionSyntax>();
-            var cases = new List<String>();
             foreach (var block in node.CaseBlocks) {
                 var labels = new List<SwitchLabelSyntax>();
                 foreach (var c in block.CaseStatement.Cases) {

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -597,7 +597,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                     //Else write comment to code?
                     var lastCase = sections.Last();
                     sections.Remove(lastCase);
-                    lastCase = lastCase.WithCsTrailingWarningComment(block, new NotSupportedException("Duplicate Case label commented out"));
+                    lastCase = lastCase.WithCsTrailingWarningComment("Unreachable case label","This case was not executable prior to code conversion, but is preserved here in case it helps troubleshoot a bug", SyntaxFactory.SwitchSection(SyntaxFactory.List(labels), list));
                     sections.Add(lastCase);
                 }
             }

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -553,7 +553,6 @@ namespace ICSharpCode.CodeConverter.CSharp
             var exprWithoutTrivia = expr.WithoutTrivia().WithoutAnnotations();
             var sections = new List<SwitchSectionSyntax>();
             var cases = new List<String>();
-            var emptyCodeList = SingleStatement(SyntaxFactory.BreakStatement()); ;
             foreach (var block in node.CaseBlocks) {
                 var labels = new List<SwitchLabelSyntax>();
                 foreach (var c in block.CaseStatement.Cases) {
@@ -589,11 +588,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                     csBlockStatements.Add(SyntaxFactory.BreakStatement());
                 }
                 var list = SingleStatement(SyntaxFactory.Block(csBlockStatements));
-                var newSectionNoCode = SyntaxFactory.SwitchSection(SyntaxFactory.List(labels), emptyCodeList);
-                var curNodeDesc = newSectionNoCode.ToFullString();
-                var numMatch = cases.Count(c => c == curNodeDesc);
+                var labelDesc = string.Join(" ", labels.Select(l => l.ToFullString()));
+                var numMatch = cases.Count(c => c == labelDesc);
                 if (numMatch == 0) {
-                    cases.Add(curNodeDesc);
+                    cases.Add(labelDesc);
                     sections.Add(SyntaxFactory.SwitchSection(SyntaxFactory.List(labels), list));
                 } else {
                     //Else write comment to code?

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -570,11 +570,6 @@ namespace ICSharpCode.CodeConverter.CSharp
                              typeConversionKind != TypeConversionAnalyzer.TypeConversionKind.Identity)) {
                             caseSwitchLabelSyntax =
                                 WrapInCasePatternSwitchLabelSyntax(node, expressionSyntax);
-                            if (isRepeatedConstantValue) {
-                                caseSwitchLabelSyntax = caseSwitchLabelSyntax.WithLeadingTrivia(
-                                    SyntaxFactory.ParseLeadingTrivia(
-                                        $"#warning This case was not executable prior to code conversion, but is preserved here in case it helps troubleshoot a bug{Environment.NewLine}"));
-                            }
                         }
                         labels.Add(caseSwitchLabelSyntax);
                     } else if (c is VBSyntax.ElseCaseClauseSyntax) {

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -1540,6 +1540,20 @@ namespace ICSharpCode.CodeConverter.Util
                 .WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.ConversionErrorAnnotationKind, exception.ToString()));
         }
 
+        public static T WithCsTrailingWarningComment<T>(this T dummyDestNode,
+            VisualBasicSyntaxNode sourceNode,
+            Exception exception) where T : CSharpSyntaxNode
+        {
+            var errorDirective = SyntaxFactory.ParseTrailingTrivia($"#warning Cannot convert {sourceNode.GetType().Name} - see comment for details{Environment.NewLine}");
+            var errorDescription = sourceNode.DescribeConversionError(exception);
+            var commentedText = "/* " + errorDescription + " */";
+            var trailingTrivia = SyntaxFactory.TriviaList(errorDirective.Concat(SyntaxFactory.Comment(commentedText)));
+
+            return dummyDestNode
+                .WithTrailingTrivia(trailingTrivia)
+                .WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.ConversionErrorAnnotationKind, exception.ToString()));
+        }
+
         public static T WithVbTrailingErrorComment<T>(
             this T dummyDestNode, CSharpSyntaxNode problematicSourceNode, Exception exception) where T : VisualBasicSyntaxNode
         {

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -219,7 +219,7 @@ namespace ICSharpCode.CodeConverter.Util
 
         /// <summary>
         /// create a new root node from the given root after adding annotations to the tokens
-        /// 
+        ///
         /// tokens should belong to the given root
         /// </summary>
         public static SyntaxNode AddAnnotations(this SyntaxNode root, IEnumerable<Tuple<SyntaxToken, SyntaxAnnotation>> pairs)
@@ -233,7 +233,7 @@ namespace ICSharpCode.CodeConverter.Util
 
         /// <summary>
         /// create a new root node from the given root after adding annotations to the nodes
-        /// 
+        ///
         /// nodes should belong to the given root
         /// </summary>
         public static SyntaxNode AddAnnotations(this SyntaxNode root, IEnumerable<Tuple<SyntaxNode, SyntaxAnnotation>> pairs)
@@ -1516,7 +1516,7 @@ namespace ICSharpCode.CodeConverter.Util
         public static string DescribeConversionError(this SyntaxNode node, Exception e)
         {
             return $"Cannot convert {node.GetType().Name}, {e}{Environment.NewLine}{Environment.NewLine}" +
-                $"Input: {Environment.NewLine}{node.ToFullString()}{Environment.NewLine}";
+                $"Input:{Environment.NewLine}{node.ToFullString()}{Environment.NewLine}";
         }
 
         private static string Truncate(this string input, int maxLength = 30, string truncationIndicator = "...")

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -1550,10 +1550,10 @@ namespace ICSharpCode.CodeConverter.Util
             CSharpSyntaxNode convertedNode
             ) where T : CSharpSyntaxNode
         {
-            var errorDirective = SyntaxFactory.ParseTrailingTrivia($"#warning {warning}{Environment.NewLine}");
-            var errorDescription = convertedNode.DescribeConversionWarning(addtlInfo);
-            var commentedText = "/* " + errorDescription + " */";
-            var trailingTrivia = SyntaxFactory.TriviaList(errorDirective.Concat(SyntaxFactory.Comment(commentedText)));
+            var warningDirective = SyntaxFactory.ParseTrailingTrivia($"#warning {warning}{Environment.NewLine}");
+            var warningDescription = convertedNode.DescribeConversionWarning(addtlInfo);
+            var commentedText = "/* " + warningDescription + " */";
+            var trailingTrivia = SyntaxFactory.TriviaList(warningDirective.Concat(SyntaxFactory.Comment(commentedText)));
 
             return dummyDestNode
                 .WithTrailingTrivia(trailingTrivia);

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -1519,6 +1519,12 @@ namespace ICSharpCode.CodeConverter.Util
                 $"Input:{Environment.NewLine}{node.ToFullString()}{Environment.NewLine}";
         }
 
+        public static string DescribeConversionWarning(this SyntaxNode node, string addtlInfo)
+        {
+            return $"{addtlInfo}{Environment.NewLine}" +
+                $"{node.NormalizeWhitespace().ToFullString()}{Environment.NewLine}";
+        }
+
         private static string Truncate(this string input, int maxLength = 30, string truncationIndicator = "...")
         {
             input = input.Replace(Environment.NewLine, "\\r\\n").Replace("    ", " ").Replace("\t", " ");
@@ -1540,18 +1546,17 @@ namespace ICSharpCode.CodeConverter.Util
                 .WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.ConversionErrorAnnotationKind, exception.ToString()));
         }
 
-        public static T WithCsTrailingWarningComment<T>(this T dummyDestNode,
-            VisualBasicSyntaxNode sourceNode,
-            Exception exception) where T : CSharpSyntaxNode
+        public static T WithCsTrailingWarningComment<T>(this T dummyDestNode, string warning, string addtlInfo,
+            CSharpSyntaxNode convertedNode
+            ) where T : CSharpSyntaxNode
         {
-            var errorDirective = SyntaxFactory.ParseTrailingTrivia($"#warning Cannot convert {sourceNode.GetType().Name} - see comment for details{Environment.NewLine}");
-            var errorDescription = sourceNode.DescribeConversionError(exception);
+            var errorDirective = SyntaxFactory.ParseTrailingTrivia($"#warning {warning}{Environment.NewLine}");
+            var errorDescription = convertedNode.DescribeConversionWarning(addtlInfo);
             var commentedText = "/* " + errorDescription + " */";
             var trailingTrivia = SyntaxFactory.TriviaList(errorDirective.Concat(SyntaxFactory.Comment(commentedText)));
 
             return dummyDestNode
-                .WithTrailingTrivia(trailingTrivia)
-                .WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.ConversionErrorAnnotationKind, exception.ToString()));
+                .WithTrailingTrivia(trailingTrivia);
         }
 
         public static T WithVbTrailingErrorComment<T>(

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -545,7 +545,49 @@ End Class",
 }");
         }
 
+        [Fact]
+        public async Task DuplicateCaseDiscarded()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(@"Imports System
+    Friend Module Module1
+    Sub Main()
+        Select Case 1
+            Case 1
+                Console.WriteLine(""a"")
 
+            Case 1
+                Console.WriteLine(""b"")
+
+        End Select
+
+    End Sub
+End Module",
+@"using System;
+
+internal static partial class Module1
+{
+    public static void Main()
+    {
+        switch (1)
+        {
+            case 1:
+                {
+                    Console.WriteLine(""a"");
+                    break;
+                }
+#warning Cannot convert CaseBlockSyntax - see comment for details
+                /* Cannot convert CaseBlockSyntax, System.NotSupportedException: Duplicate Case label commented out
+
+                Input:
+
+                            Case 1
+                                Console.WriteLine(""b"")
+
+                 */
+        }
+    }
+}");
+        }
         [Fact]
         public async Task MethodCallWithoutParens()
         {

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -575,14 +575,13 @@ internal static partial class Module1
                     Console.WriteLine(""a"");
                     break;
                 }
-#warning Cannot convert CaseBlockSyntax - see comment for details
-                /* Cannot convert CaseBlockSyntax, System.NotSupportedException: Duplicate Case label commented out
-
-                Input:
-
-                            Case 1
-                                Console.WriteLine(""b"")
-
+#warning Unreachable case label
+                /* This case was not executable prior to code conversion, but is preserved here in case it helps troubleshoot a bug
+                case 1:
+                {
+                    Console.WriteLine(""b"");
+                    break;
+                }
                  */
         }
     }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -575,14 +575,12 @@ internal static partial class Module1
                     Console.WriteLine(""a"");
                     break;
                 }
-#warning Unreachable case label
-                /* This case was not executable prior to code conversion, but is preserved here in case it helps troubleshoot a bug
-                case 1:
+
+            case var @case when @case == 1:
                 {
                     Console.WriteLine(""b"");
                     break;
                 }
-                 */
         }
     }
 }");


### PR DESCRIPTION
Link to issue(s) this covers
this fixes #374.
### Problem
Duplicate case statements resulted in compile error

### Solution
* Added warning stating the case was unreachable.  Display converted code to aid in debugging if needed.
* Instead of hard coding this message I added extensions like the `WithCsTrailingErrorComment` and `DescribeConversionError`
* [x] At least one test covering the code changed



