### PR TITLE
Ensure casing matches for namespaces [#421]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the code converter will be documented here.
 * Prefer renamed imports for name resolution (#401)
 * Correctly convert ambiguous names (#332)
 * Ensure correct visibility for constructors (#422)
+* Ensure casing is correct for namespaces (#421)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -170,6 +170,11 @@ namespace ICSharpCode.CodeConverter.CSharp
             return WithDeclarationCasing(syntax, typeSymbol);
         }
 
+        /// <summary>
+        /// Semantic model merges the symbols, but the compiled form retains multiple namespaces, which (when referenced from C#) need to keep the correct casing.
+        /// <seealso cref="DeclarationNodeVisitor.WithDeclarationCasing(VBSyntax.NamespaceBlockSyntax, ISymbol)"/>
+        /// <seealso cref="CommonConversions.WithDeclarationCasing(SyntaxToken, ISymbol, string)"/>
+        /// </summary>
         private static TypeSyntax WithDeclarationCasing(TypeSyntax syntax, ITypeSymbol typeSymbol)
         {
             var vbType = SyntaxFactory.ParseTypeName(typeSymbol.ToDisplayString());
@@ -256,6 +261,11 @@ namespace ICSharpCode.CodeConverter.CSharp
             return CsEscapedIdentifier(text);
         }
 
+        /// <summary>
+        /// Semantic model merges the symbols, but the compiled form retains multiple namespaces, which (when referenced from C#) need to keep the correct casing.
+        /// <seealso cref="DeclarationNodeVisitor.WithDeclarationCasing(VBSyntax.NamespaceBlockSyntax, ISymbol)"/>
+        /// <seealso cref="CommonConversions.WithDeclarationCasing(TypeSyntax, ITypeSymbol)"/>
+        /// </summary>
         private static string WithDeclarationCasing(SyntaxToken id, ISymbol symbol, string text)
         {
             bool isDeclaration = symbol.Locations.Any(l => l.SourceSpan == id.Span);

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -165,16 +165,21 @@ namespace ICSharpCode.CodeConverter.CSharp
         public TypeSyntax GetTypeSyntax(ITypeSymbol typeSymbol, bool useImplicitType = false)
         {
             if (useImplicitType || typeSymbol == null) return CreateVarTypeName();
-            var vbType = SyntaxFactory.ParseTypeName(typeSymbol.ToDisplayString());
-            var originalNames = vbType.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>().Select(i => i.ToString()).ToList();
-            var syntax = (TypeSyntax) CsSyntaxGenerator.TypeExpression(typeSymbol);
+            var syntax = (TypeSyntax)CsSyntaxGenerator.TypeExpression(typeSymbol);
 
-            return syntax.ReplaceNodes(syntax.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>(), (oldNode, n) => {
-                var originalName = originalNames.Where(on => string.Equals(on, oldNode.ToString(), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                if (originalName != null) {
-                    return SyntaxFactory.IdentifierName(originalName);
-                }
-                return oldNode;
+            return WithDeclarationCasing(syntax, typeSymbol);
+        }
+
+        private static TypeSyntax WithDeclarationCasing(TypeSyntax syntax, ITypeSymbol typeSymbol)
+        {
+            var vbType = SyntaxFactory.ParseTypeName(typeSymbol.ToDisplayString());
+            var originalNames = vbType.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>()
+                .Select(i => i.ToString()).ToList();
+
+            return syntax.ReplaceNodes(syntax.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>(), (oldNode, n) =>
+            {
+                var originalName = originalNames.FirstOrDefault(on => string.Equals(@on, oldNode.ToString(), StringComparison.OrdinalIgnoreCase));
+                return originalName != null ? SyntaxFactory.IdentifierName(originalName) : oldNode;
             });
         }
 

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -246,7 +246,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         text = propertyFieldSymbol.AssociatedSymbol.Name;
                     } else if (text.EndsWith("Event", StringComparison.OrdinalIgnoreCase) && idSymbol is IFieldSymbol eventFieldSymbol && eventFieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Event) == true) {
                         text = eventFieldSymbol.AssociatedSymbol.Name;
-                    } else if (MustInlinePropertyWithEventsAccess(id.Parent, baseSymbol)) {
+                    } else if (MustInlinePropertyWithEventsAccess(id.Parent, idSymbol)) {
                         // For C# Winforms designer, we need to use direct field access (and inline any event handlers)
                         text = "_" + text;
                     }

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -242,7 +242,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                         text = idSymbol.ContainingType.Name;
                         if (text.EndsWith("Attribute", StringComparison.OrdinalIgnoreCase))
                             text = text.Remove(text.Length - "Attribute".Length);
-                    } else if (idSymbol.IsKind(SymbolKind.Parameter) && idSymbol.ContainingSymbol.IsAccessorPropertySet() && ((idSymbol.IsImplicitlyDeclared && idSymbol.Name == "Value") || idSymbol.ContainingSymbol.GetParameters().FirstOrDefault(x => !x.IsImplicitlyDeclared).Equals(idSymbol))) {
+                    } else if (idSymbol.IsKind(SymbolKind.Parameter) && idSymbol.ContainingSymbol.IsAccessorPropertySet() && ((idSymbol.IsImplicitlyDeclared && idSymbol.Name == "Value") || idSymbol.Equals(idSymbol.ContainingSymbol.GetParameters().FirstOrDefault(x => !x.IsImplicitlyDeclared)))) {
                         // The case above is basically that if the symbol is a parameter, and the corresponding definition is a property set definition
                         // AND the first explicitly declared parameter is this symbol, we need to replace it with value.
                         text = "value";

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -165,7 +165,17 @@ namespace ICSharpCode.CodeConverter.CSharp
         public TypeSyntax GetTypeSyntax(ITypeSymbol typeSymbol, bool useImplicitType = false)
         {
             if (useImplicitType || typeSymbol == null) return CreateVarTypeName();
-            return (TypeSyntax) CsSyntaxGenerator.TypeExpression(typeSymbol);
+            var vbType = SyntaxFactory.ParseTypeName(typeSymbol.ToDisplayString());
+            var originalNames = vbType.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>().Select(i => i.ToString()).ToList();
+            var syntax = (TypeSyntax) CsSyntaxGenerator.TypeExpression(typeSymbol);
+
+            return syntax.ReplaceNodes(syntax.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>(), (oldNode, n) => {
+                var originalName = originalNames.Where(on => string.Equals(on, oldNode.ToString(), StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                if (originalName != null) {
+                    return SyntaxFactory.IdentifierName(originalName);
+                }
+                return oldNode;
+            });
         }
 
         private static TypeSyntax CreateVarTypeName()
@@ -216,7 +226,8 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (id.SyntaxTree == _semanticModel.SyntaxTree) {
                 var symbol = _semanticModel.GetSymbolInfo(id.Parent).Symbol;
                 if (symbol != null && !String.IsNullOrWhiteSpace(symbol.Name)) {
-                    if (text.Equals(symbol.Name, StringComparison.OrdinalIgnoreCase)) {
+                    bool isDeclaration = symbol.Locations.Any(l => l.SourceSpan == id.Span);
+                    if (!isDeclaration && text.Equals(symbol.Name, StringComparison.OrdinalIgnoreCase)) {
                         text = symbol.Name;
                     }
 

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -166,7 +166,6 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var sourceName = (await node.NamespaceStatement.Name.AcceptAsync(_triviaConvertingExpressionVisitor)).ToString();
             var namespaceToDeclare = sym?.ToDisplayString() ?? sourceName;
-            // TODO Check what happenes with namespaces such as Y.XY.Y
             int lastIndex = namespaceToDeclare.LastIndexOf(sourceName, StringComparison.OrdinalIgnoreCase);
             if (lastIndex >= 0 && lastIndex + sourceName.Length == namespaceToDeclare.Length)
             {

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -146,7 +146,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var members = (await node.Members.SelectAsync(ConvertMember)).Where(m => m != null);
             var sym = _semanticModel.GetDeclaredSymbol(node);
-            string namespaceToDeclare = await WithDeclaredCasing(node, sym);
+            string namespaceToDeclare = await WithDeclarationCasing(node, sym);
             var parentNamespaceSyntax = node.GetAncestor<VBSyntax.NamespaceBlockSyntax>();
             var parentNamespaceDecl = parentNamespaceSyntax != null ? _semanticModel.GetDeclaredSymbol(parentNamespaceSyntax) : null;
             var parentNamespaceFullName = parentNamespaceDecl?.ToDisplayString() ?? _topAncestorNamespace;
@@ -157,7 +157,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             return cSharpSyntaxNode;
         }
 
-        private async Task<string> WithDeclaredCasing(VBSyntax.NamespaceBlockSyntax node, ISymbol sym)
+        /// <summary>
+        /// Semantic model merges the symbols, but the compiled form retains multiple namespaces, which (when referenced from C#) need to keep the correct casing.
+        /// <seealso cref="CommonConversions.WithDeclarationCasing(TypeSyntax, ITypeSymbol)"/>
+        /// <seealso cref="CommonConversions.WithDeclarationCasing(SyntaxToken, ISymbol, string)"/>
+        /// </summary>
+        private async Task<string> WithDeclarationCasing(VBSyntax.NamespaceBlockSyntax node, ISymbol sym)
         {
             var sourceName = (await node.NamespaceStatement.Name.AcceptAsync(_triviaConvertingExpressionVisitor)).ToString();
             var namespaceToDeclare = sym?.ToDisplayString() ?? sourceName;

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -166,6 +166,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var sourceName = (await node.NamespaceStatement.Name.AcceptAsync(_triviaConvertingExpressionVisitor)).ToString();
             var namespaceToDeclare = sym?.ToDisplayString() ?? sourceName;
+            // TODO Check what happenes with namespaces such as Y.XY.Y
             int lastIndex = namespaceToDeclare.LastIndexOf(sourceName, StringComparison.OrdinalIgnoreCase);
             if (lastIndex >= 0 && lastIndex + sourceName.Length == namespaceToDeclare.Length)
             {

--- a/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -283,7 +283,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (left == null && nodeSymbol?.IsStatic == true) {
                 var type = nodeSymbol.ContainingType;
                 var expressionSymbolInfo = _semanticModel.GetSymbolInfo(node.Expression);
-                if (type != null && !expressionSymbolInfo.Symbol.IsType()) {
+                if (type != null) {
                     left = CommonConversions.GetTypeSyntax(type);
                 }
             }

--- a/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
+++ b/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
@@ -1,0 +1,46 @@
+Imports Xunit
+
+Namespace [Aaa]
+    Friend Class A
+    End Class
+
+    Partial Class Z
+    End Class
+    Partial Class z
+    End Class
+
+    MustInherit Class Base
+        MustOverride Sub UPPER()
+        MustOverride Property FOO As Boolean
+    End Class
+    Class NotBase
+        Inherits Base
+
+        Public Overrides Sub upper()
+        End Sub
+        Public Overrides Property foo As Boolean
+    End Class
+End Namespace
+
+Namespace Global.aaa
+    Friend Class B
+    End Class
+End Namespace
+
+Friend Module NamespaceCasing
+    <Fact>
+    Sub TestThisCompiles()
+        ' Visual Studio likes to fix casing automatically,
+        ' so if editting this, do it in a separate editor
+        Dim x = New aaa.A
+        Dim y = New Aaa.B
+        Dim z = New Aaa.A
+        Dim a = New aaa.B
+        Dim b = New aaa.a
+        Dim c = New aaa.b
+        Dim d = New AAA.A
+        Dim e = New AAA.B
+        Dim f = New Aaa.Z
+        Dim g = New Aaa.z
+    End Sub
+End Module

--- a/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
+++ b/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
@@ -2,6 +2,8 @@ Imports Xunit
 
 Namespace [Aaa]
     Friend Class A
+        Shared Sub Foo()
+        End Sub
     End Class
 
     Partial Class Z
@@ -24,6 +26,8 @@ End Namespace
 
 Namespace Global.aaa
     Friend Class B
+        Shared Sub Bar()
+        End Sub
     End Class
 End Namespace
 
@@ -42,5 +46,9 @@ Friend Module NamespaceCasing
         Dim e = New AAA.B
         Dim f = New Aaa.Z
         Dim g = New Aaa.z
+        aaa.a.foo()
+        Aaa.A.Foo()
+        aaa.b.bar()
+        Aaa.B.Bar()
     End Sub
 End Module

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -107,6 +107,23 @@ End Namespace", @"namespace Test.@class
             await TestConversionVisualBasicToCSharpWithoutComments(@"Namespace [Aaa]
     Friend Class A
     End Class
+
+    Partial Class Z
+    End Class
+    Partial Class z
+    End Class
+
+    MustInherit Class Base
+        MustOverride Sub UPPER()
+        MustOverride Property FOO As Boolean
+    End Class
+    Class NotBase
+        Inherits Base
+
+        Public Overrides Sub upper()
+        End Sub
+        Public Overrides Property foo As Boolean
+    End Class
 End Namespace
 
 Namespace Global.aaa
@@ -124,11 +141,33 @@ Friend Module C
         Dim c = New aaa.b
         Dim d = New AAA.A
         Dim e = New AAA.B
+        Dim f = New Aaa.Z
+        Dim g = New Aaa.z
     End Sub
 End Module", @"namespace Aaa
 {
     internal partial class A
     {
+    }
+
+    internal partial class Z
+    {
+    }
+    internal partial class Z
+    {
+    }
+
+    internal abstract partial class Base
+    {
+        public abstract void UPPER();
+        public abstract bool FOO { get; set; }
+    }
+    internal partial class NotBase : Base
+    {
+        public override void UPPER()
+        {
+        }
+        public override bool FOO { get; set; }
     }
 }
 
@@ -151,6 +190,8 @@ internal static partial class C
         var c = new aaa.B();
         var d = new Aaa.A();
         var e = new aaa.B();
+        var f = new Aaa.Z();
+        var g = new Aaa.Z();
     }
 }");
         }

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -106,6 +106,8 @@ End Namespace", @"namespace Test.@class
         {
             await TestConversionVisualBasicToCSharpWithoutComments(@"Namespace [Aaa]
     Friend Class A
+        Shared Sub Foo()
+        End Sub
     End Class
 
     Partial Class Z
@@ -128,6 +130,8 @@ End Namespace
 
 Namespace Global.aaa
     Friend Class B
+        Shared Sub Bar()
+        End Sub
     End Class
 End Namespace
 
@@ -143,11 +147,18 @@ Friend Module C
         Dim e = New AAA.B
         Dim f = New Aaa.Z
         Dim g = New Aaa.z
+        aaa.a.foo()
+        Aaa.A.Foo()
+        aaa.b.bar()
+        Aaa.B.Bar()
     End Sub
 End Module", @"namespace Aaa
 {
     internal partial class A
     {
+        public static void Foo()
+        {
+        }
     }
 
     internal partial class Z
@@ -175,6 +186,9 @@ namespace aaa
 {
     internal partial class B
     {
+        public static void Bar()
+        {
+        }
     }
 }
 
@@ -192,6 +206,10 @@ internal static partial class C
         var e = new aaa.B();
         var f = new Aaa.Z();
         var g = new Aaa.Z();
+        Aaa.A.Foo();
+        Aaa.A.Foo();
+        aaa.B.Bar();
+        aaa.B.Bar();
     }
 }");
         }

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -102,6 +102,60 @@ End Namespace", @"namespace Test.@class
         }
 
         [Fact]
+        public async Task TestMixedCaseNamespace()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(@"Namespace [Aaa]
+    Friend Class A
+    End Class
+End Namespace
+
+Namespace Global.aaa
+    Friend Class B
+    End Class
+End Namespace
+
+Friend Module C
+    Sub Main()
+        Dim x = New aaa.A
+        Dim y = New Aaa.B
+        Dim z = New Aaa.A
+        Dim a = New aaa.B
+        Dim b = New aaa.a
+        Dim c = New aaa.b
+        Dim d = New AAA.A
+        Dim e = New AAA.B
+    End Sub
+End Module", @"namespace Aaa
+{
+    internal partial class A
+    {
+    }
+}
+
+namespace aaa
+{
+    internal partial class B
+    {
+    }
+}
+
+internal static partial class C
+{
+    public static void Main()
+    {
+        var x = new Aaa.A();
+        var y = new aaa.B();
+        var z = new Aaa.A();
+        var a = new aaa.B();
+        var b = new Aaa.A();
+        var c = new aaa.B();
+        var d = new Aaa.A();
+        var e = new aaa.B();
+    }
+}");
+        }
+
+        [Fact]
         public async Task TestInternalStaticClass()
         {
             await TestConversionVisualBasicToCSharp(@"Namespace Test.[class]

--- a/Tests/CSharp/RootNamespaceTests.cs
+++ b/Tests/CSharp/RootNamespaceTests.cs
@@ -66,6 +66,33 @@ End Namespace",
         }
 
         [Fact]
+        public async Task RootNamespaceIsAddedToExistingNamespaceWithDeclarationCasing()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(@"Namespace AAA.AAaB.AaA
+    Public Class Class1
+    End Class
+End Namespace
+
+Namespace Aaa.aAAb.aAa
+    Public Class Class2
+    End Class
+End Namespace",
+                @"namespace TheRootNamespace.AAA.AAaB.AaA
+{
+    public partial class Class1
+    {
+    }
+}
+
+namespace TheRootNamespace.Aaa.aAAb.aAa
+{
+    public partial class Class2
+    {
+    }
+}");
+        }
+
+        [Fact]
         public async Task NestedNamespacesRemainRelative()
         {
             await TestConversionVisualBasicToCSharpWithoutComments(@"Namespace A.B


### PR DESCRIPTION
Fixes #421

### Problem

When converting multiple namespaces with the same name but different cases, the symbols from the semantic info get merged, despite being distinct symbols. Roslyn recognises this internally (using a `MergedNamespaceDeclaration`), but doesn't seem to expose it.

When this happens, `CsSyntaxGenerator` will always use the casing of the first namespace declaration it encountered, even if this is incorrect.

### Solution

 * When converting identifiers, only update the case if this is *not* a declaration
 * When getting a `TypeSyntax` for conversion, manually replace the identifiers when the strings are identical, but cases don't match.

* [x] At least one test covering the code changed

The tests for this will fail until #414 is merged. I didn't want to include it in there, since it's already doing quite a lot, and my solution to this seems rather hacky.

