### PR TITLE
C# -> VB: Remove extra parentheses around CType expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Avoid some case conflicts
 
 ### C# -> VB
-
+* Remove extra parentheses around CType expression
 
 ## [7.4.0] - 2019-12-17
 

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -316,22 +316,19 @@ namespace ICSharpCode.CodeConverter.VB
             SyntaxKind multiLineExpressionKind,
             LambdaHeaderSyntax header, SyntaxList<StatementSyntax> statements, EndBlockStatementSyntax endBlock)
         {
-            if (statements.Count == 1  && TryGetNodeForeSingleLineLambdaExpression(singleLineKind, statements, out VisualBasicSyntaxNode singleNode)) {
+            if (statements.Count == 1  && TryGetNodeForeSingleLineLambdaExpression(singleLineKind, statements[0], out VisualBasicSyntaxNode singleNode)) {
                 return SyntaxFactory.SingleLineLambdaExpression(singleLineKind, header, singleNode);
             }
 
             return SyntaxFactory.MultiLineLambdaExpression(multiLineExpressionKind, header, statements, endBlock);
         }
 
-        private static bool TryGetNodeForeSingleLineLambdaExpression(SyntaxKind kind,
-            SyntaxList<StatementSyntax> statements, out VisualBasicSyntaxNode singleNode)
-        {
-            switch (kind)
-            {
-                case SyntaxKind.SingleLineSubLambdaExpression:
-                    singleNode = statements[0];
+        private static bool TryGetNodeForeSingleLineLambdaExpression(SyntaxKind kind, StatementSyntax statement, out VisualBasicSyntaxNode singleNode) {
+            switch (kind) {
+                case SyntaxKind.SingleLineSubLambdaExpression when !(statement is MultiLineIfBlockSyntax):
+                    singleNode = statement;
                     return true;
-                case SyntaxKind.SingleLineFunctionLambdaExpression when UnpackExpressionFromStatement(statements[0], out var expression):
+                case SyntaxKind.SingleLineFunctionLambdaExpression when UnpackExpressionFromStatement(statement, out var expression):
                     singleNode = expression;
                     return true;
                 default:

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -878,24 +878,26 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitParenthesizedExpression(CSS.ParenthesizedExpressionSyntax node)
         {
-            return node.Expression.Accept(TriviaConvertingVisitor).TypeSwitch<VisualBasicSyntaxNode, AssignmentStatementSyntax, ExpressionSyntax, VisualBasicSyntaxNode>(
-                (AssignmentStatementSyntax statement) => {
-                    var subOrFunctionHeader = SyntaxFactory.LambdaHeader(
-                        SyntaxKind.FunctionLambdaHeader,
-                        SyntaxFactory.Token(SyntaxKind.FunctionKeyword)
-                    ).WithParameterList(SyntaxFactory.ParameterList());
-                    var multiLineFunctionLambdaExpression = SyntaxFactory.MultiLineFunctionLambdaExpression(
-                        subOrFunctionHeader,
-                        new SyntaxList<StatementSyntax>(new StatementSyntax[] {
-                            statement,
-                            SyntaxFactory.ReturnStatement(statement.Left)
-                        }),
-                        SyntaxFactory.EndFunctionStatement()
-                    );
-                    return SyntaxFactory.InvocationExpression(multiLineFunctionLambdaExpression, SyntaxFactory.ArgumentList());
-                },
-                (ExpressionSyntax expression) => SyntaxFactory.ParenthesizedExpression(expression)
-            );
+            return node.Expression.Accept(TriviaConvertingVisitor)
+                .TypeSwitch<VisualBasicSyntaxNode, AssignmentStatementSyntax, CTypeExpressionSyntax, ExpressionSyntax, VisualBasicSyntaxNode>(
+                    (AssignmentStatementSyntax statement) => {
+                        var subOrFunctionHeader = SyntaxFactory.LambdaHeader(
+                            SyntaxKind.FunctionLambdaHeader,
+                            SyntaxFactory.Token(SyntaxKind.FunctionKeyword)
+                        ).WithParameterList(SyntaxFactory.ParameterList());
+                        var multiLineFunctionLambdaExpression = SyntaxFactory.MultiLineFunctionLambdaExpression(
+                            subOrFunctionHeader,
+                            new SyntaxList<StatementSyntax>(new StatementSyntax[] {
+                                statement,
+                                SyntaxFactory.ReturnStatement(statement.Left)
+                            }),
+                            SyntaxFactory.EndFunctionStatement()
+                        );
+                        return SyntaxFactory.InvocationExpression(multiLineFunctionLambdaExpression, SyntaxFactory.ArgumentList());
+                    },
+                    (CTypeExpressionSyntax cTypeExpression) => cTypeExpression,
+                    (ExpressionSyntax expression) => SyntaxFactory.ParenthesizedExpression(expression)
+                );
         }
 
         public override VisualBasicSyntaxNode VisitPrefixUnaryExpression(CSS.PrefixUnaryExpressionSyntax node)

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -809,5 +809,63 @@ End Class");
     Next
 End Sub");
         }
+        [Fact]
+        public async Task MultilineSubExpressionWithSingleStatement() {
+            
+            await TestConversionCSharpToVisualBasic(
+@"public class TestClass : System.Collections.ObjectModel.ObservableCollection<string> {
+    public TestClass() {
+        PropertyChanged += (o, e) => {
+            if (e.PropertyName == ""AnyProperty"") {
+                Add(""changed"");
+            } else
+                RemoveAt(0);
+        };
+    }
+}",
+@"Public Class TestClass
+    Inherits ObjectModel.ObservableCollection(Of String)
+
+    Public Sub New()
+        AddHandler PropertyChanged, Sub(o, e)
+                                        If e.PropertyName Is ""AnyProperty"" Then
+                                            Add(""changed"")
+                                        Else
+                                            RemoveAt(0)
+                                        End If
+    End Sub
+End Class");
+        }
+        [Fact]
+        public async Task MultilineFunctionExpressionWithSingleStatement() {
+            await TestConversionCSharpToVisualBasic(
+@"using System;
+public class TestClass {
+    Func<object, string> create = o => {
+        if(o is TestClass)
+            return ""first"";
+        else
+            return ""second"";
+    };
+    public TestClass() {
+        string str = create(this);
+    }
+}",
+@"Imports System
+
+Public Class TestClass
+    Private create As Func(Of Object, String) = Function(o)
+                                                          If TypeOf o Is TestClass Then
+                                                              Return ""first""
+                                                          Else
+                                                              Return ""second""
+                                                          End If
+                                                      End Function
+
+    Public Sub New()
+        Dim str = create(Me)
+    End Sub
+End Class");
+        }
     }
 }

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -833,6 +833,7 @@ End Sub");
                                         Else
                                             RemoveAt(0)
                                         End If
+                                    End Sub
     End Sub
 End Class");
         }
@@ -854,7 +855,7 @@ public class TestClass {
 @"Imports System
 
 Public Class TestClass
-    Private create As Func(Of Object, String) = Function(o)
+    Private Event create As Func(Of Object, String) = Function(o)
                                                           If TypeOf o Is TestClass Then
                                                               Return ""first""
                                                           Else

--- a/Tests/VB/TypeCastTests.cs
+++ b/Tests/VB/TypeCastTests.cs
@@ -141,5 +141,27 @@ End Sub
 End Sub
 ");
         }
+        [Fact]
+        public async Task MethodInvocation() {
+            await TestConversionCSharpToVisualBasic(
+@"public class Test {
+    public void TestMethod() { }
+}
+public class Test2 {
+    public void TestMethod(object o) {
+        ((Test)o).TestMethod();
+    }
+}",
+@"Public Class Test
+    Public Sub TestMethod()
+    End Sub
+End Class
+
+Public Class Test2
+    Public Sub TestMethod(ByVal o As Object)
+        CType(o, Test).TestMethod()
+    End Sub
+End Class");
+        }
     }
 }


### PR DESCRIPTION
### Problem
Parentheses around CType expression lead to compilation error
((Test)o).TestMethod(); ->  (CType(o, Test)).TestMethod()