### PR TITLE
C# -> VB: remove global overqualification for type's aliases

### DIFF
--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -689,12 +689,13 @@ namespace ICSharpCode.CodeConverter.VB
             return GetFullyQualifiedNameSyntax(symbol).ToString();
         }
 
-        public NameSyntax GetFullyQualifiedNameSyntax(INamespaceOrTypeSymbol symbol)
+        public NameSyntax GetFullyQualifiedNameSyntax(INamespaceOrTypeSymbol symbol, bool allowGlobalPrefix = true)
         {
             switch (symbol)
             {
                 case ITypeSymbol ts:
-                    return (NameSyntax) VbSyntaxGenerator.TypeExpression(ts);
+                    var nameSyntax = (NameSyntax)VbSyntaxGenerator.TypeExpression(ts);
+                    return !allowGlobalPrefix && nameSyntax is QualifiedNameSyntax qns && qns.Left is GlobalNameSyntax ? qns.Right : nameSyntax;
                 case INamespaceSymbol ns:
                     return SyntaxFactory.ParseName(ns.GetFullMetadataName());
                 default:

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -182,6 +182,9 @@ namespace ICSharpCode.CodeConverter.VB
             var nameToImport = _semanticModel.GetSymbolInfo(node.Name).Symbol is INamespaceOrTypeSymbol toImport
                 ? _commonConversions.GetFullyQualifiedNameSyntax(toImport)
                 : (NameSyntax)node.Name.Accept(TriviaConvertingVisitor);
+            var globalNameNode = nameToImport.DescendantNodes().OfType<GlobalNameSyntax>().FirstOrDefault();
+            if(globalNameNode != null)
+                nameToImport = nameToImport.ReplaceNodes((globalNameNode.Parent as QualifiedNameSyntax).Yield(), (orig, rewrite) => orig.Right);
             SimpleImportsClauseSyntax clause = SyntaxFactory.SimpleImportsClause(nameToImport);
 
             if (node.Alias != null) {

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -1533,7 +1533,8 @@ namespace ICSharpCode.CodeConverter.VB
             if (IsReturnValueDiscarded(node)) return SyntaxFactory.ThrowStatement(convertedExceptionExpression);
 
             _cSharpHelperMethodDefinition.AddThrowMethod = true;
-            var typeName = SyntaxFactory.ParseTypeName(_semanticModel.GetTypeInfo(node.Parent).ConvertedType?.GetFullMetadataName() ?? "Object");
+            var convertedType = _semanticModel.GetTypeInfo(node.Parent).ConvertedType ?? _compilation.GetTypeByMetadataName("System.Object");
+            var typeName = _commonConversions.GetFullyQualifiedNameSyntax(convertedType);
             var throwEx = SyntaxFactory.GenericName(CSharpHelperMethodDefinition.QualifiedThrowMethodName, SyntaxFactory.TypeArgumentList(typeName));
             var argList = SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList<ArgumentSyntax>(SyntaxFactory.SimpleArgument(convertedExceptionExpression)));
             return SyntaxFactory.InvocationExpression(throwEx, argList);

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -185,11 +185,8 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitUsingDirective(CSS.UsingDirectiveSyntax node)
         {
             var nameToImport = _semanticModel.GetSymbolInfo(node.Name).Symbol is INamespaceOrTypeSymbol toImport
-                ? _commonConversions.GetFullyQualifiedNameSyntax(toImport)
+                ? _commonConversions.GetFullyQualifiedNameSyntax(toImport, false)
                 : (NameSyntax)node.Name.Accept(TriviaConvertingVisitor);
-            var globalNameNode = nameToImport.DescendantNodes().OfType<GlobalNameSyntax>().FirstOrDefault();
-            if(globalNameNode != null)
-                nameToImport = nameToImport.ReplaceNodes((globalNameNode.Parent as QualifiedNameSyntax).Yield(), (orig, rewrite) => orig.Right);
             SimpleImportsClauseSyntax clause = SyntaxFactory.SimpleImportsClause(nameToImport);
 
             if (node.Alias != null) {

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -241,6 +241,26 @@ End Structure");
         }
 
         [Fact]
+        public async Task GlobalImportsStatement()
+        {
+               await TestConversionCSharpToVisualBasic(@"using MyAlias = global::System.Runtime.Remoting.Metadata.W3cXsd2001;
+using SO = global::System.Runtime.Remoting.Metadata.SoapOption;
+
+class ThisUri
+{
+    private MyAlias.SoapAnyUri s;
+    private SO so;
+}",
+                        @"Imports MyAlias = System.Runtime.Remoting.Metadata.W3cXsd2001
+Imports SO = System.Runtime.Remoting.Metadata.SoapOption
+
+Friend Class ThisUri
+    Private s As MyAlias.SoapAnyUri
+    Private so As SO
+End Class");
+        }
+
+        [Fact]
         public async Task MoveImportsStatement()
         {
             await TestConversionCSharpToVisualBasic("namespace test { using SomeNamespace; }",
@@ -249,6 +269,7 @@ End Structure");
 Namespace test
 End Namespace");
         }
+
         [Fact]
         public async Task InnerNamespace_MoveImportsStatement()
         {
@@ -267,6 +288,7 @@ Namespace System
     End Class
 End Namespace", conversion: EmptyNamespaceOptionStrictOff);
         }
+
         [Fact]
         public async Task ClassImplementsInterface()
         {
@@ -298,6 +320,7 @@ Public Interface iDisplay
     Sub DisplayName()
 End Interface");
         }
+
         [Fact]
         public async Task ClassExplicitlyImplementsInterface()
         {
@@ -329,6 +352,7 @@ Public Interface iDisplay
     Sub DisplayName()
 End Interface");
         }
+
         [Fact]
         public async Task ClassExplicitlyImplementsInterface_Indexer()
         {
@@ -359,6 +383,7 @@ Public Interface iDisplay
     Default Property Item(ByVal i As Integer) As Object
 End Interface");
         }
+
         [Fact]
         public async Task ClassImplementsInterface2()
         {
@@ -387,6 +412,7 @@ End Class");
     Inherits InvalidDataException
 End Class");
         }
+
         [Fact]
         public async Task StaticGenericClass() {
             await TestConversionCSharpToVisualBasic(
@@ -419,6 +445,7 @@ Public NotInheritable Class TestClass(Of T As {Class1, New})
     End Function
 End Class");
         }
+
         [Fact]
         public async Task ImplementsGenericInterface()
         {


### PR DESCRIPTION
### Problem
Compile errors after conversion for some aliases, like:
Imports DbModelBuilder = Global.Microsoft.EntityFrameworkCore.ModelBuilder;

I can't reproduce the problem using simple test

### Solution
remove GlobalNameSyntax from QualifiedNameSyntax in Imports