### PR TITLE
C# -> VB: don't convert generic static to module, fix generic interface implements statement, concatenate inner namespaces with the parent

### DIFF
--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -421,7 +421,7 @@ namespace ICSharpCode.CodeConverter.VB
             switch (context) {
                 case TokenContext.InterfaceOrModule:
                 case TokenContext.MemberInModule:
-                    return m.IsKind(CSSyntaxKind.StaticKeyword);
+                    return m.IsKind(CSSyntaxKind.StaticKeyword) || m.IsKind(CSSyntaxKind.PublicKeyword);
             }
             return false;
         }

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -185,6 +185,17 @@ namespace ICSharpCode.CodeConverter.VB
                 var id = _commonConversions.ConvertIdentifier(name.Identifier);
                 alias = SyntaxFactory.ImportAliasClause(id);
             }
+            var identifierName = node.Name as CSS.IdentifierNameSyntax;
+            var parentSymbol = _semanticModel.GetDeclaredSymbol(node.Parent) as INamespaceSymbol;
+            INamespaceSymbol fullNamespace = null;
+            if (identifierName != null && parentSymbol != null) {
+                fullNamespace = _semanticModel.LookupNamespacesAndTypes(node.SpanStart, null, identifierName.Identifier.ValueText)
+                    .OfType<INamespaceSymbol>().FirstOrDefault();
+            }
+            if (fullNamespace != null) {
+                _allImports.Add((ImportsStatementSyntax)_vbSyntaxGenerator.NamespaceImportDeclaration(fullNamespace.ToDisplayString()));
+                return null;
+            }
             ImportsClauseSyntax clause = SyntaxFactory.SimpleImportsClause(alias, (NameSyntax)node.Name.Accept(TriviaConvertingVisitor));
             var import = SyntaxFactory.ImportsStatement(SyntaxFactory.SingletonSeparatedList(clause));
             _allImports.Add(import);

--- a/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxKindExtensions.cs
@@ -67,7 +67,7 @@ namespace ICSharpCode.CodeConverter.VB
                 case Microsoft.CodeAnalysis.CSharp.SyntaxKind.ProtectedKeyword:
                     return SyntaxKind.ProtectedKeyword;
                 case Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword:
-                    return SyntaxKind.SharedKeyword;
+                    return context == TokenContext.Global ? SyntaxKind.NotInheritableKeyword : SyntaxKind.SharedKeyword;
                 case Microsoft.CodeAnalysis.CSharp.SyntaxKind.ReadOnlyKeyword:
                     return SyntaxKind.ReadOnlyKeyword;
                 case Microsoft.CodeAnalysis.CSharp.SyntaxKind.SealedKeyword:

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -7,6 +7,8 @@ using ICSharpCode.CodeConverter;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.VB;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
 using Xunit.Sdk;
 
@@ -19,9 +21,18 @@ namespace CodeConverter.Tests.TestRunners
         private bool _testCstoVBCommentsByDefault = false;
         private readonly string _rootNamespace;
 
+        protected TextConversionOptions EmptyNamespaceOptionStrictOff { get; set; }
+
         public ConverterTestBase(string rootNamespace = null)
         {
             _rootNamespace = rootNamespace;
+            EmptyNamespaceOptionStrictOff = new TextConversionOptions(DefaultReferences.NetStandard2) {
+                RootNamespaceOverride = string.Empty, TargetCompilationOptionsOverride = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithOptionExplicit(true)
+                .WithOptionCompareText(false)
+                .WithOptionStrict(OptionStrict.Off)
+                .WithOptionInfer(true)
+            };
         }
 
         protected static async Task<string> GetConvertedCodeOrErrorString<TLanguageConversion>(string toConvert, TextConversionOptions conversionOptions = default) where TLanguageConversion : ILanguageConversion, new()

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -12,16 +12,6 @@ namespace CodeConverter.Tests.VB
 {
     public class MemberTests : ConverterTestBase
     {
-        TextConversionOptions EmptyNamespaceOptionStrictOff { get; set; }
-
-        public MemberTests() {
-            EmptyNamespaceOptionStrictOff = new TextConversionOptions(DefaultReferences.NetStandard2) { RootNamespaceOverride = string.Empty, TargetCompilationOptionsOverride = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithOptionExplicit(true)
-                .WithOptionCompareText(false)
-                .WithOptionStrict(OptionStrict.Off)
-                .WithOptionInfer(true)
-            };
-        }
         [Fact]
         public async Task TestPropertyWithModifier()
         {

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -372,5 +372,37 @@ End Class");
     Inherits InvalidDataException
 End Class");
         }
+        [Fact]
+        public async Task StaticGenericClass() {
+            await TestConversionCSharpToVisualBasic(
+@"using System.Threading.Tasks;
+
+public abstract class Class1 {
+}
+
+public static class TestClass<T> where T : Class1, new() {
+        static Task task;
+        static TestClass() {
+        }
+        public static Task Method() {
+            return task;
+        }
+    }",
+@"Imports System.Threading.Tasks
+
+Public MustInherit Class Class1
+End Class
+
+Public NotInheritable Class TestClass(Of T As {Class1, New})
+    Private Shared task As Task
+
+    Shared Sub New()
+    End Sub
+
+    Public Shared Function Method() As Task
+        Return task
+    End Function
+End Class");
+        }
     }
 }

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -251,7 +251,24 @@ End Structure");
 Namespace test
 End Namespace");
         }
+        [Fact]
+        public async Task InnerNamespace_MoveImportsStatement()
+        {
+            await TestConversionCSharpToVisualBasic(
+@"namespace System {
+    using Collections;
+    public class TestClass {
+        public Hashtable Property { get; set; }
+    }
+}",
+@"Imports System.Collections
 
+Namespace System
+    Public Class TestClass
+        Public Property [Property] As Hashtable
+    End Class
+End Namespace", conversion: EmptyNamespaceOptionStrictOff);
+        }
         [Fact]
         public async Task ClassImplementsInterface()
         {

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -404,5 +404,27 @@ Public NotInheritable Class TestClass(Of T As {Class1, New})
     End Function
 End Class");
         }
+        [Fact]
+        public async Task ImplementsGenericInterface()
+        {
+            await TestConversionCSharpToVisualBasic(
+@"public interface ITestInterface<T> {
+    void Method(List<T> list);
+}
+public class TestClass : ITestInterface<string> {
+    public void Method(List<string> list) {
+    }
+",
+@"Public Interface ITestInterface(Of T)
+    Sub Method(ByVal list As List(Of T))
+End Interface
+
+Public Class TestClass
+    Implements ITestInterface(Of String)
+
+    Public Sub Method(ByVal list As List(Of String)) Implements ITestInterface(Of String).Method
+    End Sub
+End Class");
+        }
     }
 }


### PR DESCRIPTION
https://github.com/icsharpcode/CodeConverter/issues/451
https://github.com/icsharpcode/CodeConverter/issues/454
https://github.com/icsharpcode/CodeConverter/issues/455

### Problem
1. [generic static classes are converted into modules, which can't be generic](https://github.com/icsharpcode/CodeConverter/issues/451)
2.  [Generic interfaces has wrong Implements statement without type parameters](https://github.com/icsharpcode/CodeConverter/issues/454)
3. [Inner namespaces are moving to root Imports clause as is, but in some cases its should merged with parent namespace](https://github.com/icsharpcode/CodeConverter/issues/455)
### Solution
