### PR TITLE
Ensure class constructors are marked as public [#422]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the code converter will be documented here.
 * Correctly handle type promoted module symbols (#375)
 * Prefer renamed imports for name resolution (#401)
 * Correctly convert ambiguous names (#332)
+* Ensure correct visibility for constructors (#422)
 
 ### C# -> VB
 * Convert property accessors with visiblity modifiers (#92)

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -265,7 +265,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var declaredAccessibility = declaredSymbol?.DeclaredAccessibility ?? Accessibility.NotApplicable;
 
             var contextsWithIdenticalDefaults = new[] { TokenContext.Global, TokenContext.Local, TokenContext.InterfaceOrModule, TokenContext.MemberInInterface };
-            bool isPartial = declaredSymbol.IsPartialClassDefinition() || declaredSymbol.IsPartialMethodDefinition() || declaredSymbol.IsPartialMethodImplementation();
+            bool isPartial = declaredSymbol.IsPartialClassDefinition() || declaredSymbol.IsPartialMethodDefinition() || declaredSymbol.IsPartialMethodImplementation() || declaredSymbol.IsConstructor();
             bool implicitVisibility = contextsWithIdenticalDefaults.Contains(context) || isVariableOrConst || isConstructor;
             if (implicitVisibility && !isPartial) declaredAccessibility = Accessibility.NotApplicable;
             var modifierSyntaxs = ConvertModifiersCore(declaredAccessibility, modifiers, context)

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -259,14 +259,14 @@ namespace ICSharpCode.CodeConverter.CSharp
         }
 
         public SyntaxTokenList ConvertModifiers(SyntaxNode node, IEnumerable<SyntaxToken> modifiers,
-            TokenContext context = TokenContext.Global, bool isVariableOrConst = false, bool isConstructor = false, params CSSyntaxKind[] extraCsModifierKinds)
+            TokenContext context = TokenContext.Global, bool isVariableOrConst = false, params CSSyntaxKind[] extraCsModifierKinds)
         {
             ISymbol declaredSymbol = _semanticModel.GetDeclaredSymbol(node);
             var declaredAccessibility = declaredSymbol?.DeclaredAccessibility ?? Accessibility.NotApplicable;
 
             var contextsWithIdenticalDefaults = new[] { TokenContext.Global, TokenContext.Local, TokenContext.InterfaceOrModule, TokenContext.MemberInInterface };
-            bool isPartial = declaredSymbol.IsPartialClassDefinition() || declaredSymbol.IsPartialMethodDefinition() || declaredSymbol.IsPartialMethodImplementation() || declaredSymbol.IsConstructor();
-            bool implicitVisibility = contextsWithIdenticalDefaults.Contains(context) || isVariableOrConst || isConstructor;
+            bool isPartial = declaredSymbol.IsPartialClassDefinition() || declaredSymbol.IsPartialMethodDefinition() || declaredSymbol.IsPartialMethodImplementation();
+            bool implicitVisibility = contextsWithIdenticalDefaults.Contains(context) || isVariableOrConst || declaredSymbol.IsStaticConstructor();
             if (implicitVisibility && !isPartial) declaredAccessibility = Accessibility.NotApplicable;
             var modifierSyntaxs = ConvertModifiersCore(declaredAccessibility, modifiers, context)
                 .Concat(extraCsModifierKinds.Select(SyntaxFactory.Token))

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -1041,7 +1041,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var block = node.BlockStatement;
             var attributes = await block.AttributeLists.SelectManyAsync(_expressionNodeVisitor.ConvertAttribute);
-            var modifiers = CommonConversions.ConvertModifiers(block, block.Modifiers, GetMemberContext(node), isConstructor: true);
+            var modifiers = CommonConversions.ConvertModifiers(block, block.Modifiers, GetMemberContext(node));
 
             var ctor = (node.Statements.FirstOrDefault() as VBSyntax.ExpressionStatementSyntax)?.Expression as VBSyntax.InvocationExpressionSyntax;
             var ctorExpression = ctor?.Expression as VBSyntax.MemberAccessExpressionSyntax;

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -977,7 +977,7 @@ public partial class Class1
     End Property
 End Class", @"public partial class Class1
 {
-    Class1()
+    public Class1()
     {
         var needsInitialization = default(int);
         int notUsed;

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -37,6 +37,20 @@ End Module", @"internal static partial class TestModule
         }
 
         [Fact]
+        public async Task TestConstructorVisibility()
+        {
+            await TestConversionVisualBasicToCSharpWithoutComments(@"Class Class1
+    Sub New(x As Boolean)
+    End Sub
+End Class", @"internal partial class Class1
+{
+    public Class1(bool x)
+    {
+    }
+}");
+        }
+
+        [Fact]
         public async Task TestModuleConstructor()
         {
             await TestConversionVisualBasicToCSharp(
@@ -779,7 +793,7 @@ End Class", @"internal partial class TestClass<T, T2, T3>
         {
             await TestConversionVisualBasicToCSharp(
 @"Sub New()
-End Sub", @"SurroundingClass()
+End Sub", @"public SurroundingClass()
 {
 }");
         }


### PR DESCRIPTION
Fixes #422

### Problem

Class constructors with no modifiers in VB need to be explicitly marked as public in C#.

### Solution

* [x] At least one test covering the code changed

