### PR TITLE
Nuspec dependencies

### DIFF
--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.csproj
@@ -4,24 +4,17 @@
     <AssemblyName>ICSharpCode.CodeConverter</AssemblyName>
     <RootNamespace>ICSharpCode.CodeConverter</RootNamespace>
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
-    <Company>ICSharpCode</Company>
-    <Description>Convert VB.NET to/from C#
-
-	* Accurate: Full project context (through Roslyn) is used to get the most accurate conversion.
-	* Actively developed: User feedback helps us continuously strive for a more accurate conversion.
-	* Completely free and open source: Check out [GitHub](https://github.com/icsharpcode/CodeConverter#code-converter-).</Description>
-    <Product>Code Converter for C# to/from VB.NET</Product>
-    <Copyright>Copyright (c) 2017-2020 AlphaSierraPapa for the CodeConverter team</Copyright>
     <AssemblyVersion>7.6.0.0</AssemblyVersion>
     <FileVersion>7.6.0.0</FileVersion>
     <Version>7.6.0</Version>
-    <PackageId>ICSharpCode.CodeConverter</PackageId>
+    <!-- We build against an older version to allow maximum compatibility for consumers producting a vsix for old versions, but if people target netstandard2, they might as well use the earliest version with support for that -->
+    <CodeAnalysisVersionBuiltAgainst>2.6.1</CodeAnalysisVersionBuiltAgainst>
+    <CodeAnalysisVersionForNetStandard2>3.0.0</CodeAnalysisVersionForNetStandard2>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/icsharpcode/CodeConverter/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/icsharpcode/CodeConverter/</RepositoryUrl>
-    <PackageTags>Convert Converter Conversion C# CSharp CS VB VB.NET Visual Basic Code Free Roslyn Tool</PackageTags>
-    <PackageReleaseNotes>See https://github.com/icsharpcode/CodeConverter/blob/master/CHANGELOG.md </PackageReleaseNotes>
+    <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
+    <NuspecProperties>$(NuspecProperties);id=$(AssemblyName);config=$(Configuration);version=$(Version);codeAnalysisVersionForNetStandard2=$(CodeAnalysisVersionForNetStandard2);codeAnalysisVersionBuiltAgainst=$(CodeAnalysisVersionBuiltAgainst)</NuspecProperties>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <LangVersion>7.3</LangVersion>
     <NoWarn>$(NoWarn);1998</NoWarn>
@@ -49,4 +42,10 @@
   <ItemGroup Condition="'$(SignAssembly)'=='True'">
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+        <NuspecProperties>$(NuspecProperties);commit=$(RepositoryCommit)</NuspecProperties>
+    </PropertyGroup>
+    <Message Importance="normal" Text="NuspecProperties: $(NuspecProperties)" />
+  </Target>
 </Project>

--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.nuspec
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.nuspec
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>ICSharpCode</authors>
+    <owners>ICSharpCode</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/icsharpcode/CodeConverter/</projectUrl>
+    <description>Convert VB.NET to/from C#
+
+	* Accurate: Full project context (through Roslyn) is used to get the most accurate conversion.
+	* Actively developed: User feedback helps us continuously strive for a more accurate conversion.
+	* Completely free and open source: Check out [GitHub](https://github.com/icsharpcode/CodeConverter#code-converter-).</description>
+    <releaseNotes>See https://github.com/icsharpcode/CodeConverter/blob/master/CHANGELOG.md</releaseNotes>
+    <copyright>Copyright (c) 2017-2020 AlphaSierraPapa for the CodeConverter team</copyright>
+    <tags>Convert Converter Conversion C# CSharp CS VB VB.NET Visual Basic Code Free Roslyn Tool</tags>
+    <repository type="git" url="https://github.com/icsharpcode/CodeConverter/" commit="$commit$" />
+    <dependencies>
+      <group targetFramework="netstandard1.3">
+        <dependency id="Microsoft.CodeAnalysis.CSharp" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.Common" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.VisualBasic" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$codeAnalysisVersionBuiltAgainst$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.VisualBasic" version="10.3.0" exclude="Build,Analyzers" />
+        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="netstandard2.0">
+        <dependency id="Microsoft.CodeAnalysis.CSharp" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.Common" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.VisualBasic" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.CodeAnalysis.Workspaces.Common" version="$codeAnalysisVersionForNetStandard2$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.VisualBasic" version="10.3.0" exclude="Build,Analyzers" />
+        <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\$config$\netstandard1.3\$id$.*" target="lib\netstandard1.3" />
+  </files>
+</package>

--- a/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.nuspec
+++ b/ICSharpCode.CodeConverter/ICSharpCode.CodeConverter.nuspec
@@ -41,6 +41,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\$config$\netstandard1.3\$id$.*" target="lib\netstandard1.3" />
+    <file src="bin\$config$\netstandard1.3\$id$.*" target="lib" />
   </files>
 </package>


### PR DESCRIPTION
### Problem
* The core library targets old versions of microsoft.codeanalysis in order to allow compatibility with old versions of visual studio (for both our own vsix, and other vsixs consuming this package).
* The core library also targets netstandard1.3 for this reason.
* By nuget's design, people who don't have such targeting requirements are also getting old dependency versions by default under this scheme unless they use a [nuget.config](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file) with dependency version set to highest.
* We feel a bit bad about propagating ancient versions of things

### Solution
* For people targeting netstandard2.0 or above, give them a later version (that our tests run against)

### Details
* I found the page here useful for checking which properties exist: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target/
* We may want to put a [nuget.config](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file) in our repository with dependency version set to highest to ensure we're testing against the latest consumers would get if they did the same

### To do
* [x] Set the version for netstandard2.0 to be the earliest version that supported netstandard2.0
* [ ] Test the nupkg - should give 2.6.1 if you install in a project below nestandard2, otherwise the 3.0 packages