### PR TITLE
Prefer renamed imports for symbol resolution [#401]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the code converter will be documented here.
 * Convert types in ternary expressions (#363)
 * Support for converting dot net standard VB projects (#398)
 * Avoid compilation error for duplicate cases (#374)
+* Prefer renamed imports for name resolution (#401)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -99,8 +99,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 .SelectAsync(async c => (UsingDirectiveSyntax) await c.Accept(TriviaConvertingVisitor));
             var usingDirectiveSyntax = usings
                 .Concat(_extraUsingDirectives.Select(u => SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(u))))
-                .GroupBy(u => u.ToString())
-                .Select(g => g.First());
+                .GroupBy(u => u.Name.ToString())
+                .Select(g => g.OrderBy(v => !string.IsNullOrEmpty(v.Alias?.ToString()) ? 0 : 1).First());
 
             return SyntaxFactory.CompilationUnit(
                 SyntaxFactory.List<ExternAliasDirectiveSyntax>(),

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -2281,5 +2281,23 @@ End Class", @"public partial class Class1
 }");
         }
 
+        [Fact]
+        public async Task AliasedImportsWithTypePromotionIssue401()
+        {
+            await TestConversionVisualBasicToCSharp(
+                @"Imports VB = Microsoft.VisualBasic
+
+Public Class Test
+    Private aliased As String = VB.Left(""SomeText"", 1)
+End Class",
+                @"using VB = Microsoft.VisualBasic;
+
+public partial class Test
+{
+    private string aliased = VB.Strings.Left(""SomeText"", 1);
+}");
+        }
+
+
     }
 }


### PR DESCRIPTION
Fixes #401 

### Problem

Renamed imports are removed when they match an import that's added automatically.

### Solution

If there are multiple imports of the same namespace, prefer the import with an alias, and use that for name resolution.

* [x] At least one test covering the code changed

