### PR TITLE
C# -> VB: Improve CoalesceExpression conversion

### DIFF
--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -878,7 +878,20 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitParenthesizedExpression(CSS.ParenthesizedExpressionSyntax node)
         {
-            return SyntaxFactory.ParenthesizedExpression((ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor));
+            return node.Expression.Accept(TriviaConvertingVisitor).TypeSwitch<VisualBasicSyntaxNode, AssignmentStatementSyntax, ExpressionSyntax, VisualBasicSyntaxNode>(
+                (AssignmentStatementSyntax statement) => SyntaxFactory.MultiLineFunctionLambdaExpression(
+                       SyntaxFactory.LambdaHeader(
+                               SyntaxKind.FunctionLambdaHeader,
+                               SyntaxFactory.Token(SyntaxKind.FunctionKeyword)
+                       ),
+                       new SyntaxList<StatementSyntax>(new StatementSyntax[] {
+                            statement,
+                            SyntaxFactory.ReturnStatement(statement.Left)
+                       }),
+                       SyntaxFactory.EndFunctionStatement()
+                   ),
+                (ExpressionSyntax expression) => SyntaxFactory.ParenthesizedExpression(expression)
+            );
         }
 
         public override VisualBasicSyntaxNode VisitPrefixUnaryExpression(CSS.PrefixUnaryExpressionSyntax node)
@@ -925,6 +938,9 @@ namespace ICSharpCode.CodeConverter.VB
                 return MakeAssignmentStatement(node);
             }
             if (node.Parent is CSS.ForStatementSyntax) {
+                return MakeAssignmentStatement(node);
+            }
+            if (node.Parent.IsParentKind(CS.SyntaxKind.CoalesceExpression)) {
                 return MakeAssignmentStatement(node);
             }
             if (node.Parent is CSS.InitializerExpressionSyntax) {

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -216,6 +216,40 @@ End Class");
     End Sub
 End Class");
         }
+        [Fact]
+        public async Task CoalescingExpression_Assignment()
+        {
+            await TestConversionCSharpToVisualBasic(
+@"class TestClass {
+    string prop;
+    string prop2;
+    string Property {
+        get {
+            return this.prop ?? (this.prop2 = CreateProperty());
+        }
+    }
+    string CreateProperty() {
+        return """";
+    }
+}",
+@"Friend Class TestClass
+    Private prop As String
+    Private prop2 As String
+
+    Private ReadOnly Property [Property] As String
+        Get
+            Return If(prop, Function
+                                prop2 = CreateProperty
+                                Return prop2
+                            End Function)
+        End Get
+    End Property
+
+    Private Function CreateProperty() As String
+        Return """"
+    End Function
+End Class");
+        }
 
         [Fact]
         public async Task MemberAccessAndInvocationExpression()


### PR DESCRIPTION
### Problem
ugly CSharpImpl.__Assign() in converted code

### Solution
replace

(x = AssignX())

in expression:

x ?? (x = AssignX())

with:

Function
  x = AssignX()
  Return x
EndFunction
