### PR TITLE
C# -> VB: rename fields and local variables in simple case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ### VB -> C#
-
+* Simplify compound assignment conversion
+* Avoid some case conflicts
 
 ### C# -> VB
 

--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -268,7 +268,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         private static string WithDeclarationCasing(SyntaxToken id, ISymbol idSymbol, string text)
         {
             //TODO: Consider what happens when the names aren't equal for overridden members (I think in VB you can have X implements Y)
-            var baseSymbol = idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property) ? idSymbol.FollowProperty(s => s.OverriddenMember()).Last() : idSymbol;
+            var baseSymbol = idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property) ? idSymbol.FollowProperty((ISymbol s) => s.OverriddenMember()).Last() : idSymbol;
             bool isDeclaration = baseSymbol.Locations.Any(l => l.SourceSpan == id.Span);
             bool isPartial = baseSymbol.IsPartialClassDefinition() || baseSymbol.IsPartialMethodDefinition() ||
                              baseSymbol.IsPartialMethodImplementation();

--- a/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1270,7 +1270,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             ISymbol typeContext = syntaxNodeContext.GetEnclosingDeclaredTypeSymbol(_semanticModel);
             var implicitCsQualifications = ((ITypeSymbol)typeContext).GetBaseTypesAndThis()
-                .Concat(typeContext.FollowProperty(n => n.ContainingSymbol))
+                .Concat(typeContext.FollowProperty((ISymbol n) => n.ContainingSymbol))
                 .ToList();
 
             return implicitCsQualifications.Contains(symbolToCheck);

--- a/ICSharpCode.CodeConverter/Util/NameGenerator.cs
+++ b/ICSharpCode.CodeConverter/Util/NameGenerator.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using VBasic = Microsoft.CodeAnalysis.VisualBasic;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
@@ -127,7 +129,7 @@ namespace ICSharpCode.CodeConverter.Util
             return GenerateUniqueName(baseName, string.Empty, canUse);
         }
 
-        public static string GenerateUniqueName(string baseName, ISet<string> names, StringComparer comparer)
+        public static string GenerateUniqueName(string baseName, HashSet<string> names, StringComparer comparer)
         {
             return GenerateUniqueName(baseName, x => !names.Contains(x, comparer));
         }
@@ -169,15 +171,42 @@ namespace ICSharpCode.CodeConverter.Util
         public static string GetUniqueVariableNameInScope(SemanticModel semanticModel, HashSet<string> generatedNames, VBasic.VisualBasicSyntaxNode node, string variableNameBase)
         {
             // Need to check not just the symbols this node has access to, but whether there are any nested blocks which have access to this node and contain a conflicting name
-            var scopeStarts = node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
-                        .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
+            var scopeStarts = GetScopeStarts(node);
+            return GenerateUniqueVariableNameInScope(semanticModel, generatedNames, variableNameBase, scopeStarts);
+        }
+
+        public static string GetUniqueVariableNameInScope(SemanticModel semanticModel, HashSet<string> generatedNames, CSharpSyntaxNode node, string variableNameBase)
+        {
+            // Need to check not just the symbols this node has access to, but whether there are any nested blocks which have access to this node and contain a conflicting name
+            var scopeStarts = GetScopeStarts(node);
+            return GenerateUniqueVariableNameInScope(semanticModel, generatedNames, variableNameBase, scopeStarts);
+        }
+
+        private static string GenerateUniqueVariableNameInScope(SemanticModel semanticModel, HashSet<string> generatedNames,
+            string variableNameBase, List<int> scopeStarts)
+        {
             string uniqueName = NameGenerator.GenerateUniqueName(variableNameBase, string.Empty,
-                n => {
-                    var matchingSymbols = scopeStarts.SelectMany(scopeStart => semanticModel.LookupSymbols(scopeStart, name: n));
+                n =>
+                {
+                    var matchingSymbols =
+                        scopeStarts.SelectMany(scopeStart => semanticModel.LookupSymbols(scopeStart, name: n));
                     return !generatedNames.Contains(n) && !matchingSymbols.Any();
                 });
             generatedNames.Add(uniqueName);
             return uniqueName;
+        }
+
+        private static List<int> GetScopeStarts(VBasic.VisualBasicSyntaxNode node)
+        {
+            return node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
+                .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
+        }
+
+        private static List<int> GetScopeStarts(CSharpSyntaxNode node)
+        {
+            return node.GetAncestorOrThis<StatementSyntax>()?.DescendantNodesAndSelf()
+                .OfType<StatementSyntax>().Select(n => n.SpanStart).ToList()
+                ?? new List<int>{node.SpanStart};
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CSToVBProjectContentsConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSToVBProjectContentsConverter.cs
@@ -44,6 +44,8 @@ namespace ICSharpCode.CodeConverter.VB
 
         public async Task InitializeSourceAsync(Project project)
         {
+            // TODO: Don't throw away solution-wide effects - write them to referencing files, and use in conversion of any other projects being converted at the same time.
+            project = await CaseConflictResolver.RenameClashingSymbols(project);
             _sourceCsProject = project;
             _convertedVbProject = project.ToProjectFromAnyOptions(_vbCompilationOptions, _vbParseOptions);
             _vbReferenceProject = project.CreateReferenceOnlyProjectFromAnyOptions(_vbCompilationOptions);

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -1,7 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.VisualBasic;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,7 +26,7 @@ namespace ICSharpCode.CodeConverter.VB
                        throw new InvalidOperationException(NullRootError(document));
 
             var vbSyntaxGenerator = SyntaxGenerator.GetGenerator(vbReferenceProject);
-            var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation) compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator);
+            var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation)compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator);
             return root.Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
         }
 
@@ -31,5 +37,6 @@ namespace ICSharpCode.CodeConverter.VB
                 : "Could not find valid C# within document.";
             return initial + " For best results, convert a c# document from within a C# project which compiles successfully.";
         }
+
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CaseConflictResolver.cs
+++ b/ICSharpCode.CodeConverter/VB/CaseConflictResolver.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Rename;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.VB
+{
+    public class CaseConflictResolver
+    {
+
+        public static async Task<Project> RenameClashingSymbols(Project project)
+        {
+            var compilation = await project.GetCompilationAsync();
+            var memberRenames = compilation.GlobalNamespace.FollowProperty((INamespaceOrTypeSymbol n) => n.GetMembers().OfType<INamespaceOrTypeSymbol>().Where(s => s.IsDefinedInSource()))
+                .SelectMany(GetSymbolsWithNewNames);
+            return await PerformRenames(project, memberRenames.ToList());
+        }
+
+        private static IEnumerable<(ISymbol Original, string NewName)> GetSymbolsWithNewNames(INamespaceOrTypeSymbol containerSymbol)
+        {
+            var members = containerSymbol.GetMembers();
+            //TODO If container is a type, call GetCsLocalSymbolDeclarations and rename those too - see test called CaseConflict_LocalWithLocal
+            var membersByCaseInsensitiveName = members.ToLookup(m => m.Name, m => m, StringComparer.OrdinalIgnoreCase);
+            var names = new HashSet<string>(membersByCaseInsensitiveName.Select(ms => ms.Key),
+                StringComparer.OrdinalIgnoreCase);
+            var symbolsWithNewNames = membersByCaseInsensitiveName.Where(ms => ms.Count() > 1)
+                .SelectMany(symbolGroup => GetSymbolsWithNewNames(symbolGroup.ToArray(), names));
+            return symbolsWithNewNames;
+        }
+
+        private static IEnumerable<(ISymbol Original, string NewName)> GetSymbolsWithNewNames(IReadOnlyCollection<ISymbol> symbolGroup, HashSet<string> names)
+        {
+            var methodSymbols = symbolGroup.OfType<IMethodSymbol>().Where(s => s.IsDefinedInSource()).ToArray();
+            var cannotRename = symbolGroup.Where(s => !s.IsDefinedInSource() || s.IsIndexer()).ToArray();
+            var specialSymbolUsingName = cannotRename.Any();
+            var canKeepOneNormalMemberName = !specialSymbolUsingName && !methodSymbols.Any();
+            symbolGroup = symbolGroup.Except(cannotRename).Except(methodSymbols).ToArray();
+            (ISymbol Original, string NewName)[] methodsWithNewNames = GetMethodSymbolsWithNewNames(methodSymbols, names, specialSymbolUsingName);
+            return GetSymbolsWithNewNames(symbolGroup, names.Add, canKeepOneNormalMemberName).Concat(methodsWithNewNames);
+        }
+
+        private static (ISymbol Original, string NewName)[] GetMethodSymbolsWithNewNames(IMethodSymbol[] methodSymbols,
+            HashSet<string> names,
+            bool specialSymbolUsingName)
+        {
+            var methodsByCaseInsensitiveSignature = methodSymbols
+                .ToLookup(m => (m.Name.ToLowerInvariant(), string.Join(" ", m.Parameters.Select(p => p.Type))))
+                .Where(g => g.Count() > 1)
+                .SelectMany(clashingMethodGroup =>
+                {
+                    var thisMethodGroupNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    var symbolsWithNewNames = GetSymbolsWithNewNames(clashingMethodGroup,
+                        n => !names.Contains(n) && thisMethodGroupNames.Add(n),
+                        !specialSymbolUsingName).ToArray();
+                    return symbolsWithNewNames;
+                }).ToArray();
+
+            foreach (var newMethodNames in methodsByCaseInsensitiveSignature.Select(m => m.NewName))
+            {
+                names.Add(newMethodNames);
+            }
+
+            return methodsByCaseInsensitiveSignature;
+        }
+
+        private static IEnumerable<(ISymbol Original, string NewName)> GetSymbolsWithNewNames(
+            IEnumerable<ISymbol> toRename, Func<string, bool> canUse, bool canKeepOne)
+        {
+            var symbolsWithNewNames = toRename.OrderByDescending(x => x.DeclaredAccessibility).Skip(canKeepOne ? 1 :0).Select(tr =>
+            {
+                string newName = NameGenerator.GenerateUniqueName(GetBaseName(tr), canUse);
+                return (Original: tr, NewName: newName);
+            });
+            return symbolsWithNewNames;
+        }
+
+        private static async Task<Project> PerformRenames(Project project, IReadOnlyCollection<(ISymbol Original, string NewName)> symbolsWithNewNames)
+        {
+            var solution = project.Solution;
+            foreach (var (originalSymbol, newName) in symbolsWithNewNames) {
+                project = solution.GetProject(project.Id);
+                var compilation = await project.GetCompilationAsync();
+                ISymbol currentDeclaration = SymbolFinder.FindSimilarSymbols(originalSymbol, compilation).First();
+                solution = await Renamer.RenameSymbolAsync(solution, currentDeclaration, newName, solution.Workspace.Options);
+            }
+
+            return solution.GetProject(project.Id);
+        }
+
+        private static IEnumerable<ISymbol> GetCsLocalSymbolDeclarations(SemanticModel semanticModel, ISymbol x)
+        {
+            switch (x)
+            {
+                case IMethodSymbol methodSymbol:
+                    return GetCsSymbolsDeclaredByMethod(semanticModel, methodSymbol);
+                case IPropertySymbol propertySymbol:
+                    return GetCsSymbolsDeclaredByProperty(semanticModel, propertySymbol);
+                case IEventSymbol eventSymbol:
+                    return GetCsSymbolsDeclaredByEvent(semanticModel, eventSymbol);
+                case IFieldSymbol fieldSymbol:
+                    return GetCsSymbolsDeclaredByField(semanticModel, fieldSymbol);
+                default:
+                    return new ISymbol[0];
+            }
+        }
+
+        public static IEnumerable<ISymbol> GetCsSymbolsDeclaredByMethod(SemanticModel semanticModel, IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol == null) return new ISymbol[0];
+            var symbols =
+                methodSymbol.TypeParameters
+                    .Concat<ISymbol>(methodSymbol.Parameters);
+            var bodies = DeclarationWhereNotNull(methodSymbol, (CSS.BaseMethodDeclarationSyntax b) => (CS.CSharpSyntaxNode)b.ExpressionBody ?? b.Body);
+            foreach (var body in bodies) {
+                symbols = symbols.Concat(semanticModel.LookupSymbols(body.SpanStart, methodSymbol.ContainingType));
+                var descendantNodes = body.DescendantNodes().OfType<CSS.BlockSyntax>();
+                symbols = symbols.Concat(descendantNodes.SelectMany(d => semanticModel.LookupSymbols(d.SpanStart, methodSymbol.ContainingType)));
+            }
+
+            return symbols;
+        }
+
+        private static IEnumerable<TResult> DeclarationWhereNotNull<TNode, TResult>(ISymbol symbol, Func<TNode, TResult> selectWhereNotNull)
+        {
+            return symbol.DeclaringSyntaxReferences.Select(d => d.GetSyntax()).OfType<TNode>().Select(selectWhereNotNull).Where(x => x != null);
+        }
+
+        private static IEnumerable<TResult> DeclarationWhereManyNotNull<TNode, TResult>(ISymbol symbol, Func<TNode, IEnumerable<TResult>> selectManyWhereNotNull)
+        {
+            return symbol.DeclaringSyntaxReferences.Select(d => d.GetSyntax()).OfType<TNode>().SelectMany(selectManyWhereNotNull).Where(x => x != null);
+        }
+
+        public static IEnumerable<ISymbol> GetCsSymbolsDeclaredByProperty(SemanticModel semanticModel, IPropertySymbol propertySymbol)
+        {
+            return GetCsSymbolsDeclaredByMethod(semanticModel, propertySymbol.GetMethod)
+                .Concat(GetCsSymbolsDeclaredByMethod(semanticModel, propertySymbol.SetMethod));
+        }
+
+        public static IEnumerable<ISymbol> GetCsSymbolsDeclaredByField(SemanticModel semanticModel, IFieldSymbol fieldSymbol)
+        {
+            return DeclarationWhereManyNotNull(fieldSymbol,
+                (CSS.BaseFieldDeclarationSyntax f) => f.Declaration.Variables.Select(v => v.Initializer?.Value))
+                .SelectMany(i => semanticModel.LookupSymbols(i.SpanStart, fieldSymbol.ContainingType));
+        }
+
+        public static IEnumerable<ISymbol> GetCsSymbolsDeclaredByEvent(SemanticModel semanticModel, IEventSymbol propertySymbol)
+        {
+            return GetCsSymbolsDeclaredByMethod(semanticModel, propertySymbol.AddMethod)
+                .Concat(GetCsSymbolsDeclaredByMethod(semanticModel, propertySymbol.RemoveMethod));
+        }
+
+        private static async Task<string> GenerateUniqueCaseInsensitiveName(SemanticModel model, ISymbol declaration)
+        {
+            string baseName = GetBaseName(declaration);
+            HashSet<string> generatedNames = new HashSet<string>();
+            //TODO Make looking for clashes case insensitive as above
+            return NameGenerator.GetUniqueVariableNameInScope(model, generatedNames, (CS.CSharpSyntaxNode)await declaration.DeclaringSyntaxReferences.First().GetSyntaxAsync(), baseName);
+        }
+
+        private static string GetBaseName(ISymbol declaration)
+        {
+            string prefix = declaration.Kind.ToString().ToLowerInvariant()[0] + "_";
+            string baseName = prefix + declaration.Name.Substring(0, 1).ToUpperInvariant() + declaration.Name.Substring(1);
+            return baseName;
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -18,7 +18,6 @@ using IdentifierNameSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.Identifie
 using LambdaExpressionSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.LambdaExpressionSyntax;
 using ParameterListSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterListSyntax;
 using ParameterSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ParameterSyntax;
-using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReturnStatementSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.ReturnStatementSyntax;
 using StatementSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.StatementSyntax;
 using SyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
@@ -35,7 +34,6 @@ namespace ICSharpCode.CodeConverter.VB
         private readonly CSharpSyntaxVisitor<VisualBasicSyntaxNode> _nodesVisitor;
         private readonly TriviaConverter _triviaConverter;
         private readonly SemanticModel _semanticModel;
-        readonly Dictionary<string, HashSet<string>> _renameInfo = new Dictionary<string, HashSet<string>>();
 
         public CommonConversions(SemanticModel semanticModel, CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor,
             TriviaConverter triviaConverter)
@@ -466,7 +464,6 @@ namespace ICSharpCode.CodeConverter.VB
             var declarators = new List<VariableDeclaratorSyntax>();
 
             foreach (var v in declaration.Variables) {
-                AddRenameInfoIfNeed(v);
                 if (v.Initializer == null) {
                     declaratorsWithoutInitializers.Add(v);
                 } else {
@@ -486,22 +483,6 @@ namespace ICSharpCode.CodeConverter.VB
 
             return SyntaxFactory.SeparatedList(declarators);
         }
-        
-        void AddRenameInfoIfNeed(CSS.VariableDeclaratorSyntax variable) {
-            var containingType = _semanticModel.GetDeclaredSymbol(variable).ContainingType;
-            bool shouldRename = containingType.GetMembers()
-                .Where(x => x.MatchesKind(SymbolKind.Property))
-                .Select(x => x.Name.ToLower())
-                .Any(x => x == variable.Identifier.Text.ToLower());
-            if (shouldRename) {
-                HashSet<string> toRename;
-                if (!_renameInfo.TryGetValue(containingType.Name, out toRename)) {
-                    toRename = new HashSet<string>();
-                    _renameInfo.Add(containingType.Name, toRename);
-                }
-                toRename.Add(variable.Identifier.Text);
-            }
-        }
 
         public VisualBasicSyntaxNode ConvertTopLevelExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax topLevelExpression)
         {
@@ -517,11 +498,6 @@ namespace ICSharpCode.CodeConverter.VB
         {
             CSharpSyntaxNode parent = (CSharpSyntaxNode) id.Parent;
             var idText = AdjustIfEventIdentifier(id, parent);
-            var symbol = GetSymbol(parent) ?? GetDeclaredSymbol(parent);
-            string typeName = symbol.MatchesKind(SymbolKind.Field, SymbolKind.Local) ? symbol.ContainingType?.Name : null;
-            HashSet<string> idToRename;
-            if (typeName != null && _renameInfo.TryGetValue(typeName, out idToRename) && idToRename.Contains(idText))
-                return Identifier("_" + idText, false);
             // Underscore is a special character in VB lexer which continues lines - not sure where to find the whole set of other similar tokens if any
             // Rather than a complicated contextual rename, just add an extra dash to all identifiers and hope this method is consistently used
             bool keywordRequiresEscaping = id.IsKind(CSSyntaxKind.IdentifierToken) && KeywordRequiresEscaping(id);
@@ -696,11 +672,6 @@ namespace ICSharpCode.CodeConverter.VB
         {
             return syntax.SyntaxTree == _semanticModel.SyntaxTree
                 ? _semanticModel.GetSymbolInfo(syntax).Symbol
-                : null;
-        }
-        private ISymbol GetDeclaredSymbol(CSharpSyntaxNode syntax) {
-            return syntax.SyntaxTree == _semanticModel.SyntaxTree
-                ? _semanticModel.GetDeclaredSymbol(syntax)
                 : null;
         }
 

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -440,14 +440,14 @@ public class ShouldNotChange {
 }
 ",
 @"Public Class HasConflictingPropertyAndField
-    Private _test As Integer
+    Private f_Test As Integer
 
     Public Property Test As Integer
         Get
-            Return _test
+            Return f_Test
         End Get
         Set(ByVal value As Integer)
-            _test = value
+            f_Test = value
         End Set
     End Property
 End Class
@@ -463,6 +463,60 @@ Public Class ShouldNotChange
             test = value
         End Set
     End Property
+End Class");
+        }
+
+        [Fact]
+        public async Task CaseConflict_ArgumentFieldAndMethodWithOverloads() {
+            await TestConversionCSharpToVisualBasic(
+                @"public class HasConflictingMethodAndField {
+
+    public int HasConflictingParam(int test) {
+        this.teSt = test;
+        return test;
+    }
+
+    int teSt;
+
+    private int test() {
+        return 1;
+    }
+
+    public int Test() {
+        return test();
+    }
+
+    private int test(int arg) {
+        return arg;
+    }
+
+    public int Test(int arg) {
+        return test(arg);
+    }
+}",
+                @"Public Class HasConflictingMethodAndField
+    Public Function HasConflictingParam(ByVal test As Integer) As Integer
+        f_TeSt = test
+        Return test
+    End Function
+
+    Private f_TeSt As Integer
+
+    Private Function m_Test() As Integer
+        Return 1
+    End Function
+
+    Public Function Test() As Integer
+        Return m_Test()
+    End Function
+
+    Private Function m_Test(ByVal arg As Integer) As Integer
+        Return arg
+    End Function
+
+    Public Function Test(ByVal arg As Integer) As Integer
+        Return m_Test(arg)
+    End Function
 End Class");
         }
 
@@ -484,26 +538,25 @@ End Class");
     }
 }",
 @"Public Class HasConflictingPropertyAndField
-
     Public Function HasConflictingParam(ByVal test As Integer) As Integer
-        _test = test
+        f_Test = test
         Return test
     End Function
 
-    Private _test As Integer
+    Private f_Test As Integer
 
     Public Property Test As Integer
         Get
-            Return _test
+            Return f_Test
         End Get
         Set(ByVal value As Integer)
-            _test = value
+            f_Test = value
         End Set
     End Property
 End Class");
         }
 
-        [Fact]
+        [Fact(Skip = "Enable this once Expand phases is introduced which should disambiguate")]
         public async Task CaseConflict_ArgumentPropertyAndField() {
             await TestConversionCSharpToVisualBasic(
 @"public class HasConflictingPropertyAndField {
@@ -518,14 +571,14 @@ End Class");
     }
 }",
 @"Public Class HasConflictingPropertyAndField
-    Private _test As Integer
+    Private f_Test As Integer
 
     Public Property Test As Integer
         Get
-            Return _test
+            Return f_Test
         End Get
         Set(ByVal value As Integer)
-            _test = value
+            f_Test = value
         End Set
     End Property
 
@@ -555,20 +608,20 @@ public partial class HasConflictingPropertyAndField {
 }",
 @"Public Partial Class HasConflictingPropertyAndField
     Public Function HasConflictingParam(ByVal test As Integer) As Integer
-        Me._test = test
+        f_Test = test
         Return test
     End Function
 End Class
 
 Public Partial Class HasConflictingPropertyAndField
-    Private _test As Integer
+    Private f_Test As Integer
 
     Public Property Test As Integer
         Get
-            Return _test
+            Return f_Test
         End Get
         Set(ByVal value As Integer)
-            _test = value
+            f_Test = value
         End Set
     End Property
 End Class");

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -420,49 +420,18 @@ End Module");
     End Property
 End Class");
         }
-        [Fact]
-        public async Task Property_SameName() {
-            await TestConversionCSharpToVisualBasic(
-@"public class TestClass {
-    int test;
-    public int Test {
-        get { return test; }
-        set { test = value}
-    }
-    public int Method() {
-        int test = Test;
-        return test;
-    }
-}",
-@"Public Class TestClass
-    Private _test As Integer
 
-    Public Property Test As Integer
-        Get
-            Return _test
-        End Get
-        Set(ByVal value As Integer)
-            _test = value
-        End Set
-    End Property
-
-    Public Function Method() As Integer
-        Dim _test = Test
-        Return _test
-    End Function
-End Class");
-        }
         [Fact]
-        public async Task TwoClasses_SameName() {
+        public async Task CaseConflict_PropertyAndField_EnsureOtherClassNotAffected() {
             await TestConversionCSharpToVisualBasic(
-@"public class TestClass {
+@"public class HasConflictingPropertyAndField {
     int test;
     public int Test {
         get { return test; }
         set { test = value}
     }
 }
-public class TestClass1 {
+public class ShouldNotChange {
     int test;
     public int Test1 {
         get { return test; }
@@ -470,7 +439,7 @@ public class TestClass1 {
     }
 }
 ",
-@"Public Class TestClass
+@"Public Class HasConflictingPropertyAndField
     Private _test As Integer
 
     Public Property Test As Integer
@@ -483,7 +452,7 @@ public class TestClass1 {
     End Property
 End Class
 
-Public Class TestClass1
+Public Class ShouldNotChange
     Private test As Integer
 
     Public Property Test1 As Integer
@@ -496,21 +465,22 @@ Public Class TestClass1
     End Property
 End Class");
         }
+
         [Fact]
-        public async Task Argument_SameName() {
+        public async Task CaseConflict_ArgumentFieldAndProperty() {
             await TestConversionCSharpToVisualBasic(
-@"public class TestClass {
+@"public class HasConflictingPropertyAndField {
     int test;
     public int Test {
         get { return test; }
         set { test = value}
     }
-    public int Method(int test) {
+    public int HasConflictingParam(int test) {
         this.test = test;
         return test;
     }
 }",
-@"Public Class TestClass
+@"Public Class HasConflictingPropertyAndField
     Private _test As Integer
 
     Public Property Test As Integer
@@ -522,7 +492,7 @@ End Class");
         End Set
     End Property
 
-    Public Function Method(ByVal test As Integer) As Integer
+    Public Function HasConflictingParam(ByVal test As Integer) As Integer
         _test = test
         Return test
     End Function

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -537,6 +537,44 @@ End Class");
         }
 
         [Fact]
+        public async Task CaseConflict_PartialClass_ArgumentFieldAndProeprty() {
+            await TestConversionCSharpToVisualBasic(
+@"public partial class HasConflictingPropertyAndField {
+    public int HasConflictingParam(int test) {
+        this.test = test;
+        return test;
+    }
+}
+
+public partial class HasConflictingPropertyAndField {
+    int test;
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
+}",
+@"Public Partial Class HasConflictingPropertyAndField
+    Public Function HasConflictingParam(ByVal test As Integer) As Integer
+        Me._test = test
+        Return test
+    End Function
+End Class
+
+Public Partial Class HasConflictingPropertyAndField
+    Private _test As Integer
+
+    Public Property Test As Integer
+        Get
+            Return _test
+        End Get
+        Set(ByVal value As Integer)
+            _test = value
+        End Set
+    End Property
+End Class");
+        }
+
+        [Fact]
         public async Task TestPropertyWithExpressionBody()
         {
             await TestConversionCSharpToVisualBasic(

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -420,6 +420,114 @@ End Module");
     End Property
 End Class");
         }
+        [Fact]
+        public async Task Property_SameName() {
+            await TestConversionCSharpToVisualBasic(
+@"public class TestClass {
+    int test;
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
+    public int Method() {
+        int test = Test;
+        return test;
+    }
+}",
+@"Public Class TestClass
+    Private _test As Integer
+
+    Public Property Test As Integer
+        Get
+            Return _test
+        End Get
+        Set(ByVal value As Integer)
+            _test = value
+        End Set
+    End Property
+
+    Public Function Method() As Integer
+        Dim _test = Test
+        Return _test
+    End Function
+End Class");
+        }
+        [Fact]
+        public async Task TwoClasses_SameName() {
+            await TestConversionCSharpToVisualBasic(
+@"public class TestClass {
+    int test;
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
+}
+public class TestClass1 {
+    int test;
+    public int Test1 {
+        get { return test; }
+        set { test = value}
+    }
+}
+",
+@"Public Class TestClass
+    Private _test As Integer
+
+    Public Property Test As Integer
+        Get
+            Return _test
+        End Get
+        Set(ByVal value As Integer)
+            _test = value
+        End Set
+    End Property
+End Class
+
+Public Class TestClass1
+    Private test As Integer
+
+    Public Property Test1 As Integer
+        Get
+            Return test
+        End Get
+        Set(ByVal value As Integer)
+            test = value
+        End Set
+    End Property
+End Class");
+        }
+        [Fact]
+        public async Task Argument_SameName() {
+            await TestConversionCSharpToVisualBasic(
+@"public class TestClass {
+    int test;
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
+    public int Method(int test) {
+        this.test = test;
+        return test;
+    }
+}",
+@"Public Class TestClass
+    Private _test As Integer
+
+    Public Property Test As Integer
+        Get
+            Return _test
+        End Get
+        Set(ByVal value As Integer)
+            _test = value
+        End Set
+    End Property
+
+    Public Function Method(ByVal test As Integer) As Integer
+        _test = test
+        Return test
+    End Function
+End Class");
+        }
 
         [Fact]
         public async Task TestPropertyWithExpressionBody()

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -500,6 +500,39 @@ End Class");
         }
 
         [Fact]
+        public async Task CaseConflict_ArgumentPropertyAndField() {
+            await TestConversionCSharpToVisualBasic(
+@"public class HasConflictingPropertyAndField {
+    int test;
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
+    public int HasConflictingParam(int test) {
+        this.Test = test;
+        return test;
+    }
+}",
+@"Public Class HasConflictingPropertyAndField
+    Private _test As Integer
+
+    Public Property Test As Integer
+        Get
+            Return _test
+        End Get
+        Set(ByVal value As Integer)
+            _test = value
+        End Set
+    End Property
+
+    Public Function HasConflictingParam(ByVal test As Integer) As Integer
+        Me.Test = test
+        Return test
+    End Function
+End Class");
+        }
+
+        [Fact]
         public async Task TestPropertyWithExpressionBody()
         {
             await TestConversionCSharpToVisualBasic(

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -470,17 +470,26 @@ End Class");
         public async Task CaseConflict_ArgumentFieldAndProperty() {
             await TestConversionCSharpToVisualBasic(
 @"public class HasConflictingPropertyAndField {
-    int test;
-    public int Test {
-        get { return test; }
-        set { test = value}
-    }
+
     public int HasConflictingParam(int test) {
         this.test = test;
         return test;
     }
+
+    int test;
+
+    public int Test {
+        get { return test; }
+        set { test = value}
+    }
 }",
 @"Public Class HasConflictingPropertyAndField
+
+    Public Function HasConflictingParam(ByVal test As Integer) As Integer
+        _test = test
+        Return test
+    End Function
+
     Private _test As Integer
 
     Public Property Test As Integer
@@ -491,11 +500,6 @@ End Class");
             _test = value
         End Set
     End Property
-
-    Public Function HasConflictingParam(ByVal test As Integer) As Integer
-        _test = test
-        Return test
-    End Function
 End Class");
         }
 
@@ -509,7 +513,7 @@ End Class");
         set { test = value}
     }
     public int HasConflictingParam(int test) {
-        this.Test = test;
+        Test = test;
         return test;
     }
 }",

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -364,5 +364,22 @@ End Module");
     Public CR = &H0D * &B1
 End Class");
         }
+
+
+    [Fact(Skip = "Not yet implemented")]
+    public async Task CaseConflict_LocalWithLocal()
+    {
+        await TestConversionCSharpToVisualBasic(
+        @"void Test()
+{
+    object test = 5;
+    int tesT = (int) o;
+}
+", @"Private Sub Test()
+    Dim lTest As Object = 5
+    Dim lTesT = CInt(o)
+End Sub
+");
+        }
     }
 }


### PR DESCRIPTION
### Problem
In VB identifiers' names are case insensitive. There is
compilation error, when a property have the same name as a field or a local variable

### Solution
rename fields and local variables if needed with "_" at begin