### PR TITLE
Port trivia line by line C# -> VB

### DIFF
--- a/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
+++ b/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
@@ -7,11 +7,17 @@ namespace ICSharpCode.CodeConverter.Shared
         public const string SelectedNodeAnnotationKind = "CodeConverter.SelectedNode";
         public const string AnnotatedNodeIsParentData = "CodeConverter.SelectedNode.IsAllChildrenOfThisNode";
         public const string ConversionErrorAnnotationKind = "CodeConverter.ConversionError";
-        public const string WithinOriginalLineAnnotationKind = "CodeConverter.WithinOriginalLine";
+        public const string SourceStartLineAnnotationKind = "CodeConverter.SourceStartLine";
+        public const string SourceEndLineAnnotationKind = "CodeConverter.SourceEndLine";
 
-        public static SyntaxAnnotation OriginalLineAnnotation(FileLinePositionSpan origLinespan)
+        public static SyntaxAnnotation SourceStartLine(FileLinePositionSpan origLinespan)
         {
-            return new SyntaxAnnotation(WithinOriginalLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString());
+            return new SyntaxAnnotation(SourceStartLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString());
+        }
+
+        public static SyntaxAnnotation SourceEndLine(FileLinePositionSpan origLinespan)
+        {
+            return new SyntaxAnnotation(SourceEndLineAnnotationKind, origLinespan.EndLinePosition.Line.ToString());
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
+++ b/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
@@ -5,5 +5,6 @@
         public const string SelectedNodeAnnotationKind = "CodeConverter.SelectedNode";
         public const string AnnotatedNodeIsParentData = "CodeConverter.SelectedNode.IsAllChildrenOfThisNode";
         public const string ConversionErrorAnnotationKind = "CodeConverter.ConversionError";
+        public const string WithinOriginalLineAnnotationKind = "CodeConverter.WithinOriginalLine";
     }
 }

--- a/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
+++ b/ICSharpCode.CodeConverter/Shared/AnnotationConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace ICSharpCode.CodeConverter.Shared
+﻿using Microsoft.CodeAnalysis;
+
+namespace ICSharpCode.CodeConverter.Shared
 {
     internal class AnnotationConstants
     {
@@ -6,5 +8,10 @@
         public const string AnnotatedNodeIsParentData = "CodeConverter.SelectedNode.IsAllChildrenOfThisNode";
         public const string ConversionErrorAnnotationKind = "CodeConverter.ConversionError";
         public const string WithinOriginalLineAnnotationKind = "CodeConverter.WithinOriginalLine";
+
+        public static SyntaxAnnotation OriginalLineAnnotation(FileLinePositionSpan origLinespan)
+        {
+            return new SyntaxAnnotation(WithinOriginalLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString());
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -88,8 +88,8 @@ namespace ICSharpCode.CodeConverter.Shared
         {
             var convertedTrivia = trailingTrivia.ConvertTrivia();
             var toReplace = FindNonZeroWidthToken(target, targetLine.End);
-            if (toReplace.Span.Start > targetLine.End) {
-                toReplace = toReplace.GetPreviousToken(); //TODO: Find out why FindToken is off by one from what I want sometimes, is there a better alternative?
+            if (toReplace.Width() == 0) {
+                toReplace = toReplace.GetPreviousToken(); //Never append *trailing* trivia to the end of file token
             }
             target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.TrailingTrivia)));
             return target;

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -91,7 +91,7 @@ namespace ICSharpCode.CodeConverter.Shared
             if (toReplace.Width() == 0) {
                 toReplace = toReplace.GetPreviousToken(); //Never append *trailing* trivia to the end of file token
             }
-            target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.TrailingTrivia)));
+            target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia.ToList(), toReplace.TrailingTrivia)));
             return target;
         }
 
@@ -122,7 +122,7 @@ namespace ICSharpCode.CodeConverter.Shared
             if (toReplace.Span.End < targetLine.Start) {
                 toReplace = toReplace.GetNextToken(); //TODO: Find out why FindToken is off by one from what I want sometimes, is there a better alternative?
             }
-            target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.LeadingTrivia)));
+            target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(PrependPreservingImportantTrivia(convertedTrivia.ToList(), toReplace.LeadingTrivia)));
             return target;
         }
 
@@ -132,7 +132,7 @@ namespace ICSharpCode.CodeConverter.Shared
             return default;
         }
 
-        private static IEnumerable<SyntaxTrivia> PrependPreservingImportantTrivia(IEnumerable<SyntaxTrivia> convertedTrivia, IEnumerable<SyntaxTrivia> existingTrivia)
+        private static IEnumerable<SyntaxTrivia> PrependPreservingImportantTrivia(IReadOnlyCollection<SyntaxTrivia> convertedTrivia, IReadOnlyCollection<SyntaxTrivia> existingTrivia)
         {
             if (existingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
                 return convertedTrivia.Concat(existingTrivia);

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -58,8 +58,8 @@ namespace ICSharpCode.CodeConverter.Shared
             //TODO Possible perf: Find token starting from position of last replaced token rather than from the root node each time?
             _target = target;
             for (int i = _sourceLines.Count - 1; i >= 0; i--) {
-                target = ConvertTrailingForSourceLine(target, i);
-                target = ConvertLeadingForSourceLine(target, i);
+                ConvertTrailingForSourceLine(target, i);
+                ConvertLeadingForSourceLine(target, i);
             }
             //return target;
             return _target.ReplaceTokens(_targetTokenToTrivia.Keys, (original, rewritten) => {
@@ -86,7 +86,7 @@ namespace ICSharpCode.CodeConverter.Shared
                 if (line != default) {
                     _trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
                     foreach (var triviaList in _trailingTriviaCarriedOver) {
-                        target = PrependTrailingTrivia(target, line, triviaList);
+                        PrependTrailingTrivia(target, line, triviaList);
                     }
                     _trailingTriviaCarriedOver.Clear();
                 } else if (endOfSourceLine.TrailingTrivia.Span.Start > sourceLine.Start) {
@@ -126,7 +126,7 @@ namespace ICSharpCode.CodeConverter.Shared
                 if (line != default) {
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
                     foreach (var triviaList in _leadingTriviaCarriedOver) {
-                        target = PrependLeadingTrivia(target, line, triviaList);
+                        PrependLeadingTrivia(target, line, triviaList);
                     }
                     _leadingTriviaCarriedOver.Clear();
                 } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -109,7 +109,7 @@ namespace ICSharpCode.CodeConverter.Shared
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
                     var originalToReplace = targetLine.GetLeadingForLine(_target); //TODO Use withinline textline extensions
                     var targetTrivia = GetTargetTriviaCollection(originalToReplace);
-                    targetTrivia.Trailing.AddRange(_leadingTriviaCarriedOver.Select(t => t.ConvertTrivia().ToList()));
+                    targetTrivia.Leading.AddRange(_leadingTriviaCarriedOver.Select(t => t.ConvertTrivia().ToList()));
                     _leadingTriviaCarriedOver.Clear();
                 } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ICSharpCode.CodeConverter.Shared
+{
+    internal class LineTriviaMapper
+    {
+        private readonly SyntaxNode source;
+        private readonly TextLineCollection sourceLines;
+        private readonly TextLineCollection originalTargetLines;
+        private readonly IReadOnlyDictionary<int, TextLine> targetLeadingTextLineFromSourceLine;
+        private readonly IReadOnlyDictionary<int, TextLine> targetTrailingTextLineFromSourceLine;
+
+        public LineTriviaMapper(SyntaxNode source, TextLineCollection sourceLines, TextLineCollection originalTargetLines, Dictionary<int, TextLine> targetLeadingTextLineFromSourceLine, Dictionary<int, TextLine> targetTrailingTextLineFromSourceLine)
+        {
+            this.source = source;
+            this.sourceLines = sourceLines;
+            this.originalTargetLines = originalTargetLines;
+            this.targetLeadingTextLineFromSourceLine = targetLeadingTextLineFromSourceLine;
+            this.targetTrailingTextLineFromSourceLine = targetTrailingTextLineFromSourceLine;
+        }
+
+        /// <summary>
+        /// For each source line:
+        /// * Add leading trivia to the start of the first target line containing a node converted from that source line
+        /// * Add trailing trivia to the end of the last target line containing a node converted from that source line
+        /// Makes no attempt to convert whitespace/newline-only trivia
+        /// Currently doesn't deal with any within-line trivia (i.e. /* block comments */)
+        /// </summary>
+        public static SyntaxNode MapSourceTriviaToTarget(SyntaxNode source, SyntaxNode target)
+        {
+            var originalTargetLines = target.GetText().Lines;
+
+            var targetNodesBySourceStartLine = target.GetAnnotatedNodesAndTokens(AnnotationConstants.SourceStartLineAnnotationKind)
+                .ToLookup(n => n.GetAnnotations(AnnotationConstants.SourceStartLineAnnotationKind).Select(a => int.Parse(a.Data)).Min())
+                .ToDictionary(g => g.Key, g => originalTargetLines.GetLineFromPosition(g.Min(x => x.GetLocation().SourceSpan.Start)));
+
+            var targetNodesBySourceEndLine = target.GetAnnotatedNodesAndTokens(AnnotationConstants.SourceEndLineAnnotationKind)
+                .ToLookup(n => n.GetAnnotations(AnnotationConstants.SourceEndLineAnnotationKind).Select(a => int.Parse(a.Data)).Max())
+                .ToDictionary(g => g.Key, g => originalTargetLines.GetLineFromPosition(g.Max(x => x.GetLocation().SourceSpan.End)));
+
+            var sourceLines = source.GetText().Lines;
+            var lineTriviaMapper = new LineTriviaMapper(source, sourceLines, originalTargetLines, targetNodesBySourceStartLine, targetNodesBySourceEndLine);
+            return lineTriviaMapper.GetTargetWithSourceTrivia(target);
+        }
+
+        private SyntaxNode GetTargetWithSourceTrivia(SyntaxNode target)
+        {
+            //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
+            //TODO Keep track of lost comments and put them in a comment at the end of the file
+            for (int i = sourceLines.Count - 1; i >= 0; i--) {
+                var sourceLine = sourceLines[i];
+                var endOfSourceLine = source.FindToken(sourceLine.End);
+                var startOfSourceLine = source.FindTokenOnRightOfPosition(sourceLine.Start);
+
+                if (endOfSourceLine.TrailingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
+                    var line = GetBestLine(targetTrailingTextLineFromSourceLine, i);
+                    if (line != default) {
+                        var convertedTrivia = endOfSourceLine.TrailingTrivia.ConvertTrivia();
+                        var toReplace = target.FindToken(line.End);
+                        target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(convertedTrivia));
+                    }
+                }
+
+                if (startOfSourceLine.LeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
+                    var line = GetBestLine(targetLeadingTextLineFromSourceLine, i);
+                    if (line != default) {
+                        var convertedTrivia = startOfSourceLine.LeadingTrivia.ConvertTrivia();
+                        var toReplace = target.FindTokenOnRightOfPosition(line.Start);
+                        target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(convertedTrivia));
+                    }
+                }
+            }
+            return target;
+        }
+
+        private TextLine GetBestLine(IReadOnlyDictionary<int, TextLine> sourceToTargetLine, int sourceLineIndex)
+        {
+            if (sourceToTargetLine.TryGetValue(sourceLineIndex, out var targetLineIndex)) return targetLineIndex;
+
+            var (previousOffset, previousLine) = GetOffsetSourceLineTargetNodes(sourceToTargetLine, sourceLineIndex, -1);
+            var (nextOffset, nextLine) = GetOffsetSourceLineTargetNodes(sourceToTargetLine, sourceLineIndex, 1);
+            if (previousLine != default && nextLine != default) {
+                var guessedTargetLine = originalTargetLines[((previousLine.LineNumber - previousOffset) + (nextLine.LineNumber - nextOffset)) / 2];
+                //TODO Annotate this case with a comment to say it's a guess
+                //TODO Move this guessing phase to fill in the gaps after all other allocations are made to avoid clashes with other moved lines
+                if (previousLine.LineNumber < guessedTargetLine.LineNumber && guessedTargetLine.LineNumber < nextLine.LineNumber) return guessedTargetLine;
+            }
+            return default;
+        }
+
+        private static (int offset, TextLine targetLine) GetOffsetSourceLineTargetNodes(IReadOnlyDictionary<int, TextLine> sourceToTargetLine, int sourceLineIndex, int multiplier)
+        {
+            for (int offset = 1; offset <= 5; offset++) {
+                if (sourceToTargetLine.TryGetValue(sourceLineIndex + (offset * multiplier), out var line)) {
+                    return (offset * multiplier, line);
+                }
+            }
+            return (0, default);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -99,11 +99,8 @@ namespace ICSharpCode.CodeConverter.Shared
 
         private SyntaxNode PrependTrailingTrivia(SyntaxNode target, TextLine targetLine, SyntaxTriviaList trailingTrivia)
         {
-            var convertedTrivia = trailingTrivia.ConvertTrivia();
-            var toReplace = GetTrailingForLine(target, targetLine);
             var originalToReplace = GetTrailingForLine(_target, targetLine);
             SaveTrailingTrivia(originalToReplace, new [] { trailingTrivia }.ToList());
-            target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia.ToList(), toReplace.TrailingTrivia)));
             return target;
         }
 
@@ -139,11 +136,8 @@ namespace ICSharpCode.CodeConverter.Shared
 
         private SyntaxNode PrependLeadingTrivia(SyntaxNode target, TextLine targetLine, SyntaxTriviaList leadingTrivia)
         {
-            var convertedTrivia = leadingTrivia.ConvertTrivia();
-            var toReplace = GetLeadingForLine(target, targetLine);
             var originalToReplace = GetLeadingForLine(_target, targetLine);
             SaveLeadingTrivia(originalToReplace, new[] { leadingTrivia }.ToList());
-            target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(PrependPreservingImportantTrivia(convertedTrivia.ToList(), toReplace.LeadingTrivia)));
             return target;
         }
 

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -85,22 +85,14 @@ namespace ICSharpCode.CodeConverter.Shared
                 var targetLine = GetBestLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
                 if (targetLine != default) {
                     _trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
-                    foreach (var triviaList in _trailingTriviaCarriedOver) {
-                        PrependTrailingTrivia(target, targetLine, triviaList);
-                    }
+                    var originalToReplace = GetTrailingForLine(_target, targetLine);
+                    SaveTrailingTrivia(originalToReplace, _trailingTriviaCarriedOver);
                     _trailingTriviaCarriedOver.Clear();
                 } else if (endOfSourceLine.TrailingTrivia.Span.Start > sourceLine.Start) {
                     _trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
                 }
             }
 
-            return target;
-        }
-
-        private SyntaxNode PrependTrailingTrivia(SyntaxNode target, TextLine targetLine, SyntaxTriviaList trailingTrivia)
-        {
-            var originalToReplace = GetTrailingForLine(_target, targetLine);
-            SaveTrailingTrivia(originalToReplace, new [] { trailingTrivia }.ToList());
             return target;
         }
 
@@ -122,22 +114,14 @@ namespace ICSharpCode.CodeConverter.Shared
                 var targetLine = GetBestLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
                 if (targetLine != default) {
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
-                    foreach (var triviaList in _leadingTriviaCarriedOver) {
-                        PrependLeadingTrivia(target, targetLine, triviaList);
-                    }
+                    var originalToReplace = GetLeadingForLine(_target, targetLine);
+                    SaveLeadingTrivia(originalToReplace, _leadingTriviaCarriedOver);
                     _leadingTriviaCarriedOver.Clear();
                 } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
                 }
             }
 
-            return target;
-        }
-
-        private SyntaxNode PrependLeadingTrivia(SyntaxNode target, TextLine targetLine, SyntaxTriviaList leadingTrivia)
-        {
-            var originalToReplace = GetLeadingForLine(_target, targetLine);
-            SaveLeadingTrivia(originalToReplace, new[] { leadingTrivia }.ToList());
             return target;
         }
 

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -61,15 +61,17 @@ namespace ICSharpCode.CodeConverter.Shared
                 target = ConvertTrailingForSourceLine(target, i);
                 target = ConvertLeadingForSourceLine(target, i);
             }
-            return target;
-            //return _target.ReplaceTokens(_targetTokenToTrivia.Keys, (original, rewritten) => {
-            //    var trivia = _targetTokenToTrivia[original];
-            //    trivia.Leading.Reverse();
-            //    trivia.Trailing.Reverse();
-            //    var leadingTrivia = rewritten.LeadingTrivia.Concat(trivia.Leading.SelectMany(triviaList => triviaList));
-            //    var trailingTrivia = rewritten.TrailingTrivia.Concat(trivia.Trailing.SelectMany(triviaList => triviaList));
-            //    return rewritten.WithLeadingTrivia(leadingTrivia).WithTrailingTrivia(trailingTrivia);
-            //});
+            //return target;
+            return _target.ReplaceTokens(_targetTokenToTrivia.Keys, (original, rewritten) => {
+                var trivia = _targetTokenToTrivia[original];
+                foreach (var triviaList in trivia.Trailing) {
+                    rewritten = rewritten.WithTrailingTrivia(PrependPreservingImportantTrivia(triviaList.ToList(), rewritten.TrailingTrivia));
+                }
+                foreach (var triviaList in trivia.Leading) {
+                    rewritten = rewritten.WithLeadingTrivia(PrependPreservingImportantTrivia(triviaList.ToList(), rewritten.LeadingTrivia));
+                }
+                return rewritten;
+            });
         }
 
 

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -82,11 +82,11 @@ namespace ICSharpCode.CodeConverter.Shared
             var endOfSourceLine = FindNonZeroWidthToken(_source, sourceLine.End);
 
             if (endOfSourceLine.TrailingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                var line = GetBestLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
-                if (line != default) {
+                var targetLine = GetBestLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
+                if (targetLine != default) {
                     _trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
                     foreach (var triviaList in _trailingTriviaCarriedOver) {
-                        PrependTrailingTrivia(target, line, triviaList);
+                        PrependTrailingTrivia(target, targetLine, triviaList);
                     }
                     _trailingTriviaCarriedOver.Clear();
                 } else if (endOfSourceLine.TrailingTrivia.Span.Start > sourceLine.Start) {
@@ -119,11 +119,11 @@ namespace ICSharpCode.CodeConverter.Shared
             var sourceLine = _sourceLines[sourceLineIndex];
             var startOfSourceLine = FindNonZeroWidthToken(_source, sourceLine.Start);
             if (startOfSourceLine.LeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                var line = GetBestLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
-                if (line != default) {
+                var targetLine = GetBestLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
+                if (targetLine != default) {
                     _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
                     foreach (var triviaList in _leadingTriviaCarriedOver) {
-                        PrependLeadingTrivia(target, line, triviaList);
+                        PrependLeadingTrivia(target, targetLine, triviaList);
                     }
                     _leadingTriviaCarriedOver.Clear();
                 } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -9,18 +9,18 @@ namespace ICSharpCode.CodeConverter.Shared
 {
     internal class LineTriviaMapper
     {
-        private readonly SyntaxNode source;
-        private readonly TextLineCollection sourceLines;
-        private readonly IReadOnlyDictionary<int, TextLine> targetLeadingTextLineFromSourceLine;
-        private readonly IReadOnlyDictionary<int, TextLine> targetTrailingTextLineFromSourceLine;
-        private readonly List<SyntaxTriviaList> leadingTriviaCarriedOver = new List<SyntaxTriviaList>();
-        private readonly List<SyntaxTriviaList> trailingTriviaCarriedOver = new List<SyntaxTriviaList>();
+        private readonly SyntaxNode _source;
+        private readonly TextLineCollection _sourceLines;
+        private readonly IReadOnlyDictionary<int, TextLine> _targetLeadingTextLineFromSourceLine;
+        private readonly IReadOnlyDictionary<int, TextLine> _targetTrailingTextLineFromSourceLine;
+        private readonly List<SyntaxTriviaList> _leadingTriviaCarriedOver = new List<SyntaxTriviaList>();
+        private readonly List<SyntaxTriviaList> _trailingTriviaCarriedOver = new List<SyntaxTriviaList>();
         public LineTriviaMapper(SyntaxNode source, TextLineCollection sourceLines, Dictionary<int, TextLine> targetLeadingTextLineFromSourceLine, Dictionary<int, TextLine> targetTrailingTextLineFromSourceLine)
         {
-            this.source = source;
-            this.sourceLines = sourceLines;
-            this.targetLeadingTextLineFromSourceLine = targetLeadingTextLineFromSourceLine;
-            this.targetTrailingTextLineFromSourceLine = targetTrailingTextLineFromSourceLine;
+            _source = source;
+            _sourceLines = sourceLines;
+            _targetLeadingTextLineFromSourceLine = targetLeadingTextLineFromSourceLine;
+            _targetTrailingTextLineFromSourceLine = targetTrailingTextLineFromSourceLine;
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace ICSharpCode.CodeConverter.Shared
             //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
             //TODO Possible perf: Find token starting from position of last replaced token rather than from the root node each time?
 
-            for (int i = sourceLines.Count - 1; i >= 0; i--) {
+            for (int i = _sourceLines.Count - 1; i >= 0; i--) {
                 target = ConvertTrailingForSourceLine(target, i);
                 target = ConvertLeadingForSourceLine(target, i);
             }
@@ -65,19 +65,19 @@ namespace ICSharpCode.CodeConverter.Shared
 
         private SyntaxNode ConvertTrailingForSourceLine(SyntaxNode target, int sourceLineIndex)
         {
-            var sourceLine = sourceLines[sourceLineIndex];
-            var endOfSourceLine = FindNonZeroWidthToken(source, sourceLine.End);
+            var sourceLine = _sourceLines[sourceLineIndex];
+            var endOfSourceLine = FindNonZeroWidthToken(_source, sourceLine.End);
 
             if (endOfSourceLine.TrailingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                var line = GetBestLine(targetTrailingTextLineFromSourceLine, sourceLineIndex);
+                var line = GetBestLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
                 if (line != default) {
-                    foreach (var triviaList in trailingTriviaCarriedOver) {
+                    foreach (var triviaList in _trailingTriviaCarriedOver) {
                         target = PrependTrailingTrivia(target, line, triviaList);
                     }
-                    trailingTriviaCarriedOver.Clear();
+                    _trailingTriviaCarriedOver.Clear();
                     target = PrependTrailingTrivia(target, line, endOfSourceLine.TrailingTrivia);
                 } else if (endOfSourceLine.TrailingTrivia.Span.Start > sourceLine.Start) {
-                    trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
+                    _trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
                 }
             }
 
@@ -97,18 +97,18 @@ namespace ICSharpCode.CodeConverter.Shared
 
         private SyntaxNode ConvertLeadingForSourceLine(SyntaxNode target, int sourceLineIndex)
         {
-            var sourceLine = sourceLines[sourceLineIndex];
-            var startOfSourceLine = FindNonZeroWidthToken(source, sourceLine.Start);
+            var sourceLine = _sourceLines[sourceLineIndex];
+            var startOfSourceLine = FindNonZeroWidthToken(_source, sourceLine.Start);
             if (startOfSourceLine.LeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                var line = GetBestLine(targetLeadingTextLineFromSourceLine, sourceLineIndex);
+                var line = GetBestLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
                 if (line != default) {
-                    foreach (var triviaList in leadingTriviaCarriedOver) {
+                    foreach (var triviaList in _leadingTriviaCarriedOver) {
                         target = PrependLeadingTrivia(target, line, triviaList);
                     }
-                    leadingTriviaCarriedOver.Clear();
+                    _leadingTriviaCarriedOver.Clear();
                     target = PrependLeadingTrivia(target, line, startOfSourceLine.LeadingTrivia);
                 } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {
-                    leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
+                    _leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
                 }
             }
 

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -11,15 +11,13 @@ namespace ICSharpCode.CodeConverter.Shared
     {
         private readonly SyntaxNode source;
         private readonly TextLineCollection sourceLines;
-        private readonly TextLineCollection originalTargetLines;
         private readonly IReadOnlyDictionary<int, TextLine> targetLeadingTextLineFromSourceLine;
         private readonly IReadOnlyDictionary<int, TextLine> targetTrailingTextLineFromSourceLine;
 
-        public LineTriviaMapper(SyntaxNode source, TextLineCollection sourceLines, TextLineCollection originalTargetLines, Dictionary<int, TextLine> targetLeadingTextLineFromSourceLine, Dictionary<int, TextLine> targetTrailingTextLineFromSourceLine)
+        public LineTriviaMapper(SyntaxNode source, TextLineCollection sourceLines, Dictionary<int, TextLine> targetLeadingTextLineFromSourceLine, Dictionary<int, TextLine> targetTrailingTextLineFromSourceLine)
         {
             this.source = source;
             this.sourceLines = sourceLines;
-            this.originalTargetLines = originalTargetLines;
             this.targetLeadingTextLineFromSourceLine = targetLeadingTextLineFromSourceLine;
             this.targetTrailingTextLineFromSourceLine = targetTrailingTextLineFromSourceLine;
         }
@@ -44,7 +42,7 @@ namespace ICSharpCode.CodeConverter.Shared
                 .ToDictionary(g => g.Key, g => originalTargetLines.GetLineFromPosition(g.Max(x => x.GetLocation().SourceSpan.End)));
 
             var sourceLines = source.GetText().Lines;
-            var lineTriviaMapper = new LineTriviaMapper(source, sourceLines, originalTargetLines, targetNodesBySourceStartLine, targetNodesBySourceEndLine);
+            var lineTriviaMapper = new LineTriviaMapper(source, sourceLines, targetNodesBySourceStartLine, targetNodesBySourceEndLine);
             return lineTriviaMapper.GetTargetWithSourceTrivia(target);
         }
 
@@ -53,7 +51,6 @@ namespace ICSharpCode.CodeConverter.Shared
             //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
             //TODO Keep track of lost comments and put them in a comment at the end of the file
             var triviaMappings = new List<TriviaMapping>();
-            var leadingSourceForTargetMappings = new List<TriviaMapping>();
             for (int i = sourceLines.Count - 1; i >= 0; i--) {
                 var sourceLine = sourceLines[i];
                 var endOfSourceLine = source.FindToken(sourceLine.End);

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -13,7 +13,8 @@ namespace ICSharpCode.CodeConverter.Shared
         private readonly TextLineCollection sourceLines;
         private readonly IReadOnlyDictionary<int, TextLine> targetLeadingTextLineFromSourceLine;
         private readonly IReadOnlyDictionary<int, TextLine> targetTrailingTextLineFromSourceLine;
-
+        private readonly List<SyntaxTriviaList> leadingTriviaCarriedOver = new List<SyntaxTriviaList>();
+        private readonly List<SyntaxTriviaList> trailingTriviaCarriedOver = new List<SyntaxTriviaList>();
         public LineTriviaMapper(SyntaxNode source, TextLineCollection sourceLines, Dictionary<int, TextLine> targetLeadingTextLineFromSourceLine, Dictionary<int, TextLine> targetTrailingTextLineFromSourceLine)
         {
             this.source = source;
@@ -51,8 +52,8 @@ namespace ICSharpCode.CodeConverter.Shared
         private SyntaxNode GetTargetWithSourceTrivia(SyntaxNode target)
         {
             //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
-            //TODO Keep track of lost comments and put them in a comment at the end of the file
             //TODO Possible perf: Find token starting from position of last replaced token rather than from the root node each time?
+
             for (int i = sourceLines.Count - 1; i >= 0; i--) {
                 target = ConvertTrailingForSourceLine(target, i);
                 target = ConvertLeadingForSourceLine(target, i);
@@ -60,28 +61,12 @@ namespace ICSharpCode.CodeConverter.Shared
             return target;
         }
 
-        private SyntaxNode ConvertLeadingForSourceLine(SyntaxNode target, int sourceLineIndex)
-        {
-            var startOfSourceLine = source.FindToken(sourceLines[sourceLineIndex].Start);
-            if (startOfSourceLine.LeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                var line = GetBestLine(targetLeadingTextLineFromSourceLine, sourceLineIndex);
-                if (line != default) {
-                    var convertedTrivia = startOfSourceLine.LeadingTrivia.ConvertTrivia();
-                    var toReplace = target.FindToken(line.Start);
-                    //TODO Check whether there's a general version of FindToken that covers this and similar comments
-                    if (toReplace.Span.End < line.Start) {
-                        toReplace = toReplace.GetNextToken(); //Zero width tokens with newline trivia can cause this, e.g. EOF
-                    }
-                    target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.LeadingTrivia)));
-                }
-            }
 
-            return target;
-        }
 
         private SyntaxNode ConvertTrailingForSourceLine(SyntaxNode target, int sourceLineIndex)
         {
-            var endOfSourceLine = source.FindToken(sourceLines[sourceLineIndex].End);
+            var sourceLine = sourceLines[sourceLineIndex];
+            var endOfSourceLine = source.FindToken(sourceLine.End);
 
             //TODO Check whether there's a general version of FindToken that covers this and similar comments
             if (endOfSourceLine.Width() == 0 && !endOfSourceLine.HasTrailingTrivia && !endOfSourceLine.HasLeadingTrivia) {
@@ -91,16 +76,60 @@ namespace ICSharpCode.CodeConverter.Shared
             if (endOfSourceLine.TrailingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
                 var line = GetBestLine(targetTrailingTextLineFromSourceLine, sourceLineIndex);
                 if (line != default) {
-                    var convertedTrivia = endOfSourceLine.TrailingTrivia.ConvertTrivia();
-                    var toReplace = target.FindToken(line.End);
-                    //TODO Check whether there's a general version of FindToken that covers this and similar comments
-                    if (toReplace.Span.Start > line.End) {
-                        toReplace = toReplace.GetPreviousToken(); //Zero width tokens with newline trivia can cause this, e.g. EOF
+                    foreach (var triviaList in trailingTriviaCarriedOver) {
+                        target = PrependTrailingTrivia(target, line, triviaList);
                     }
-                    target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.TrailingTrivia)));
+                    trailingTriviaCarriedOver.Clear();
+                    target = PrependTrailingTrivia(target, line, endOfSourceLine.TrailingTrivia);
+                } else if (endOfSourceLine.TrailingTrivia.Span.Start > sourceLine.Start) {
+                    trailingTriviaCarriedOver.Add(endOfSourceLine.TrailingTrivia);
                 }
             }
 
+            return target;
+        }
+
+        private static SyntaxNode PrependTrailingTrivia(SyntaxNode target, TextLine line, SyntaxTriviaList trailingTrivia)
+        {
+            var convertedTrivia = trailingTrivia.ConvertTrivia();
+            var toReplace = target.FindToken(line.End);
+            //TODO Check whether there's a general version of FindToken that covers this and similar comments
+            if (toReplace.Span.Start > line.End) {
+                toReplace = toReplace.GetPreviousToken(); //Zero width tokens with newline trivia can cause this, e.g. EOF
+            }
+            target = target.ReplaceToken(toReplace, toReplace.WithTrailingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.TrailingTrivia)));
+            return target;
+        }
+
+        private SyntaxNode ConvertLeadingForSourceLine(SyntaxNode target, int sourceLineIndex)
+        {
+            var sourceLine = sourceLines[sourceLineIndex];
+            var startOfSourceLine = source.FindToken(sourceLine.Start);
+            if (startOfSourceLine.LeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
+                var line = GetBestLine(targetLeadingTextLineFromSourceLine, sourceLineIndex);
+                if (line != default) {
+                    foreach (var triviaList in leadingTriviaCarriedOver) {
+                        target = PrependLeadingTrivia(target, line, triviaList);
+                    }
+                    leadingTriviaCarriedOver.Clear();
+                    target = PrependLeadingTrivia(target, line, startOfSourceLine.LeadingTrivia);
+                } else if (startOfSourceLine.LeadingTrivia.Span.End < sourceLine.End) {
+                    leadingTriviaCarriedOver.Add(startOfSourceLine.LeadingTrivia);
+                }
+            }
+
+            return target;
+        }
+
+        private static SyntaxNode PrependLeadingTrivia(SyntaxNode target, TextLine line, SyntaxTriviaList leadingTrivia)
+        {
+            var convertedTrivia = leadingTrivia.ConvertTrivia();
+            var toReplace = target.FindToken(line.Start);
+            //TODO Check whether there's a general version of FindToken that covers this and similar comments
+            if (toReplace.Span.End < line.Start) {
+                toReplace = toReplace.GetNextToken(); //Zero width tokens with newline trivia can cause this, e.g. EOF
+            }
+            target = target.ReplaceToken(toReplace, toReplace.WithLeadingTrivia(PrependPreservingImportantTrivia(convertedTrivia, toReplace.LeadingTrivia)));
             return target;
         }
 

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -86,26 +86,7 @@ namespace ICSharpCode.CodeConverter.Shared
         private TextLine GetBestLine(IReadOnlyDictionary<int, TextLine> sourceToTargetLine, int sourceLineIndex)
         {
             if (sourceToTargetLine.TryGetValue(sourceLineIndex, out var targetLineIndex)) return targetLineIndex;
-
-            var (previousOffset, previousLine) = GetOffsetSourceLineTargetNodes(sourceToTargetLine, sourceLineIndex, -1);
-            var (nextOffset, nextLine) = GetOffsetSourceLineTargetNodes(sourceToTargetLine, sourceLineIndex, 1);
-            if (previousLine != default && nextLine != default) {
-                var guessedTargetLine = originalTargetLines[((previousLine.LineNumber - previousOffset) + (nextLine.LineNumber - nextOffset)) / 2];
-                //TODO Annotate this case with a comment to say it's a guess
-                //TODO Move this guessing phase to fill in the gaps after all other allocations are made to avoid clashes with other moved lines
-                if (previousLine.LineNumber < guessedTargetLine.LineNumber && guessedTargetLine.LineNumber < nextLine.LineNumber) return guessedTargetLine;
-            }
             return default;
-        }
-
-        private static (int offset, TextLine targetLine) GetOffsetSourceLineTargetNodes(IReadOnlyDictionary<int, TextLine> sourceToTargetLine, int sourceLineIndex, int multiplier)
-        {
-            for (int offset = 1; offset <= 5; offset++) {
-                if (sourceToTargetLine.TryGetValue(sourceLineIndex + (offset * multiplier), out var line)) {
-                    return (offset * multiplier, line);
-                }
-            }
-            return (0, default);
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
+++ b/ICSharpCode.CodeConverter/Shared/LineTriviaMapper.cs
@@ -55,7 +55,6 @@ namespace ICSharpCode.CodeConverter.Shared
 
         /// <remarks>
         /// Possible future improvements:
-        /// * Accuracy: Can we make use of both dictionaries for each trivia type?
         /// * Performance: Probably faster to find tokens starting from position of last replaced token rather than from the root node each time
         /// </remarks>
         private SyntaxNode GetTargetWithSourceTrivia()
@@ -111,6 +110,7 @@ namespace ICSharpCode.CodeConverter.Shared
 
             if (_trailingTriviaCarriedOver.Any()) {
                 var targetLine = GetTargetLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
+                if (targetLine == default) targetLine = GetTargetLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
                 if (targetLine != default) {
                     var originalToReplace = targetLine.GetTrailingForLine(_target);
                     if (originalToReplace != null) {
@@ -133,6 +133,7 @@ namespace ICSharpCode.CodeConverter.Shared
 
             if (_leadingTriviaCarriedOver.Any()) {
                 var targetLine = GetTargetLine(_targetLeadingTextLineFromSourceLine, sourceLineIndex);
+                if (targetLine == default) targetLine = GetTargetLine(_targetTrailingTextLineFromSourceLine, sourceLineIndex);
                 if (targetLine != default) {
                     var originalToReplace = targetLine.GetLeadingForLine(_target);
                     if (originalToReplace != default) {

--- a/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
+++ b/ICSharpCode.CodeConverter/Shared/ProjectConversion.cs
@@ -188,7 +188,11 @@ namespace ICSharpCode.CodeConverter.Shared
                 Document document = await _languageConversion.SingleSecondPass(convertedDocument);
                 if (_returnSelectedNode) {
                     selectedNode = await GetSelectedNode(document);
+                    var extraLeadingTrivia = selectedNode.GetFirstToken().GetPreviousToken().TrailingTrivia;
+                    var extraTrailingTrivia = selectedNode.GetLastToken().GetNextToken().LeadingTrivia;
                     selectedNode = Formatter.Format(selectedNode, document.Project.Solution.Workspace);
+                    if (extraLeadingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) selectedNode = selectedNode.WithPrependedLeadingTrivia(extraLeadingTrivia);
+                    if (extraTrailingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) selectedNode = selectedNode.WithAppendedTrailingTrivia(extraTrailingTrivia);
                 } else {
                     selectedNode = await document.GetSyntaxRootAsync();
                     selectedNode = Formatter.Format(selectedNode, document.Project.Solution.Workspace);

--- a/ICSharpCode.CodeConverter/Shared/TextLineExtensions.cs
+++ b/ICSharpCode.CodeConverter/Shared/TextLineExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ICSharpCode.CodeConverter.Shared
+{
+
+    internal static class TextLineExtensions
+    {
+        public static bool ContainsPosition(this TextLine line, int position)
+        {
+            return line.Start <= position && position <= line.End;
+        }
+
+        public static SyntaxToken FindFirstTokenWithinLine(this TextLine line, SyntaxNode node)
+        {
+            var syntaxToken = node.FindToken(line.Start);
+            var previousToken = syntaxToken.GetPreviousToken();
+            var nextToken = syntaxToken.GetNextToken();
+            return new[] { previousToken, syntaxToken, nextToken }
+                .FirstOrDefault(t => line.ContainsPosition(t.Span.Start));
+        }
+
+        public static SyntaxToken FindLastTokenWithinLine(this TextLine line, SyntaxNode node)
+        {
+            var syntaxToken = node.FindToken(line.End);
+            var previousToken = syntaxToken.GetPreviousToken();
+            var nextToken = syntaxToken.GetNextToken();
+            return new[] { nextToken, syntaxToken, previousToken }
+                .FirstOrDefault(t => line.ContainsPosition(t.Span.End) && t.Width() > 0);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/Shared/TextLineExtensions.cs
+++ b/ICSharpCode.CodeConverter/Shared/TextLineExtensions.cs
@@ -32,5 +32,25 @@ namespace ICSharpCode.CodeConverter.Shared
             return new[] { nextToken, syntaxToken, previousToken }
                 .FirstOrDefault(t => line.ContainsPosition(t.Span.End) && t.Width() > 0);
         }
+
+        public static SyntaxToken GetLeadingForLine(this TextLine targetLine, SyntaxNode target)
+        {
+            var toReplace = target.FindNonZeroWidthToken(targetLine.Start);
+            if (toReplace.Span.End < targetLine.Start) {
+                toReplace = toReplace.GetNextToken(); //TODO: Find out why FindToken is off by one from what I want sometimes, is there a better alternative?
+            }
+
+            return toReplace;
+        }
+
+        public static SyntaxToken GetTrailingForLine(this TextLine targetLine, SyntaxNode target)
+        {
+            var toReplace = target.FindNonZeroWidthToken(targetLine.End);
+            if (toReplace.Width() == 0) {
+                toReplace = toReplace.GetPreviousToken(); //Never append *trailing* trivia to the end of file token
+            }
+
+            return toReplace;
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/Shared/TriviaMapping.cs
+++ b/ICSharpCode.CodeConverter/Shared/TriviaMapping.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ICSharpCode.CodeConverter.Shared
+{
+
+    internal struct TriviaMapping
+    {
+        public int SourceLine;
+        public int TargetLine;
+        public SyntaxTriviaList SourceTrivia;
+        public SyntaxToken TargetToken;
+        public bool IsLeading;
+
+        public TriviaMapping(int sourceLine, int targetLine, SyntaxTriviaList sourceTrivia, SyntaxToken targetToken, bool isLeading)
+        {
+            SourceLine = sourceLine;
+            TargetLine = targetLine;
+            SourceTrivia = sourceTrivia;
+            TargetToken = targetToken;
+            IsLeading = isLeading;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is TriviaMapping other &&
+                   SourceLine == other.SourceLine &&
+                   TargetLine == other.TargetLine &&
+                   SourceTrivia.Equals(other.SourceTrivia) &&
+                   TargetToken.Equals(other.TargetToken) &&
+                   IsLeading == other.IsLeading;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1113933263;
+            hashCode = hashCode * -1521134295 + SourceLine.GetHashCode();
+            hashCode = hashCode * -1521134295 + TargetLine.GetHashCode();
+            hashCode = hashCode * -1521134295 + SourceTrivia.GetHashCode();
+            hashCode = hashCode * -1521134295 + TargetToken.GetHashCode();
+            hashCode = hashCode * -1521134295 + IsLeading.GetHashCode();
+            return hashCode;
+        }
+
+        public void Deconstruct(out int sourceLine, out int targetLine, out SyntaxTriviaList sourceTrivia, out SyntaxToken targetToken, out bool isLeading)
+        {
+            sourceLine = SourceLine;
+            targetLine = TargetLine;
+            sourceTrivia = SourceTrivia;
+            targetToken = TargetToken;
+            isLeading = IsLeading;
+        }
+
+        public static implicit operator (int SourceLine, int TargetLine, SyntaxTriviaList SourceTrivia, SyntaxToken TargetToken, bool IsLeading)(TriviaMapping value)
+        {
+            return (value.SourceLine, value.TargetLine, value.SourceTrivia, value.TargetToken, value.IsLeading);
+        }
+
+        public static implicit operator TriviaMapping((int SourceLine, int TargetLine, SyntaxTriviaList SourceTrivia, SyntaxToken TargetToken, bool IsLeading) value)
+        {
+            return new TriviaMapping(value.SourceLine, value.TargetLine, value.SourceTrivia, value.TargetToken, value.IsLeading);
+        }
+
+        public override string ToString()
+        {
+            var type = IsLeading ? "Leading" : "Trailing";
+            return $"{type} {TargetLine}: {TargetToken} - {SourceTrivia}";
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -921,7 +921,7 @@ namespace ICSharpCode.CodeConverter.Util
             if (t.IsKind(CSSyntaxKind.RegionDirectiveTrivia)) {
                 var structure = ((CSSyntax.RegionDirectiveTriviaSyntax)t.GetStructure());
                 string name = structure.EndOfDirectiveToken.LeadingTrivia.Single().ToString();
-                var regionSyntax = VBSyntaxFactory.RegionDirectiveTrivia(VBSyntaxFactory.Token(VBSyntaxKind.HashToken), VBSyntaxFactory.Token(VBSyntaxKind.RegionKeyword), VBSyntaxFactory.StringLiteralToken(name, name));
+                var regionSyntax = VBSyntaxFactory.RegionDirectiveTrivia(VBSyntaxFactory.Token(VBSyntaxKind.HashToken), VBSyntaxFactory.Token(VBSyntaxKind.RegionKeyword), VBSyntaxFactory.StringLiteralToken("\"" + name + "\"", name));
                 return regionSyntax;
             }
 

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -842,9 +842,9 @@ namespace ICSharpCode.CodeConverter.Util
                 if (t.Language == LanguageNames.VisualBasic) {
                     return ConvertVBTrivia(t).Yield();
                 } else {
-                    return ConvertCSTrivia(t).Where(x => x != default(SyntaxTrivia));
+                    return ConvertCSTrivia(t);
                 }
-            });
+            }).Where(x => x != default(SyntaxTrivia));
         }
 
         private static SyntaxTrivia ConvertVBTrivia(SyntaxTrivia t)

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -1673,5 +1673,15 @@ namespace ICSharpCode.CodeConverter.Util
         {
             return modifiers.Any(m => m.IsCsVisibility(isVariableOrConst, isConstructor));
         }
+
+        public static SyntaxToken FindNonZeroWidthToken(this SyntaxNode node, int position)
+        {
+            var syntaxToken = node.FindToken(position);
+            if (syntaxToken.FullWidth() == 0) {
+                return syntaxToken.GetPreviousToken();
+            } else {
+                return syntaxToken;
+            }
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -225,10 +225,11 @@ namespace ICSharpCode.CodeConverter.Util
         public static T WithSourceMappingFrom<T>(this T converted, SyntaxNodeOrToken fromSource) where T : SyntaxNode
         {
             if (converted == null) return null;
-            var origLinespan = fromSource.SyntaxTree.GetLineSpan(fromSource.Span);
+            var startLinespan = fromSource.SyntaxTree.GetLineSpan(fromSource.Span);
+            var endLinespan = fromSource.IsNode ? fromSource.SyntaxTree.GetLineSpan(fromSource.AsNode().GetLastToken().Span) : startLinespan;
             return converted
-                .WithSourceStartLineAnnotation(origLinespan)
-                .WithSourceEndLineAnnotation(origLinespan);
+                .WithSourceStartLineAnnotation(startLinespan)
+                .WithSourceEndLineAnnotation(endLinespan);
         }
 
         public static T WithSourceStartLineAnnotation<T>(this T node, FileLinePositionSpan sourcePosition) where T : SyntaxNode

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -222,11 +222,11 @@ namespace ICSharpCode.CodeConverter.Util
             return semanticModel.GetDeclaredSymbol(typeBlockSyntax);
         }
 
-        public static T WithSourceMappingFrom<T>(this T converted, SyntaxNode fromNode) where T : SyntaxNode
+        public static T WithSourceMappingFrom<T>(this T converted, SyntaxNodeOrToken fromSource) where T : SyntaxNode
         {
             if (converted == null) return null;
-            var origLinespan = fromNode.SyntaxTree.GetLineSpan(fromNode.Span);
-            return fromNode.CopyAnnotationsTo(converted)
+            var origLinespan = fromSource.SyntaxTree.GetLineSpan(fromSource.Span);
+            return converted
                 .WithSourceStartLineAnnotation(origLinespan)
                 .WithSourceEndLineAnnotation(origLinespan);
         }

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -9,10 +9,14 @@ using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using AnonymousObjectCreationExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousObjectCreationExpressionSyntax;
 using ArgumentListSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax;
 using ArrayRankSpecifierSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.ArrayRankSpecifierSyntax;
@@ -856,10 +860,12 @@ namespace ICSharpCode.CodeConverter.Util
                 return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.EndOfLineTrivia, t.ToString());
             }
 
-            var convertedKind = t.GetVBKind();
-            return convertedKind.HasValue
-                ? VBSyntaxFactory.CommentTrivia($"' TODO ERROR: Skipped {convertedKind.Value}")
-                : default(SyntaxTrivia);
+            //if (t.IsKind(CSSyntaxKind.IfDirectiveTrivia) && t.GetStructure() is CSSyntax.IfDirectiveTriviaSyntax idts) {
+            //    //TODO Actually use converter
+            //    return VBasic.SyntaxFactory.IfDirectiveTrivia(VBasic.SyntaxFactory.Token(VBSyntaxKind.IfKeyword), VBasic.SyntaxFactory.ParseExpression(idts.Condition.ToString()));
+            //}
+
+            return VBSyntaxFactory.CommentTrivia($"' TODO ERROR: Skipped {t}\r\n");
         }
 
         public static T WithoutTrailingEndOfLineTrivia<T>(this T cSharpNode) where T : CSharpSyntaxNode

--- a/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -759,6 +759,12 @@ namespace ICSharpCode.CodeConverter.Util
             return node.WithConvertedLeadingTriviaFrom(otherNode).WithConvertedTrailingTriviaFrom(otherNode);
         }
 
+        public static T WithConvertedLeadingTriviaFrom<T>(this T node, SyntaxToken fromToken) where T : SyntaxNode
+        {
+            var firstConvertedToken = node.GetFirstToken();
+            return node.ReplaceToken(firstConvertedToken, firstConvertedToken.WithConvertedLeadingTriviaFrom(fromToken));
+        }
+
         public static SyntaxToken WithConvertedLeadingTriviaFrom(this SyntaxToken node, SyntaxNode otherNode)
         {
             var firstToken = otherNode?.GetFirstToken();
@@ -770,6 +776,12 @@ namespace ICSharpCode.CodeConverter.Util
             if (sourceToken == null) return node;
             var convertedTrivia = ConvertTrivia(sourceToken.Value.LeadingTrivia);
             return node.WithLeadingTrivia(convertedTrivia);
+        }
+
+        public static T WithConvertedTrailingTriviaFrom<T>(this T node, SyntaxToken fromToken) where T : SyntaxNode
+        {
+            var lastConvertedToken = node.GetLastToken();
+            return node.ReplaceToken(lastConvertedToken, lastConvertedToken.WithConvertedTrailingTriviaFrom(fromToken));
         }
 
         public static SyntaxToken WithConvertedTrailingTriviaFrom(this SyntaxToken node, SyntaxNode otherNode)
@@ -845,8 +857,7 @@ namespace ICSharpCode.CodeConverter.Util
                 var outputCommentText = multiLine
                     ? "''' " + String.Join($"\r\n{previousWhitespace}''' ", commentTextLines)
                     : $"' {commentTextLines.Single()}";
-                return VBSyntaxFactory.SyntaxTrivia(VBSyntaxKind.DocumentationCommentTrivia,
-                    outputCommentText);
+                return VBSyntaxFactory.CommentTrivia(outputCommentText);
             }
 
             if (t.IsKind(CSSyntaxKind.WhitespaceTrivia)) {

--- a/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -769,12 +769,12 @@ namespace ICSharpCode.CodeConverter.Util
                 || SyntaxFacts.IsPreprocessorKeyword(token.Kind());
         }
 
-        public static SyntaxToken GetNextNonZeroWidthTokenOrEndOfFile(this SyntaxToken token)
+        public static SyntaxToken GetNextNonZeroWidthCsTokenOrEndOfFile(this SyntaxToken token)
         {
-            return token.GetNextTokenOrEndOfFile();
+            return token.GetNextCsTokenOrEndOfFile();
         }
 
-        public static SyntaxToken GetNextTokenOrEndOfFile(
+        public static SyntaxToken GetNextCsTokenOrEndOfFile(
             this SyntaxToken token,
             bool includeZeroWidth = false,
             bool includeSkipped = false,
@@ -897,7 +897,7 @@ namespace ICSharpCode.CodeConverter.Util
                 yield return trivia;
             }
 
-            var nextToken = token.GetNextTokenOrEndOfFile(includeZeroWidth: true, includeSkipped: true, includeDirectives: true, includeDocumentationComments: true);
+            var nextToken = token.GetNextCsTokenOrEndOfFile(includeZeroWidth: true, includeSkipped: true, includeDirectives: true, includeDocumentationComments: true);
 
             foreach (var trivia in nextToken.LeadingTrivia) {
                 yield return trivia;

--- a/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -1061,14 +1061,22 @@ namespace ICSharpCode.CodeConverter.Util
                    || isConstructor && token.IsKind(SyntaxKind.StaticKeyword);
         }
 
-        public static SyntaxToken WithOriginalLineAnnotationsFrom(this SyntaxToken converted, SyntaxToken fromToken)
+        public static SyntaxToken WithSourceMappingFrom(this SyntaxToken converted, SyntaxToken fromToken)
         {
             var origLinespan = fromToken.SyntaxTree.GetLineSpan(fromToken.Span);
-            if (origLinespan.StartLinePosition.Line == origLinespan.EndLinePosition.Line) {
-                converted = converted.WithAdditionalAnnotations(AnnotationConstants.OriginalLineAnnotation(origLinespan));
-            }
+            return fromToken.CopyAnnotationsTo(converted)
+                .WithSourceStartLineAnnotation(origLinespan)
+                .WithSourceEndLineAnnotation(origLinespan);
+        }
 
-            return converted;
+        public static SyntaxToken WithSourceStartLineAnnotation(this SyntaxToken node, FileLinePositionSpan sourcePosition)
+        {
+            return node.WithAdditionalAnnotations(AnnotationConstants.SourceStartLine(sourcePosition));
+        }
+
+        public static SyntaxToken WithSourceEndLineAnnotation(this SyntaxToken node, FileLinePositionSpan sourcePosition)
+        {
+            return node.WithAdditionalAnnotations(AnnotationConstants.SourceEndLine(sourcePosition));
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Text;
 using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
 using VisualBasicExtensions = Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions;
 using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using ICSharpCode.CodeConverter.Shared;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -1058,6 +1059,16 @@ namespace ICSharpCode.CodeConverter.Util
             return token.IsKind(SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.PrivateKeyword)
                    || isVariableOrConst && token.IsKind(SyntaxKind.ConstKeyword)
                    || isConstructor && token.IsKind(SyntaxKind.StaticKeyword);
+        }
+
+        public static SyntaxToken WithOriginalLineAnnotationsFrom(this SyntaxToken converted, SyntaxToken fromToken)
+        {
+            var origLinespan = fromToken.SyntaxTree.GetLineSpan(fromToken.Span);
+            if (origLinespan.StartLinePosition.Line == origLinespan.EndLinePosition.Line) {
+                converted = converted.WithAdditionalAnnotations(AnnotationConstants.OriginalLineAnnotation(origLinespan));
+            }
+
+            return converted;
         }
     }
 }

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -197,7 +197,7 @@ namespace ICSharpCode.CodeConverter.Util
                 textBuilder.Remove(textBuilder.Length - newLine.Length, newLine.Length);
 
                 return textBuilder.ToString();
-            } else if (trivia.IsKind(VBasic.SyntaxKind.DocumentationCommentTrivia)) {
+            } else if (trivia.IsKind(VBasic.SyntaxKind.DocumentationCommentTrivia) || trivia.Kind() == CS.SyntaxKind.SingleLineDocumentationCommentTrivia) {
                 var textBuilder = new StringBuilder();
 
                 if (commentText.EndsWith("*/")) {

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -46,8 +46,8 @@ namespace ICSharpCode.CodeConverter.Util
             {VBasic.SyntaxKind.ElseIfDirectiveTrivia, CS.SyntaxKind.ElifDirectiveTrivia},
             {VBasic.SyntaxKind.ElseDirectiveTrivia, CS.SyntaxKind.ElseDirectiveTrivia},
             {VBasic.SyntaxKind.EndIfDirectiveTrivia, CS.SyntaxKind.EndIfDirectiveTrivia},
-            //{VBSyntaxKind.RegionDirectiveTrivia, SyntaxKind.RegionDirectiveTrivia}, Oh no I accidentally disabled regions :O ;)
-            //{VBSyntaxKind.EndRegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia},
+            {VBasic.SyntaxKind.RegionDirectiveTrivia, CS.SyntaxKind.RegionDirectiveTrivia},
+            {VBasic.SyntaxKind.EndRegionDirectiveTrivia, CS.SyntaxKind.EndRegionDirectiveTrivia},
             {VBasic.SyntaxKind.EnableWarningDirectiveTrivia, CS.SyntaxKind.WarningDirectiveTrivia},
             {VBasic.SyntaxKind.DisableWarningDirectiveTrivia, CS.SyntaxKind.WarningDirectiveTrivia},
             {VBasic.SyntaxKind.ReferenceDirectiveTrivia, CS.SyntaxKind.ReferenceDirectiveTrivia},

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -221,6 +221,10 @@ namespace ICSharpCode.CodeConverter.Util
                         trimmedLine = trimmedLine.TrimStart('\'');
                         trimmedLine = trimmedLine.TrimStart(null);
                     }
+                    if (trimmedLine.StartsWith("/")) {
+                        trimmedLine = trimmedLine.TrimStart('/');
+                        trimmedLine = trimmedLine.TrimStart(null);
+                    }
 
                     textBuilder.AppendLine(trimmedLine);
                 }

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -293,14 +293,6 @@ namespace ICSharpCode.CodeConverter.Util
             return syntaxTree.GetRoot(cancellationToken).FindTrivia(span.Start - 1, findInsideTrivia);
         }
 
-        public static IEnumerable<SyntaxTrivia> PrependPreservingImportantTrivia(this IReadOnlyCollection<SyntaxTrivia> convertedTrivia, IReadOnlyCollection<SyntaxTrivia> existingTrivia)
-        {
-            if (existingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
-                return convertedTrivia.Concat(existingTrivia);
-            }
-            return convertedTrivia;
-        }
-
 #if false
         public static int Width(this SyntaxTrivia trivia)
         {

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -293,6 +293,14 @@ namespace ICSharpCode.CodeConverter.Util
             return syntaxTree.GetRoot(cancellationToken).FindTrivia(span.Start - 1, findInsideTrivia);
         }
 
+        public static IEnumerable<SyntaxTrivia> PrependPreservingImportantTrivia(this IReadOnlyCollection<SyntaxTrivia> convertedTrivia, IReadOnlyCollection<SyntaxTrivia> existingTrivia)
+        {
+            if (existingTrivia.Any(t => !t.IsWhitespaceOrEndOfLine())) {
+                return convertedTrivia.Concat(existingTrivia);
+            }
+            return convertedTrivia;
+        }
+
 #if false
         public static int Width(this SyntaxTrivia trivia)
         {

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using CSharp = Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
+using CS = Microsoft.CodeAnalysis.CSharp;
 using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.Util
 {
@@ -33,37 +34,37 @@ namespace ICSharpCode.CodeConverter.Util
         /// </summary>
         private static IEnumerable<SyntaxToken> GetSkippedTokens(SyntaxTriviaList list)
         {
-            return list.Where(trivia => trivia.RawKind == (int)SyntaxKind.SkippedTokensTrivia)
-                .SelectMany(t => ((SkippedTokensTriviaSyntax)t.GetStructure()).Tokens);
+            return list.Where(trivia => trivia.RawKind == (int)CS.SyntaxKind.SkippedTokensTrivia)
+                .SelectMany(t => ((CSSyntax.SkippedTokensTriviaSyntax)t.GetStructure()).Tokens);
         }
 
-        private static readonly Dictionary<VBasic.SyntaxKind, SyntaxKind> VBToCSSyntaxKinds = new Dictionary<VBasic.SyntaxKind, SyntaxKind> {
-            {VBasic.SyntaxKind.SkippedTokensTrivia, SyntaxKind.SkippedTokensTrivia},
-            {VBasic.SyntaxKind.DisabledTextTrivia, SyntaxKind.DisabledTextTrivia},
-            {VBasic.SyntaxKind.ConstDirectiveTrivia, SyntaxKind.DefineDirectiveTrivia}, // Just a guess
-            {VBasic.SyntaxKind.IfDirectiveTrivia, SyntaxKind.IfDirectiveTrivia},
-            {VBasic.SyntaxKind.ElseIfDirectiveTrivia, SyntaxKind.ElifDirectiveTrivia},
-            {VBasic.SyntaxKind.ElseDirectiveTrivia, SyntaxKind.ElseDirectiveTrivia},
-            {VBasic.SyntaxKind.EndIfDirectiveTrivia, SyntaxKind.EndIfDirectiveTrivia},
+        private static readonly Dictionary<VBasic.SyntaxKind, CS.SyntaxKind> VBToCSSyntaxKinds = new Dictionary<VBasic.SyntaxKind, CS.SyntaxKind> {
+            {VBasic.SyntaxKind.SkippedTokensTrivia, CS.SyntaxKind.SkippedTokensTrivia},
+            {VBasic.SyntaxKind.DisabledTextTrivia, CS.SyntaxKind.DisabledTextTrivia},
+            {VBasic.SyntaxKind.ConstDirectiveTrivia, CS.SyntaxKind.DefineDirectiveTrivia}, // Just a guess
+            {VBasic.SyntaxKind.IfDirectiveTrivia, CS.SyntaxKind.IfDirectiveTrivia},
+            {VBasic.SyntaxKind.ElseIfDirectiveTrivia, CS.SyntaxKind.ElifDirectiveTrivia},
+            {VBasic.SyntaxKind.ElseDirectiveTrivia, CS.SyntaxKind.ElseDirectiveTrivia},
+            {VBasic.SyntaxKind.EndIfDirectiveTrivia, CS.SyntaxKind.EndIfDirectiveTrivia},
             //{VBSyntaxKind.RegionDirectiveTrivia, SyntaxKind.RegionDirectiveTrivia}, Oh no I accidentally disabled regions :O ;)
             //{VBSyntaxKind.EndRegionDirectiveTrivia, SyntaxKind.EndRegionDirectiveTrivia},
-            {VBasic.SyntaxKind.EnableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
-            {VBasic.SyntaxKind.DisableWarningDirectiveTrivia, SyntaxKind.WarningDirectiveTrivia},
-            {VBasic.SyntaxKind.ReferenceDirectiveTrivia, SyntaxKind.ReferenceDirectiveTrivia},
-            {VBasic.SyntaxKind.BadDirectiveTrivia, SyntaxKind.BadDirectiveTrivia},
-            {VBasic.SyntaxKind.ConflictMarkerTrivia, SyntaxKind.ConflictMarkerTrivia},
-            {VBasic.SyntaxKind.ExternalSourceDirectiveTrivia, SyntaxKind.LoadDirectiveTrivia}, //Just a guess
-            {VBasic.SyntaxKind.ExternalChecksumDirectiveTrivia, SyntaxKind.LineDirectiveTrivia}, // Even more random guess
+            {VBasic.SyntaxKind.EnableWarningDirectiveTrivia, CS.SyntaxKind.WarningDirectiveTrivia},
+            {VBasic.SyntaxKind.DisableWarningDirectiveTrivia, CS.SyntaxKind.WarningDirectiveTrivia},
+            {VBasic.SyntaxKind.ReferenceDirectiveTrivia, CS.SyntaxKind.ReferenceDirectiveTrivia},
+            {VBasic.SyntaxKind.BadDirectiveTrivia, CS.SyntaxKind.BadDirectiveTrivia},
+            {VBasic.SyntaxKind.ConflictMarkerTrivia, CS.SyntaxKind.ConflictMarkerTrivia},
+            {VBasic.SyntaxKind.ExternalSourceDirectiveTrivia, CS.SyntaxKind.LoadDirectiveTrivia}, //Just a guess
+            {VBasic.SyntaxKind.ExternalChecksumDirectiveTrivia, CS.SyntaxKind.LineDirectiveTrivia}, // Even more random guess
         };
 
-        private static readonly Dictionary<SyntaxKind, VBasic.SyntaxKind> CSToVBSyntaxKinds =
+        private static readonly Dictionary<CS.SyntaxKind, VBasic.SyntaxKind> CSToVBSyntaxKinds =
             VBToCSSyntaxKinds
                 .ToLookup(kvp => kvp.Value, kvp => kvp.Key)
                 .ToDictionary(g => g.Key, g => g.First());
 
-        public static SyntaxKind? GetCSKind(this SyntaxTrivia t)
+        public static CS.SyntaxKind? GetCSKind(this SyntaxTrivia t)
         {
-            return VBToCSSyntaxKinds.TryGetValue(VBasic.VisualBasicExtensions.Kind(t), out var csKind) ? csKind : (SyntaxKind?)null;
+            return VBToCSSyntaxKinds.TryGetValue(VBasic.VisualBasicExtensions.Kind(t), out var csKind) ? csKind : (CS.SyntaxKind?)null;
         }
         public static VBasic.SyntaxKind? GetVBKind(this SyntaxTrivia t)
         {
@@ -85,18 +86,18 @@ namespace ICSharpCode.CodeConverter.Util
             return trivia.HasAnnotation(SyntaxAnnotation.ElasticAnnotation);
         }
 
-        public static bool MatchesKind(this SyntaxTrivia trivia, SyntaxKind kind)
+        public static bool MatchesKind(this SyntaxTrivia trivia, CS.SyntaxKind kind)
         {
             return trivia.Kind() == kind;
         }
 
-        public static bool MatchesKind(this SyntaxTrivia trivia, SyntaxKind kind1, SyntaxKind kind2)
+        public static bool MatchesKind(this SyntaxTrivia trivia, CS.SyntaxKind kind1, CS.SyntaxKind kind2)
         {
             var triviaKind = trivia.Kind();
             return triviaKind == kind1 || triviaKind == kind2;
         }
 
-        public static bool MatchesKind(this SyntaxTrivia trivia, params SyntaxKind[] kinds)
+        public static bool MatchesKind(this SyntaxTrivia trivia, params CS.SyntaxKind[] kinds)
         {
             return kinds.Contains(trivia.Kind());
         }
@@ -113,17 +114,17 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsSingleLineComment(this SyntaxTrivia trivia)
         {
-            return trivia.Kind() == SyntaxKind.SingleLineCommentTrivia;
+            return trivia.Kind() == CS.SyntaxKind.SingleLineCommentTrivia;
         }
 
         public static bool IsMultiLineComment(this SyntaxTrivia trivia)
         {
-            return trivia.Kind() == SyntaxKind.MultiLineCommentTrivia;
+            return trivia.Kind() == CS.SyntaxKind.MultiLineCommentTrivia;
         }
 
         public static bool IsCompleteMultiLineComment(this SyntaxTrivia trivia)
         {
-            if (trivia.Kind() != SyntaxKind.MultiLineCommentTrivia) {
+            if (trivia.Kind() != CS.SyntaxKind.MultiLineCommentTrivia) {
                 return false;
             }
 
@@ -140,19 +141,19 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsSingleLineDocComment(this SyntaxTrivia trivia)
         {
-            return trivia.Kind() == SyntaxKind.SingleLineDocumentationCommentTrivia;
+            return trivia.Kind() == CS.SyntaxKind.SingleLineDocumentationCommentTrivia;
         }
 
         public static bool IsMultiLineDocComment(this SyntaxTrivia trivia)
         {
-            return trivia.Kind() == SyntaxKind.MultiLineDocumentationCommentTrivia;
+            return trivia.Kind() == CS.SyntaxKind.MultiLineDocumentationCommentTrivia;
         }
 
         /// <remarks>Good candidate for unit testing to catch newline issues hidden by the test harness</remarks>
         public static string GetCommentText(this SyntaxTrivia trivia)
         {
             var commentText = trivia.ToString();
-            if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)) {
+            if (trivia.IsKind(CS.SyntaxKind.SingleLineCommentTrivia)) {
                 if (commentText.StartsWith("//")) {
                     commentText = commentText.Substring(2);
                 }
@@ -164,7 +165,7 @@ namespace ICSharpCode.CodeConverter.Util
                 }
 
                 return commentText.TrimStart(null);
-            } else if (trivia.Kind() == SyntaxKind.MultiLineCommentTrivia) {
+            } else if (trivia.Kind() == CS.SyntaxKind.MultiLineCommentTrivia) {
                 var textBuilder = new StringBuilder();
 
                 if (commentText.EndsWith("*/")) {
@@ -251,7 +252,7 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static SyntaxTriviaList AsTrivia(this string s)
         {
-            return SyntaxFactory.ParseLeadingTrivia(s ?? String.Empty);
+            return CS.SyntaxFactory.ParseLeadingTrivia(s ?? String.Empty);
         }
 
         public static bool IsWhitespaceOrEndOfLine(this SyntaxTrivia trivia)
@@ -261,12 +262,12 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static bool IsEndOfLine(this SyntaxTrivia x)
         {
-            return x.IsKind(VBasic.SyntaxKind.EndOfLineTrivia) || x.IsKind(SyntaxKind.EndOfLineTrivia);
+            return x.IsKind(VBasic.SyntaxKind.EndOfLineTrivia) || x.IsKind(CS.SyntaxKind.EndOfLineTrivia);
         }
 
         private static bool IsWhitespace(this SyntaxTrivia x)
         {
-            return x.IsKind(VBasic.SyntaxKind.WhitespaceTrivia) || x.IsKind(SyntaxKind.WhitespaceTrivia);
+            return x.IsKind(VBasic.SyntaxKind.WhitespaceTrivia) || x.IsKind(CS.SyntaxKind.WhitespaceTrivia);
         }
 
         public static SyntaxTrivia GetPreviousTrivia(

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -210,8 +210,7 @@ namespace ICSharpCode.CodeConverter.Util
 
                 commentText = commentText.Trim();
 
-                var newLine = commentText.Contains('\n') ? '\n' : '\r';
-                var lines = commentText.Split(new []{newLine}, StringSplitOptions.None);
+                var lines = commentText.Replace("\r\n", "\n").Split('\n');
                 foreach (var line in lines) {
                     var trimmedLine = line.Trim();
 
@@ -269,7 +268,7 @@ namespace ICSharpCode.CodeConverter.Util
             return x.IsKind(VBasic.SyntaxKind.EndOfLineTrivia) || x.IsKind(CS.SyntaxKind.EndOfLineTrivia);
         }
 
-        private static bool IsWhitespace(this SyntaxTrivia x)
+        public static bool IsWhitespace(this SyntaxTrivia x)
         {
             return x.IsKind(VBasic.SyntaxKind.WhitespaceTrivia) || x.IsKind(CS.SyntaxKind.WhitespaceTrivia);
         }

--- a/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/ICSharpCode.CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -149,6 +149,15 @@ namespace ICSharpCode.CodeConverter.Util
             return trivia.Kind() == CS.SyntaxKind.MultiLineDocumentationCommentTrivia;
         }
 
+        public static SyntaxTrivia GetEndOfLine(string lang)
+        {
+            if (lang == LanguageNames.CSharp) {
+                return CS.SyntaxFactory.ElasticCarriageReturnLineFeed;
+            } else {
+                return VBasic.SyntaxFactory.ElasticCarriageReturnLineFeed;
+            }
+        }
+
         /// <remarks>Good candidate for unit testing to catch newline issues hidden by the test harness</remarks>
         public static string GetCommentText(this SyntaxTrivia trivia)
         {

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 
 namespace ICSharpCode.CodeConverter.VB
 {
@@ -28,7 +29,7 @@ namespace ICSharpCode.CodeConverter.VB
             var compilation = await document.Project.GetCompilationAsync();
             var tree = await document.GetSyntaxTreeAsync();
             var semanticModel = compilation.GetSemanticModel(tree, true);
-            var root = await document.GetSyntaxRootAsync() as CS.CSharpSyntaxNode ??
+            var root = await document.GetSyntaxRootAsync() as CSS.CompilationUnitSyntax ??
                        throw new InvalidOperationException(NullRootError(document));
 
             var vbSyntaxGenerator = SyntaxGenerator.GetGenerator(vbReferenceProject);
@@ -36,7 +37,10 @@ namespace ICSharpCode.CodeConverter.VB
 
             var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation)compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator, numberOfLines);
             var converted = root.Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
-            var formattedConverted = Formatter.Format(converted, document.Project.Solution.Workspace);
+
+            var formattedConverted = (VBSyntax.CompilationUnitSyntax) Formatter.Format(converted, document.Project.Solution.Workspace);
+
+
             return LineTriviaMapper.MapSourceTriviaToTarget(root, formattedConverted);
         }
 

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.CSharp;
@@ -9,7 +10,9 @@ using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.VisualBasic;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -29,8 +32,12 @@ namespace ICSharpCode.CodeConverter.VB
                        throw new InvalidOperationException(NullRootError(document));
 
             var vbSyntaxGenerator = SyntaxGenerator.GetGenerator(vbReferenceProject);
-            var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation)compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator);
-            return root.Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
+            var numberOfLines = tree.GetLineSpan(root.FullSpan).EndLinePosition.Line;
+
+            var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation)compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator, numberOfLines);
+            var converted = root.Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
+            var formattedConverted = Formatter.Format(converted, document.Project.Solution.Workspace);
+            return WithLineTrivia(root, formattedConverted);
         }
 
         private static string NullRootError(Document document)
@@ -41,5 +48,75 @@ namespace ICSharpCode.CodeConverter.VB
             return initial + " For best results, convert a c# document from within a C# project which compiles successfully.";
         }
 
+        /// <summary>
+        /// For each source line:
+        /// * Add leading trivia to the start of the first target line containing a node converted from that source line
+        /// * Add trailing trivia to the end of the last target line containing a node converted from that source line
+        /// Makes no attempt to convert whitespace/newline-only trivia
+        /// Currently doesn't deal with any within-line trivia (i.e. /* block comments */)
+        /// </summary>
+        private static SyntaxNode WithLineTrivia(SyntaxNode source, SyntaxNode target)
+        {
+            var sourceLines = source.GetText().Lines;
+            var originalTargetLines = target.GetText().Lines;
+            var targetNodesBySourceLine = target.GetAnnotatedNodes(AnnotationConstants.WithinOriginalLineAnnotationKind).ToLookup(n => n.GetAnnotations(AnnotationConstants.WithinOriginalLineAnnotationKind).Select(a => int.Parse(a.Data)).Min());
+            //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
+
+            for (int i = sourceLines.Count - 1; i >= 0; i--) {
+                var sourceLine = sourceLines[i];
+                var endOfSourceLine = source.FindToken(sourceLine.End);
+                var convertedTrailingTrivia = endOfSourceLine.TrailingTrivia.ConvertTrivia();
+                var startOfSourceLine = source.FindTokenOnRightOfPosition(sourceLine.Start);
+                var convertedLeadingTrivia = startOfSourceLine.LeadingTrivia.ConvertTrivia();
+                if (convertedLeadingTrivia.Concat(convertedTrailingTrivia).All(t => t.IsWhitespaceTrivia())) continue;
+
+                var (leadingLine, trailingLine) = GetBestLeadingAndTrailingLine(originalTargetLines, targetNodesBySourceLine, i);
+                if (leadingLine == default || trailingLine == default) continue;
+
+                var last = target.FindToken(trailingLine.End);
+                target = target.ReplaceToken(last, last.WithTrailingTrivia(convertedTrailingTrivia));
+
+                var first = target.FindTokenOnRightOfPosition(leadingLine.Start);
+                target = target.ReplaceToken(first, first.WithLeadingTrivia(convertedLeadingTrivia));
+            }
+            return target;
+        }
+
+        private static (TextLine leadingLine, TextLine trailingLine) GetBestLeadingAndTrailingLine(Microsoft.CodeAnalysis.Text.TextLineCollection originalTargetLines, ILookup<int, SyntaxNode> targetNodesBySourceLine, int sourceLineIndex)
+        {
+            var targetNodeGroup = targetNodesBySourceLine[sourceLineIndex];
+            if (targetNodeGroup.Any()) return GetExactLeadingLineAndTrailingLine(originalTargetLines, targetNodeGroup);
+
+            var (previousOffset, previousSourceLineTargetNodes) = GetOffsetSourceLineTargetNodes(targetNodesBySourceLine, sourceLineIndex, -1);
+            var (nextOffset, nextSourceLineTargetNodes) = GetOffsetSourceLineTargetNodes(targetNodesBySourceLine, sourceLineIndex, 1);
+            if (previousSourceLineTargetNodes.Any() && nextSourceLineTargetNodes.Any()) {
+                var (previousleading, previousTrailing) = GetExactLeadingLineAndTrailingLine(originalTargetLines, previousSourceLineTargetNodes);
+                var (nextLeading, nextTrailing) = GetExactLeadingLineAndTrailingLine(originalTargetLines, nextSourceLineTargetNodes);
+                var guessedTargetLine = originalTargetLines[(previousTrailing.LineNumber + previousOffset + nextLeading.LineNumber - nextOffset) / 2];
+                //TODO Annotate this case with a comment to say it's a guess
+                //TODO Move this guessing phase to fill in the gaps after all other allocations are made to avoid clashes with other moved lines
+                if (previousTrailing.LineNumber < guessedTargetLine.LineNumber && guessedTargetLine.LineNumber < nextLeading.LineNumber) return (guessedTargetLine, guessedTargetLine);
+            }
+            return (default, default);
+        }
+
+        private static (int offset, IEnumerable<SyntaxNode>targetNodes) GetOffsetSourceLineTargetNodes(ILookup<int, SyntaxNode> targetNodesBySourceLine, int sourceLineIndex, int multiplier)
+        {
+            for (int offset = 1; offset <= 5; offset++) {
+                var thisLine = targetNodesBySourceLine[sourceLineIndex + (offset * multiplier)];
+                if (thisLine.Any()) return (offset, thisLine);
+            }
+            return (0, Enumerable.Empty<SyntaxNode>());
+        }
+
+        private static (TextLine leadingLine, TextLine trailingLine) GetExactLeadingLineAndTrailingLine(TextLineCollection originalTargetLines, IEnumerable<SyntaxNode> targetNodeGroup)
+        {
+            var trailingTriviaAfterPosition = targetNodeGroup.Max(x => x.GetLocation().SourceSpan.End);
+            var leadTriviaBeforePosition = targetNodeGroup.Min(x => x.GetLocation().SourceSpan.Start);
+
+            var trailingLine = originalTargetLines.GetLineFromPosition(trailingTriviaAfterPosition);
+            var leadingLine = originalTargetLines.GetLineFromPosition(leadTriviaBeforePosition);
+            return (leadingLine, trailingLine);
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
+++ b/ICSharpCode.CodeConverter/VB/CSharpConverter.cs
@@ -37,7 +37,7 @@ namespace ICSharpCode.CodeConverter.VB
             var visualBasicSyntaxVisitor = new NodesVisitor(document, (CS.CSharpCompilation)compilation, semanticModel, vbViewOfCsSymbols, vbSyntaxGenerator, numberOfLines);
             var converted = root.Accept(visualBasicSyntaxVisitor.TriviaConvertingVisitor);
             var formattedConverted = Formatter.Format(converted, document.Project.Solution.Workspace);
-            return WithLineTrivia(root, formattedConverted);
+            return LineTriviaMapper.MapSourceTriviaToTarget(root, formattedConverted);
         }
 
         private static string NullRootError(Document document)
@@ -46,79 +46,6 @@ namespace ICSharpCode.CodeConverter.VB
                 ? "Document cannot be converted because it's not within a C# project."
                 : "Could not find valid C# within document.";
             return initial + " For best results, convert a c# document from within a C# project which compiles successfully.";
-        }
-
-        /// <summary>
-        /// For each source line:
-        /// * Add leading trivia to the start of the first target line containing a node converted from that source line
-        /// * Add trailing trivia to the end of the last target line containing a node converted from that source line
-        /// Makes no attempt to convert whitespace/newline-only trivia
-        /// Currently doesn't deal with any within-line trivia (i.e. /* block comments */)
-        /// </summary>
-        private static SyntaxNode WithLineTrivia(SyntaxNode source, SyntaxNode target)
-        {
-            var sourceLines = source.GetText().Lines;
-            var originalTargetLines = target.GetText().Lines;
-            var targetNodesBySourceLine = target.GetAnnotatedNodesAndTokens(AnnotationConstants.WithinOriginalLineAnnotationKind).ToLookup(n => n.GetAnnotations(AnnotationConstants.WithinOriginalLineAnnotationKind).Select(a => int.Parse(a.Data)).Min());
-            //TODO Try harder to avoid losing track of various precalculated positions changing during the replacements, for example build up a dictionary of replacements and make them in a single ReplaceTokens call
-
-            for (int i = sourceLines.Count - 1; i >= 0; i--) {
-                var sourceLine = sourceLines[i];
-                var endOfSourceLine = source.FindToken(sourceLine.End);
-                var startOfSourceLine = source.FindTokenOnRightOfPosition(sourceLine.Start);
-
-                if (endOfSourceLine.TrailingTrivia.Concat(startOfSourceLine.LeadingTrivia).All(t => t.IsWhitespaceOrEndOfLine())) continue;
-
-                var convertedTrailingTrivia = endOfSourceLine.TrailingTrivia.ConvertTrivia();
-                var convertedLeadingTrivia = startOfSourceLine.LeadingTrivia.ConvertTrivia();
-
-                var (leadingLine, trailingLine) = GetBestLeadingAndTrailingLine(originalTargetLines, targetNodesBySourceLine, i);
-                if (leadingLine == default || trailingLine == default) continue;
-
-                var last = target.FindToken(trailingLine.End);
-                target = target.ReplaceToken(last, last.WithTrailingTrivia(convertedTrailingTrivia));
-
-                var first = target.FindTokenOnRightOfPosition(leadingLine.Start);
-                target = target.ReplaceToken(first, first.WithLeadingTrivia(convertedLeadingTrivia));
-            }
-            return target;
-        }
-
-        private static (TextLine leadingLine, TextLine trailingLine) GetBestLeadingAndTrailingLine(Microsoft.CodeAnalysis.Text.TextLineCollection originalTargetLines, ILookup<int, SyntaxNodeOrToken> targetNodesBySourceLine, int sourceLineIndex)
-        {
-            var targetNodeGroup = targetNodesBySourceLine[sourceLineIndex];
-            if (targetNodeGroup.Any()) return GetExactLeadingLineAndTrailingLine(originalTargetLines, targetNodeGroup);
-
-            var (previousOffset, previousSourceLineTargetNodes) = GetOffsetSourceLineTargetNodes(targetNodesBySourceLine, sourceLineIndex, -1);
-            var (nextOffset, nextSourceLineTargetNodes) = GetOffsetSourceLineTargetNodes(targetNodesBySourceLine, sourceLineIndex, 1);
-            if (previousSourceLineTargetNodes.Any() && nextSourceLineTargetNodes.Any()) {
-                var (previousleading, previousTrailing) = GetExactLeadingLineAndTrailingLine(originalTargetLines, previousSourceLineTargetNodes);
-                var (nextLeading, nextTrailing) = GetExactLeadingLineAndTrailingLine(originalTargetLines, nextSourceLineTargetNodes);
-                var guessedTargetLine = originalTargetLines[(previousTrailing.LineNumber + previousOffset + nextLeading.LineNumber - nextOffset) / 2];
-                //TODO Annotate this case with a comment to say it's a guess
-                //TODO Move this guessing phase to fill in the gaps after all other allocations are made to avoid clashes with other moved lines
-                if (previousTrailing.LineNumber < guessedTargetLine.LineNumber && guessedTargetLine.LineNumber < nextLeading.LineNumber) return (guessedTargetLine, guessedTargetLine);
-            }
-            return (default, default);
-        }
-
-        private static (int offset, IEnumerable<SyntaxNodeOrToken> targetNodes) GetOffsetSourceLineTargetNodes(ILookup<int, SyntaxNodeOrToken> targetNodesBySourceLine, int sourceLineIndex, int multiplier)
-        {
-            for (int offset = 1; offset <= 5; offset++) {
-                var thisLine = targetNodesBySourceLine[sourceLineIndex + (offset * multiplier)];
-                if (thisLine.Any()) return (offset, thisLine);
-            }
-            return (0, Enumerable.Empty<SyntaxNodeOrToken>());
-        }
-
-        private static (TextLine leadingLine, TextLine trailingLine) GetExactLeadingLineAndTrailingLine(TextLineCollection originalTargetLines, IEnumerable<SyntaxNodeOrToken> targetNodeGroup)
-        {
-            var trailingTriviaAfterPosition = targetNodeGroup.Max(x => x.GetLocation().SourceSpan.End);
-            var leadTriviaBeforePosition = targetNodeGroup.Min(x => x.GetLocation().SourceSpan.Start);
-
-            var trailingLine = originalTargetLines.GetLineFromPosition(trailingTriviaAfterPosition);
-            var leadingLine = originalTargetLines.GetLineFromPosition(leadTriviaBeforePosition);
-            return (leadingLine, trailingLine);
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
@@ -30,15 +30,7 @@ namespace ICSharpCode.CodeConverter.VB
         {
             try {
                 var converted = _wrappedVisitor.Visit(node);
-                if (!converted.Any()) return converted;
-                var first = converted.First();
-                converted = converted.Replace(first, node.CopyAnnotationsTo(first));
-
-                var origLinespan = node.SyntaxTree.GetLineSpan(node.Span);
-                if (origLinespan.StartLinePosition == origLinespan.EndLinePosition) {
-                    converted = VBasic.SyntaxFactory.List(converted.Select(c => c.WithOriginalLineAnnotation(origLinespan.EndLinePosition.Line)));
-                }
-                return converted;
+                return converted.WithSourceMappingFrom(node);
             } catch (Exception e) {
                 var dummyStatement = VBasic.SyntaxFactory.EmptyStatement();
                 var withVbTrailingErrorComment = dummyStatement.WithVbTrailingErrorComment<VBSyntax.StatementSyntax>((CS.CSharpSyntaxNode) node, e);

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
@@ -16,14 +16,10 @@ namespace ICSharpCode.CodeConverter.VB
     public class CommentConvertingMethodBodyVisitor : CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>>
     {
         private readonly CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> _wrappedVisitor;
-        private readonly TriviaConverter _triviaConverter;
-        private readonly BitArray _lineTriviaMapped;
 
-        public CommentConvertingMethodBodyVisitor(CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor, TriviaConverter triviaConverter, BitArray lineTriviaMapped)
+        public CommentConvertingMethodBodyVisitor(CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor)
         {
             this._wrappedVisitor = wrappedVisitor;
-            this._triviaConverter = triviaConverter;
-            _lineTriviaMapped = lineTriviaMapped;
         }
 
         public override SyntaxList<VBSyntax.StatementSyntax> DefaultVisit(SyntaxNode node)

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
@@ -44,14 +44,5 @@ namespace ICSharpCode.CodeConverter.VB
                 return VBasic.SyntaxFactory.SingletonList(withVbTrailingErrorComment);
             }
         }
-
-        private SyntaxList<VBSyntax.StatementSyntax> ConvertWithTrivia(SyntaxNode node)
-        {
-            var convertedNodes = _wrappedVisitor.Visit(node);
-            if (!convertedNodes.Any()) return convertedNodes;
-            // Port trivia to the last statement in the list
-            var lastWithConvertedTrivia = _triviaConverter.PortConvertedTrivia(node, convertedNodes.LastOrDefault());
-            return convertedNodes.Replace(convertedNodes.LastOrDefault(), lastWithConvertedTrivia);
-        }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingMethodBodyVisitor.cs
@@ -8,6 +8,8 @@ using VBasic = Microsoft.CodeAnalysis.VisualBasic;
 using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using SyntaxNodeExtensions = ICSharpCode.CodeConverter.Util.SyntaxNodeExtensions;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Linq;
+using System.Collections;
 
 namespace ICSharpCode.CodeConverter.VB
 {
@@ -15,17 +17,27 @@ namespace ICSharpCode.CodeConverter.VB
     {
         private readonly CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> _wrappedVisitor;
         private readonly TriviaConverter _triviaConverter;
+        private readonly BitArray _lineTriviaMapped;
 
-        public CommentConvertingMethodBodyVisitor(CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor, TriviaConverter triviaConverter)
+        public CommentConvertingMethodBodyVisitor(CS.CSharpSyntaxVisitor<SyntaxList<VBSyntax.StatementSyntax>> wrappedVisitor, TriviaConverter triviaConverter, BitArray lineTriviaMapped)
         {
             this._wrappedVisitor = wrappedVisitor;
             this._triviaConverter = triviaConverter;
+            _lineTriviaMapped = lineTriviaMapped;
         }
 
         public override SyntaxList<VBSyntax.StatementSyntax> DefaultVisit(SyntaxNode node)
         {
             try {
-                return ConvertWithTrivia(node);
+                var converted = _wrappedVisitor.Visit(node);
+                if (!converted.Any()) return converted;
+                converted = converted.Replace(converted.First(), node.CopyAnnotationsTo(converted.First()));
+                var origLinespan = node.SyntaxTree.GetLineSpan(node.Span);
+                if (origLinespan.StartLinePosition.Line != origLinespan.EndLinePosition.Line) {
+                    return converted;
+                }
+                var statementsWithAnnotations = converted.Select(s => s.WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.WithinOriginalLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString())));
+                return VBasic.SyntaxFactory.List(statementsWithAnnotations);
             } catch (Exception e) {
                 var dummyStatement = VBasic.SyntaxFactory.EmptyStatement();
                 var withVbTrailingErrorComment = dummyStatement.WithVbTrailingErrorComment<VBSyntax.StatementSyntax>((CS.CSharpSyntaxNode) node, e);

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -10,28 +10,42 @@ using Microsoft.CodeAnalysis.VisualBasic;
 using VbSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using CsSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using SyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
+using System.Collections;
 
 namespace ICSharpCode.CodeConverter.VB
 {
-    public class CommentConvertingNodesVisitor : CSharpSyntaxVisitor<VisualBasicSyntaxNode>
+    internal class CommentConvertingNodesVisitor : CSharpSyntaxVisitor<VisualBasicSyntaxNode>
     {
         public TriviaConverter TriviaConverter { get; }
         private readonly CSharpSyntaxVisitor<VisualBasicSyntaxNode> _wrappedVisitor;
+        private BitArray _lineTriviaMapped;
+        private SemanticModel _semanticModel;
+        private TextLineCollection _lines;
 
-        public CommentConvertingNodesVisitor(CSharpSyntaxVisitor<VisualBasicSyntaxNode> wrappedVisitor)
+        public CommentConvertingNodesVisitor(CSharpSyntaxVisitor<VisualBasicSyntaxNode> wrappedVisitor, BitArray lineTriviaMapped, SemanticModel semanticModel)
         {
             TriviaConverter = new TriviaConverter();
-            this._wrappedVisitor = wrappedVisitor;
+            _wrappedVisitor = wrappedVisitor;
+            _lineTriviaMapped = lineTriviaMapped;
+            _semanticModel = semanticModel;
+            _lines = semanticModel.SyntaxTree.GetText().Lines; //TODO: Consider using GetTextAsync
         }
+
         public override VisualBasicSyntaxNode DefaultVisit(SyntaxNode node)
         {
             try {
-                return TriviaConverter.PortConvertedTrivia(node, _wrappedVisitor.Visit(node));
+                var converted = _wrappedVisitor.Visit(node);
+                if (converted == null) return converted;
+                converted = node.CopyAnnotationsTo(converted);
+                var origLinespan = node.SyntaxTree.GetLineSpan(node.Span);
+                if (origLinespan.StartLinePosition.Line != origLinespan.EndLinePosition.Line) {
+                    return converted;
+                }
+                return converted.WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.WithinOriginalLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString()));
             } catch (Exception e) {
                 var dummyStatement = SyntaxFactory.EmptyStatement();
                 return dummyStatement.WithVbTrailingErrorComment<VbSyntax.StatementSyntax>((CSharpSyntaxNode) node, e);
             }
-
         }
 
         public override VisualBasicSyntaxNode VisitAttributeList(CsSyntax.AttributeListSyntax node)

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -36,12 +36,7 @@ namespace ICSharpCode.CodeConverter.VB
             try {
                 var converted = _wrappedVisitor.Visit(node);
                 if (converted == null) return converted;
-                converted = node.CopyAnnotationsTo(converted);
-                var origLinespan = node.SyntaxTree.GetLineSpan(node.Span);
-                if (origLinespan.StartLinePosition.Line != origLinespan.EndLinePosition.Line) {
-                    return converted;
-                }
-                return converted.WithAdditionalAnnotations(new SyntaxAnnotation(AnnotationConstants.WithinOriginalLineAnnotationKind, origLinespan.StartLinePosition.Line.ToString()));
+                return node.CopyAnnotationsTo(converted).WithOriginalLineAnnotationsFrom(node);
             } catch (Exception e) {
                 var dummyStatement = SyntaxFactory.EmptyStatement();
                 return dummyStatement.WithVbTrailingErrorComment<VbSyntax.StatementSyntax>((CSharpSyntaxNode) node, e);

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -43,7 +43,43 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitCompilationUnit(CsSyntax.CompilationUnitSyntax node)
         {
             var convertedNode = (VbSyntax.CompilationUnitSyntax)DefaultVisitInner(node);
-            return convertedNode.WithEndOfFileToken(convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken));
+            // Special case where we need to map manually because it's a special zero-width token that just has leading trivia that isn't at the start of the line necessarily
+            return convertedNode.WithEndOfFileToken(
+                convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken).WithConvertedLeadingTriviaFrom(node.EndOfFileToken)
+            );
+        }
+
+        public override VisualBasicSyntaxNode VisitNamespaceDeclaration(CsSyntax.NamespaceDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.NamespaceBlockSyntax)DefaultVisitInner(node);
+            return convertedNode.WithEndNamespaceStatement(
+                convertedNode.EndNamespaceStatement.WithSourceMappingFrom(node.CloseBraceToken)
+            );
+        }
+
+        public override VisualBasicSyntaxNode VisitClassDeclaration(CsSyntax.ClassDeclarationSyntax node)
+        {
+            return WithMappedBlockEnd(node);
+        }
+
+        public override VisualBasicSyntaxNode VisitStructDeclaration(CsSyntax.StructDeclarationSyntax node)
+        {
+            return WithMappedBlockEnd(node);
+        }
+
+        public override VisualBasicSyntaxNode VisitEnumDeclaration(CsSyntax.EnumDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.EnumBlockSyntax)DefaultVisitInner(node);
+            return convertedNode.WithEndEnumStatement(
+                convertedNode.EndEnumStatement.WithSourceMappingFrom(node.CloseBraceToken)
+            );
+        }
+        private VisualBasicSyntaxNode WithMappedBlockEnd(CsSyntax.BaseTypeDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.TypeBlockSyntax)DefaultVisitInner(node);
+            return convertedNode.WithEndBlockStatement(
+                convertedNode.EndBlockStatement.WithSourceMappingFrom(node.CloseBraceToken)
+            );
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -57,5 +57,39 @@ namespace ICSharpCode.CodeConverter.VB
             var convertedNode = (VbSyntax.CompilationUnitSyntax)DefaultVisitInner(node);
             return convertedNode.WithEndOfFileToken(convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken));
         }
+
+        public override VisualBasicSyntaxNode VisitNamespaceDeclaration(CsSyntax.NamespaceDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.NamespaceBlockSyntax)DefaultVisitInner(node);
+            var blockStart = convertedNode.NamespaceStatement.GetLastToken();
+            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
+        }
+
+        public override VisualBasicSyntaxNode VisitClassDeclaration(CsSyntax.ClassDeclarationSyntax node)
+        {
+            var convertedNode = DefaultVisitInner(node);
+            VbSyntax.StatementSyntax blockStmt = convertedNode is VbSyntax.ClassBlockSyntax cbs ? (VbSyntax.StatementSyntax) cbs.ClassStatement
+                : convertedNode is VbSyntax.ModuleBlockSyntax mbs ? (VbSyntax.StatementSyntax) mbs.ModuleStatement
+                : null;
+            var endOfBlock = blockStmt?.GetLastToken();
+            if (endOfBlock != null) {
+                return convertedNode.ReplaceToken(endOfBlock.Value, endOfBlock.Value.WithSourceMappingFrom(node.OpenBraceToken));
+            }
+            return convertedNode;
+        }
+
+        public override VisualBasicSyntaxNode VisitStructDeclaration(CsSyntax.StructDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.StructureBlockSyntax)DefaultVisitInner(node);
+            var blockStart = convertedNode.StructureStatement.GetLastToken();
+            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
+        }
+
+        public override VisualBasicSyntaxNode VisitEnumDeclaration(CsSyntax.EnumDeclarationSyntax node)
+        {
+            var convertedNode = (VbSyntax.EnumBlockSyntax)DefaultVisitInner(node);
+            var blockStart = convertedNode.EnumStatement.GetLastToken();
+            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -45,7 +45,7 @@ namespace ICSharpCode.CodeConverter.VB
             var convertedNode = (VbSyntax.CompilationUnitSyntax)DefaultVisitInner(node);
             // Special case where we need to map manually because it's a special zero-width token that just has leading trivia that isn't at the start of the line necessarily
             return convertedNode.WithEndOfFileToken(
-                convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken).WithConvertedLeadingTriviaFrom(node.EndOfFileToken)
+                convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken)
             );
         }
 

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -16,17 +16,11 @@ namespace ICSharpCode.CodeConverter.VB
 {
     internal class CommentConvertingNodesVisitor : CSharpSyntaxVisitor<VisualBasicSyntaxNode>
     {
-        public TriviaConverter TriviaConverter { get; }
         private readonly CSharpSyntaxVisitor<VisualBasicSyntaxNode> _wrappedVisitor;
-        private BitArray _lineTriviaMapped;
-        private SemanticModel _semanticModel;
 
-        public CommentConvertingNodesVisitor(CSharpSyntaxVisitor<VisualBasicSyntaxNode> wrappedVisitor, BitArray lineTriviaMapped, SemanticModel semanticModel)
+        public CommentConvertingNodesVisitor(CSharpSyntaxVisitor<VisualBasicSyntaxNode> wrappedVisitor)
         {
-            TriviaConverter = new TriviaConverter();
             _wrappedVisitor = wrappedVisitor;
-            _lineTriviaMapped = lineTriviaMapped;
-            _semanticModel = semanticModel;
         }
 
         public override VisualBasicSyntaxNode DefaultVisit(SyntaxNode node)
@@ -36,13 +30,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         private VisualBasicSyntaxNode DefaultVisitInner(SyntaxNode node)
         {
-            try {
-                var converted = _wrappedVisitor.Visit(node);
-                return converted.WithSourceMappingFrom(node);
-            } catch (Exception e) {
-                var dummyStatement = SyntaxFactory.EmptyStatement();
-                return dummyStatement.WithVbTrailingErrorComment<VbSyntax.StatementSyntax>((CSharpSyntaxNode)node, e);
-            }
+            return _wrappedVisitor.Visit(node);
         }
 
         public override VisualBasicSyntaxNode VisitAttributeList(CsSyntax.AttributeListSyntax node)

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -57,39 +57,5 @@ namespace ICSharpCode.CodeConverter.VB
             var convertedNode = (VbSyntax.CompilationUnitSyntax)DefaultVisitInner(node);
             return convertedNode.WithEndOfFileToken(convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken));
         }
-
-        public override VisualBasicSyntaxNode VisitNamespaceDeclaration(CsSyntax.NamespaceDeclarationSyntax node)
-        {
-            var convertedNode = (VbSyntax.NamespaceBlockSyntax)DefaultVisitInner(node);
-            var blockStart = convertedNode.NamespaceStatement.GetLastToken();
-            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
-        }
-
-        public override VisualBasicSyntaxNode VisitClassDeclaration(CsSyntax.ClassDeclarationSyntax node)
-        {
-            var convertedNode = DefaultVisitInner(node);
-            VbSyntax.StatementSyntax blockStmt = convertedNode is VbSyntax.ClassBlockSyntax cbs ? (VbSyntax.StatementSyntax) cbs.ClassStatement
-                : convertedNode is VbSyntax.ModuleBlockSyntax mbs ? (VbSyntax.StatementSyntax) mbs.ModuleStatement
-                : null;
-            var endOfBlock = blockStmt?.GetLastToken();
-            if (endOfBlock != null) {
-                return convertedNode.ReplaceToken(endOfBlock.Value, endOfBlock.Value.WithSourceMappingFrom(node.OpenBraceToken));
-            }
-            return convertedNode;
-        }
-
-        public override VisualBasicSyntaxNode VisitStructDeclaration(CsSyntax.StructDeclarationSyntax node)
-        {
-            var convertedNode = (VbSyntax.StructureBlockSyntax)DefaultVisitInner(node);
-            var blockStart = convertedNode.StructureStatement.GetLastToken();
-            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
-        }
-
-        public override VisualBasicSyntaxNode VisitEnumDeclaration(CsSyntax.EnumDeclarationSyntax node)
-        {
-            var convertedNode = (VbSyntax.EnumBlockSyntax)DefaultVisitInner(node);
-            var blockStart = convertedNode.EnumStatement.GetLastToken();
-            return convertedNode.ReplaceToken(blockStart, blockStart.WithSourceMappingFrom(node.OpenBraceToken));
-        }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -52,7 +52,7 @@ namespace ICSharpCode.CodeConverter.VB
         {
             var convertedNode = _wrappedVisitor.Visit(node)
                 .WithPrependedLeadingTrivia(SyntaxFactory.EndOfLineTrivia(Environment.NewLine));
-            return TriviaConverter.PortConvertedTrivia(node, convertedNode);
+            return convertedNode;
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingNodesVisitor.cs
@@ -51,5 +51,11 @@ namespace ICSharpCode.CodeConverter.VB
                 .WithPrependedLeadingTrivia(SyntaxFactory.EndOfLineTrivia(Environment.NewLine));
             return convertedNode;
         }
+
+        public override VisualBasicSyntaxNode VisitCompilationUnit(CsSyntax.CompilationUnitSyntax node)
+        {
+            var convertedNode = (VbSyntax.CompilationUnitSyntax)DefaultVisitInner(node);
+            return convertedNode.WithEndOfFileToken(convertedNode.EndOfFileToken.WithSourceMappingFrom(node.EndOfFileToken));
+        }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper.cs
@@ -33,7 +33,7 @@ namespace ICSharpCode.CodeConverter.VB
             if (toggleSourceMapping) _addSourceMapping = false;
             try {
                 var converted = _wrappedVisitor.Visit(node);
-                return _addSourceMapping ? converted.WithSourceMappingFrom(node) : converted;
+                return _addSourceMapping ? node.CopyAnnotationsTo(converted).WithSourceMappingFrom(node) : converted;
             } catch (Exception e) {
                 var dummyStatement = SyntaxFactory.EmptyStatement();
                 return ((T)(object)dummyStatement).WithVbTrailingErrorComment((CSharpSyntaxNode)node, e);

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper.cs
@@ -29,8 +29,8 @@ namespace ICSharpCode.CodeConverter.VB
 
         public T Accept(SyntaxNode node, bool forceNoSourceMapping)
         {
-            bool toggleSourceMapping = forceNoSourceMapping && _addSourceMapping;
-            if (toggleSourceMapping) _addSourceMapping = false;
+            bool disableSourceMapping = forceNoSourceMapping && _addSourceMapping;
+            if (disableSourceMapping) _addSourceMapping = false;
             try {
                 var converted = _wrappedVisitor.Visit(node);
                 return _addSourceMapping ? node.CopyAnnotationsTo(converted).WithSourceMappingFrom(node) : converted;
@@ -38,7 +38,7 @@ namespace ICSharpCode.CodeConverter.VB
                 var dummyStatement = SyntaxFactory.EmptyStatement();
                 return ((T)(object)dummyStatement).WithVbTrailingErrorComment((CSharpSyntaxNode)node, e);
             } finally {
-                if (toggleSourceMapping) _addSourceMapping = true;
+                if (disableSourceMapping) _addSourceMapping = true;
             }
 
         }

--- a/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper`1.cs
+++ b/ICSharpCode.CodeConverter/VB/CommentConvertingVisitorWrapper`1.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.VisualBasic;
+using VbSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using CsSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+using SyntaxFactory = Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory;
+using System.Collections;
+
+namespace ICSharpCode.CodeConverter.VB
+{
+
+    internal class CommentConvertingVisitorWrapper<T> where T : VisualBasicSyntaxNode
+    {
+        private readonly CSharpSyntaxVisitor<T> _wrappedVisitor;
+
+        public CommentConvertingVisitorWrapper(CSharpSyntaxVisitor<T> wrappedVisitor)
+        {
+            _wrappedVisitor = wrappedVisitor;
+        }
+
+        public TriviaConverter TriviaConverter { get; }
+
+        public T Accept(SyntaxNode node, bool addSourceMapping)
+        {
+            try {
+                var converted = _wrappedVisitor.Visit(node);
+                return addSourceMapping ? converted.WithSourceMappingFrom(node) : converted;
+            } catch (Exception e) {
+                var dummyStatement = SyntaxFactory.EmptyStatement();
+                return ((T)(object) dummyStatement).WithVbTrailingErrorComment((CSharpSyntaxNode)node, e);
+            }
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using ICSharpCode.CodeConverter.Shared;
@@ -37,6 +38,7 @@ namespace ICSharpCode.CodeConverter.VB
         private readonly CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> _nodesVisitor;
         private readonly TriviaConverter _triviaConverter;
         private readonly SemanticModel _semanticModel;
+        private readonly BitArray _lineTriviaMapped;
 
         public CommonConversions(SemanticModel semanticModel, SyntaxGenerator vbSyntaxGenerator,
             CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor,
@@ -201,7 +203,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         private CS.CSharpSyntaxVisitor<SyntaxList<StatementSyntax>> CreateMethodBodyVisitor(MethodBodyExecutableStatementVisitor methodBodyExecutableStatementVisitor = null)
         {
-            var visitor = methodBodyExecutableStatementVisitor ?? new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this);
+            var visitor = methodBodyExecutableStatementVisitor ?? new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this, _lineTriviaMapped);
             return visitor.CommentConvertingVisitor;
         }
 
@@ -212,7 +214,7 @@ namespace ICSharpCode.CodeConverter.VB
             EndBlockStatementSyntax endStmt;
             SyntaxList<StatementSyntax> body;
             isIterator = false;
-            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this);
+            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this, _lineTriviaMapped);
             body = ConvertBody(node.Body, node.ExpressionBody, isIteratorState);
             isIterator = isIteratorState.IsIterator;
             var attributes = SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(_nodesVisitor)));

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -232,7 +232,7 @@ namespace ICSharpCode.CodeConverter.VB
                 case CSSyntaxKind.SetAccessorDeclaration:
                     blockKind = SyntaxKind.SetAccessorBlock;
                     valueParam = SyntaxFactory.Parameter(SyntaxFactory.ModifiedIdentifier("value"))
-                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor)))
+                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor, false)))
                         .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ByValKeyword)));
                     stmt = SyntaxFactory.SetAccessorStatement(attributes, modifiers, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(valueParam)));
                     endStmt = SyntaxFactory.EndSetStatement();
@@ -244,7 +244,7 @@ namespace ICSharpCode.CodeConverter.VB
                 case CSSyntaxKind.AddAccessorDeclaration:
                     blockKind = SyntaxKind.AddHandlerAccessorBlock;
                     valueParam = SyntaxFactory.Parameter(SyntaxFactory.ModifiedIdentifier("value"))
-                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor)))
+                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor, false)))
                         .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ByValKeyword)));
                     stmt = SyntaxFactory.AddHandlerAccessorStatement(attributes, modifiers, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(valueParam)));
                     endStmt = SyntaxFactory.EndAddHandlerStatement();
@@ -252,7 +252,7 @@ namespace ICSharpCode.CodeConverter.VB
                 case CSSyntaxKind.RemoveAccessorDeclaration:
                     blockKind = SyntaxKind.RemoveHandlerAccessorBlock;
                     valueParam = SyntaxFactory.Parameter(SyntaxFactory.ModifiedIdentifier("value"))
-                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor)))
+                        .WithAsClause(SyntaxFactory.SimpleAsClause((TypeSyntax)parent.Type.Accept(_nodesVisitor, false)))
                         .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.ByValKeyword)));
                     stmt = SyntaxFactory.RemoveHandlerAccessorStatement(attributes, modifiers, SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(valueParam)));
                     endStmt = SyntaxFactory.EndRemoveHandlerStatement();

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -518,7 +518,7 @@ namespace ICSharpCode.CodeConverter.VB
                     idText = "Item";
                     break;
             }
-            return Identifier(idText, keywordRequiresEscaping);
+            return Identifier(idText, keywordRequiresEscaping).WithOriginalLineAnnotationsFrom(id);
         }
 
         private string AdjustIfEventIdentifier(SyntaxToken id, CS.CSharpSyntaxNode parent)

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -260,7 +260,7 @@ namespace ICSharpCode.CodeConverter.VB
                 default:
                     throw new NotSupportedException();
             }
-            return SyntaxFactory.AccessorBlock(blockKind, stmt, body, endStmt);
+            return SyntaxFactory.AccessorBlock(blockKind, stmt, body, endStmt).WithSourceMappingFrom(node);
         }
 
         private static SyntaxToken GetVbPropertyBackingFieldName(CSS.BasePropertyDeclarationSyntax parent)

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -36,19 +36,15 @@ namespace ICSharpCode.CodeConverter.VB
     internal class CommonConversions
     {
         public SyntaxGenerator VbSyntaxGenerator { get; }
-        private readonly CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> _nodesVisitor;
-        private readonly TriviaConverter _triviaConverter;
+        private readonly CommentConvertingVisitorWrapper<VisualBasicSyntaxNode> _nodesVisitor;
         private readonly SemanticModel _semanticModel;
-        private readonly BitArray _lineTriviaMapped;
 
         public CommonConversions(SemanticModel semanticModel, SyntaxGenerator vbSyntaxGenerator,
-            CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor,
-            TriviaConverter triviaConverter)
+            CommentConvertingVisitorWrapper<VisualBasicSyntaxNode> nodesVisitor)
         {
             VbSyntaxGenerator = vbSyntaxGenerator;
             _semanticModel = semanticModel;
             _nodesVisitor = nodesVisitor;
-            _triviaConverter = triviaConverter;
         }
 
         public SyntaxList<StatementSyntax> ConvertBody(CSS.BlockSyntax body,
@@ -204,7 +200,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         private CS.CSharpSyntaxVisitor<SyntaxList<StatementSyntax>> CreateMethodBodyVisitor(MethodBodyExecutableStatementVisitor methodBodyExecutableStatementVisitor = null)
         {
-            var visitor = methodBodyExecutableStatementVisitor ?? new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this, _lineTriviaMapped);
+            var visitor = methodBodyExecutableStatementVisitor ?? new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, this);
             return visitor.CommentConvertingVisitor;
         }
 
@@ -215,7 +211,7 @@ namespace ICSharpCode.CodeConverter.VB
             EndBlockStatementSyntax endStmt;
             SyntaxList<StatementSyntax> body;
             isIterator = false;
-            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, _triviaConverter, this, _lineTriviaMapped);
+            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, _nodesVisitor, this);
             body = ConvertBody(node.Body, node.ExpressionBody, isIteratorState);
             isIterator = isIteratorState.IsIterator;
             var attributes = SyntaxFactory.List(node.AttributeLists.Select(a => (AttributeListSyntax)a.Accept(_nodesVisitor)));

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using AttributeListSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeListSyntax;
 using BinaryExpressionSyntax = Microsoft.CodeAnalysis.CSharp.Syntax.BinaryExpressionSyntax;
 using CSharpExtensions = Microsoft.CodeAnalysis.CSharp.CSharpExtensions;
+using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
 using CSSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -518,7 +519,7 @@ namespace ICSharpCode.CodeConverter.VB
                     idText = "Item";
                     break;
             }
-            return Identifier(idText, keywordRequiresEscaping).WithOriginalLineAnnotationsFrom(id);
+            return Identifier(idText, keywordRequiresEscaping).WithSourceMappingFrom(id);
         }
 
         private string AdjustIfEventIdentifier(SyntaxToken id, CS.CSharpSyntaxNode parent)

--- a/ICSharpCode.CodeConverter/VB/CsExpander.cs
+++ b/ICSharpCode.CodeConverter/VB/CsExpander.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.CodeConverter.VB
             var aliasNodes = expandedNode.GetAnnotatedNodes(Simplifier.Annotation).Select(syntaxNode =>
                 LeftMostDescendant(syntaxNode).Parent).OfType<AliasQualifiedNameSyntax>().Where(n => n.Alias.IsGlobalId()).ToArray();
             if (aliasNodes.Any()) {
-                return expandedNode.ReplaceNodes(aliasNodes, (orig, rewrite) => rewrite.Name);
+                return expandedNode.ReplaceNodes(aliasNodes, (orig, rewrite) => rewrite.Name.WithLeadingTrivia(rewrite.GetLeadingTrivia()));
             }
             return expandedNode;
         }

--- a/ICSharpCode.CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
@@ -29,7 +29,7 @@ namespace ICSharpCode.CodeConverter.VB
     internal class MethodBodyExecutableStatementVisitor : CS.CSharpSyntaxVisitor<SyntaxList<StatementSyntax>>
     {
         private SemanticModel _semanticModel;
-        private readonly CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode> _nodesVisitor;
+        private readonly CommentConvertingVisitorWrapper<VisualBasicSyntaxNode> _nodesVisitor;
         private readonly CommonConversions _commonConversions;
         private readonly Stack<BlockInfo> _blockInfo = new Stack<BlockInfo>(); // currently only works with switch blocks
         private int _switchCount = 0;
@@ -42,13 +42,12 @@ namespace ICSharpCode.CodeConverter.VB
         public CommentConvertingMethodBodyVisitor CommentConvertingVisitor { get; }
 
         public MethodBodyExecutableStatementVisitor(SemanticModel semanticModel,
-            CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor, TriviaConverter triviaConverter,
-            CommonConversions commonConversions, System.Collections.BitArray lineTriviaMapped)
+            CommentConvertingVisitorWrapper<VisualBasicSyntaxNode> nodesVisitor, CommonConversions commonConversions)
         {
             this._semanticModel = semanticModel;
             this._nodesVisitor = nodesVisitor;
             _commonConversions = commonConversions;
-            CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter, lineTriviaMapped);
+            CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this);
         }
 
         public override SyntaxList<StatementSyntax> DefaultVisit(SyntaxNode node)

--- a/ICSharpCode.CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
@@ -43,12 +43,12 @@ namespace ICSharpCode.CodeConverter.VB
 
         public MethodBodyExecutableStatementVisitor(SemanticModel semanticModel,
             CSharpSyntaxVisitor<VisualBasicSyntaxNode> nodesVisitor, TriviaConverter triviaConverter,
-            CommonConversions commonConversions)
+            CommonConversions commonConversions, System.Collections.BitArray lineTriviaMapped)
         {
             this._semanticModel = semanticModel;
             this._nodesVisitor = nodesVisitor;
             _commonConversions = commonConversions;
-            CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter);
+            CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(this, triviaConverter, lineTriviaMapped);
         }
 
         public override SyntaxList<StatementSyntax> DefaultVisit(SyntaxNode node)

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -59,8 +59,7 @@ namespace ICSharpCode.CodeConverter.VB
         private readonly CommonConversions _commonConversions;
 
         private int _placeholder = 1;
-        private readonly BitArray _lineTriviaMapped;
-        public CommentConvertingNodesVisitor TriviaConvertingVisitor { get; }
+        public CommentConvertingVisitorWrapper<VisualBasicSyntaxNode> TriviaConvertingVisitor { get; }
 
         private string GeneratePlaceholder(string v)
         {
@@ -75,9 +74,8 @@ namespace ICSharpCode.CodeConverter.VB
             _semanticModel = semanticModel;
             _vbViewOfCsSymbols = vbViewOfCsSymbols;
             _vbSyntaxGenerator = vbSyntaxGenerator;
-            _lineTriviaMapped = new BitArray(numberOfLines);
-            TriviaConvertingVisitor = new CommentConvertingNodesVisitor(this, _lineTriviaMapped, _semanticModel);
-            _commonConversions = new CommonConversions(semanticModel, vbSyntaxGenerator, TriviaConvertingVisitor, TriviaConvertingVisitor.TriviaConverter);
+            TriviaConvertingVisitor = new CommentConvertingVisitorWrapper<VisualBasicSyntaxNode>(new CommentConvertingNodesVisitor(this));
+            _commonConversions = new CommonConversions(semanticModel, vbSyntaxGenerator, TriviaConvertingVisitor);
             _cSharpHelperMethodDefinition = new CSharpHelperMethodDefinition();
         }
 
@@ -415,7 +413,7 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitMethodDeclaration(CSS.MethodDeclarationSyntax node)
         {
-            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, TriviaConvertingVisitor, TriviaConvertingVisitor.TriviaConverter, _commonConversions, _lineTriviaMapped);
+            var isIteratorState = new MethodBodyExecutableStatementVisitor(_semanticModel, TriviaConvertingVisitor, _commonConversions);
             bool requiresBody = node.Body != null || node.ExpressionBody != null || node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, CS.SyntaxKind.ExternKeyword));
             var block = _commonConversions.ConvertBody(node.Body, node.ExpressionBody, isIteratorState);
             var id = _commonConversions.ConvertIdentifier(node.Identifier);

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -67,11 +67,6 @@ namespace ICSharpCode.CodeConverter.VB
             return $"__{v}{_placeholder++}__";
         }
 
-        private static int GetImportantTriviaLength(ImportsClauseSyntax c)
-        {
-            return c.GetLeadingTrivia().Concat(c.GetTrailingTrivia()).Where(t => !t.IsWhitespaceOrEndOfLine()).Sum(t => t.ToString().Length);
-        }
-
         public NodesVisitor(Document document, CS.CSharpCompilation compilation, SemanticModel semanticModel,
             VisualBasicCompilation vbViewOfCsSymbols, SyntaxGenerator vbSyntaxGenerator, int numberOfLines)
         {
@@ -90,11 +85,6 @@ namespace ICSharpCode.CodeConverter.VB
         {
             throw new NotImplementedException($"Conversion for {CS.CSharpExtensions.Kind(node)} not implemented, please report this issue")
                 .WithNodeInformation(node);
-        }
-
-        private Func<SyntaxNode, SyntaxNode> DelegateConversion(Func<SyntaxNode, SyntaxList<StatementSyntax>> convert)
-        {
-            return node => MethodBodyExecutableStatementVisitor.CreateBlock(convert(node));
         }
 
         public override VisualBasicSyntaxNode VisitCompilationUnit(CSS.CompilationUnitSyntax node)

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -199,7 +199,9 @@ namespace ICSharpCode.CodeConverter.VB
                 clause = clause.WithAlias(alias);
             }
 
-            _convertedImports.Add(SyntaxFactory.ImportsStatement(SyntaxFactory.SingletonSeparatedList<ImportsClauseSyntax>(clause)));
+            _convertedImports.Add(SyntaxFactory.ImportsStatement(SyntaxFactory.SingletonSeparatedList<ImportsClauseSyntax>(clause))
+                .WithSourceMappingFrom(node) //Because we're returning null, the visiting process can't do the normal mapping
+            );
             return null;
         }
 

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -618,7 +618,7 @@ namespace ICSharpCode.CodeConverter.VB
                 .Select(x => x.Expression)
                 .OfType<CSS.AssignmentExpressionSyntax>()
                 .SelectMany(x => x.Left.DescendantNodesAndSelf().OfType<CSS.IdentifierNameSyntax>())
-                .FirstOrDefault()?.Accept(TriviaConvertingVisitor);
+                .FirstOrDefault()?.Accept(TriviaConvertingVisitor, false);
 
             var riseEventAccessor = SyntaxFactory.RaiseEventAccessorBlock(
                 SyntaxFactory.RaiseEventAccessorStatement(

--- a/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ICSharpCode.CodeConverter.CSharp;
+using ICSharpCode.CodeConverter.Shared;
+using ICSharpCode.CodeConverter.Util;
+using Microsoft.CodeAnalysis;
+using CS = Microsoft.CodeAnalysis.CSharp;
+using VBasic = Microsoft.CodeAnalysis.VisualBasic;
+using CSSyntax = Microsoft.CodeAnalysis.CSharp.Syntax;
+using SyntaxNodeExtensions = ICSharpCode.CodeConverter.Util.SyntaxNodeExtensions;
+using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
+using System.Linq;
+using System.Collections;
+
+namespace ICSharpCode.CodeConverter.VB
+{
+
+    internal static class SyntaxNodeVisitorExtensions
+    {
+        public static T Accept<T>(this SyntaxNode node, CommentConvertingVisitorWrapper<T> visitorWrapper, bool addSourceMapping = true) where T : VBasic.VisualBasicSyntaxNode
+        {
+            if (node == null) return default(T);
+            return visitorWrapper.Accept(node, addSourceMapping);
+        }
+    }
+}

--- a/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
@@ -19,7 +19,7 @@ namespace ICSharpCode.CodeConverter.VB
         public static T Accept<T>(this SyntaxNode node, CommentConvertingVisitorWrapper<T> visitorWrapper, bool addSourceMapping = true) where T : VBasic.VisualBasicSyntaxNode
         {
             if (node == null) return default(T);
-            return visitorWrapper.Accept(node, !addSourceMapping);
+            return visitorWrapper.Accept(node, addSourceMapping);
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
@@ -19,12 +19,7 @@ namespace ICSharpCode.CodeConverter.VB
         public static T Accept<T>(this SyntaxNode node, CommentConvertingVisitorWrapper<T> visitorWrapper, bool addSourceMapping = true) where T : VBasic.VisualBasicSyntaxNode
         {
             if (node == null) return default(T);
-            try {
-                return visitorWrapper.Accept(node, !addSourceMapping);
-            } finally {
-
-            }
-
+            return visitorWrapper.Accept(node, !addSourceMapping);
         }
     }
 }

--- a/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
+++ b/ICSharpCode.CodeConverter/VB/SyntaxNodeVisitorExtensions.cs
@@ -19,7 +19,12 @@ namespace ICSharpCode.CodeConverter.VB
         public static T Accept<T>(this SyntaxNode node, CommentConvertingVisitorWrapper<T> visitorWrapper, bool addSourceMapping = true) where T : VBasic.VisualBasicSyntaxNode
         {
             if (node == null) return default(T);
-            return visitorWrapper.Accept(node, addSourceMapping);
+            try {
+                return visitorWrapper.Accept(node, !addSourceMapping);
+            } finally {
+
+            }
+
         }
     }
 }

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -37,7 +37,6 @@ public partial class TestClass
         bool enumEnumEquality = eEnum == RankEnum.First;
     }
 }");
-
         }
 
         [Fact]
@@ -58,7 +57,6 @@ End Class", @"public partial class TestClass
 
     private static int Val;
 }");
-
         }
 
         [Fact]
@@ -2227,7 +2225,6 @@ End Module", @"internal static partial class Module1
 ");
         }
 
-
         [Fact]
         public async Task StringInterpolationWithConditionalOperator()
         {
@@ -2619,7 +2616,6 @@ public partial class Test
     }
 }");
         }
-
 
     }
 }

--- a/Tests/CSharp/LinqExpressionTests.cs
+++ b/Tests/CSharp/LinqExpressionTests.cs
@@ -19,13 +19,13 @@ Private Shared Sub SimpleQuery()
         Console.WriteLine(n)
     Next
 End Sub",
-                @"private static void SimpleQuery()
+                @"
+private static void SimpleQuery()
 {
     var numbers = new[] { 7, 9, 5, 3, 6 };
     var res = from n in numbers
               where n > 5
               select n;
-
     foreach (var n in res)
         Console.WriteLine(n);
 }");

--- a/Tests/CSharp/LinqExpressionTests.cs
+++ b/Tests/CSharp/LinqExpressionTests.cs
@@ -11,16 +11,14 @@ namespace CodeConverter.Tests.CSharp
         [Fact]
         public async Task Linq1()
         {
-            await TestConversionVisualBasicToCSharp(@"
-Private Shared Sub SimpleQuery()
+            await TestConversionVisualBasicToCSharp(@"Private Shared Sub SimpleQuery()
     Dim numbers = {7, 9, 5, 3, 6}
     Dim res = From n In numbers Where n > 5 Select n
     For Each n In res
         Console.WriteLine(n)
     Next
 End Sub",
-                @"
-private static void SimpleQuery()
+                @"private static void SimpleQuery()
 {
     var numbers = new[] { 7, 9, 5, 3, 6 };
     var res = from n in numbers

--- a/Tests/CSharp/LinqExpressionTests.cs
+++ b/Tests/CSharp/LinqExpressionTests.cs
@@ -11,10 +11,10 @@ namespace CodeConverter.Tests.CSharp
         [Fact]
         public async Task Linq1()
         {
-            await TestConversionVisualBasicToCSharp(@"Private Shared Sub SimpleQuery()
+            await TestConversionVisualBasicToCSharp(@"
+Private Shared Sub SimpleQuery()
     Dim numbers = {7, 9, 5, 3, 6}
     Dim res = From n In numbers Where n > 5 Select n
-
     For Each n In res
         Console.WriteLine(n)
     Next

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -871,10 +871,8 @@ End Sub", @"public SurroundingClass()
         public async Task TestStaticConstructor()
         {
             await TestConversionVisualBasicToCSharp(
-@"
-Shared Sub New()
-End Sub", @"
-static SurroundingClass()
+@"Shared Sub New()
+End Sub", @"static SurroundingClass()
 {
 }");
         }
@@ -2049,11 +2047,9 @@ internal partial class AsyncCode
         public async Task TestExternDllImport()
         {
             await TestConversionVisualBasicToCSharp(
-                @"
-<DllImport(""kernel32.dll"", SetLastError:=True)>
+                @"<DllImport(""kernel32.dll"", SetLastError:=True)>
 Private Shared Function OpenProcess(ByVal dwDesiredAccess As AccessMask, ByVal bInheritHandle As Boolean, ByVal dwProcessId As UInteger) As IntPtr
-End Function", @"
-[DllImport(""kernel32.dll"", SetLastError = true)]
+End Function", @"[DllImport(""kernel32.dll"", SetLastError = true)]
 private static extern IntPtr OpenProcess(AccessMask dwDesiredAccess, bool bInheritHandle, uint dwProcessId);");
         }
     }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -871,7 +871,8 @@ End Sub", @"public SurroundingClass()
         public async Task TestStaticConstructor()
         {
             await TestConversionVisualBasicToCSharp(
-@"Shared Sub New()
+@"
+Shared Sub New()
 End Sub", @"static SurroundingClass()
 {
 }");
@@ -2047,7 +2048,8 @@ internal partial class AsyncCode
         public async Task TestExternDllImport()
         {
             await TestConversionVisualBasicToCSharp(
-                @"<DllImport(""kernel32.dll"", SetLastError:=True)>
+                @"
+<DllImport(""kernel32.dll"", SetLastError:=True)>
 Private Shared Function OpenProcess(ByVal dwDesiredAccess As AccessMask, ByVal bInheritHandle As Boolean, ByVal dwProcessId As UInteger) As IntPtr
 End Function", @"[DllImport(""kernel32.dll"", SetLastError = true)]
 private static extern IntPtr OpenProcess(AccessMask dwDesiredAccess, bool bInheritHandle, uint dwProcessId);");

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -873,7 +873,8 @@ End Sub", @"public SurroundingClass()
             await TestConversionVisualBasicToCSharp(
 @"
 Shared Sub New()
-End Sub", @"static SurroundingClass()
+End Sub", @"
+static SurroundingClass()
 {
 }");
         }
@@ -2051,7 +2052,8 @@ internal partial class AsyncCode
                 @"
 <DllImport(""kernel32.dll"", SetLastError:=True)>
 Private Shared Function OpenProcess(ByVal dwDesiredAccess As AccessMask, ByVal bInheritHandle As Boolean, ByVal dwProcessId As UInteger) As IntPtr
-End Function", @"[DllImport(""kernel32.dll"", SetLastError = true)]
+End Function", @"
+[DllImport(""kernel32.dll"", SetLastError = true)]
 private static extern IntPtr OpenProcess(AccessMask dwDesiredAccess, bool bInheritHandle, uint dwProcessId);");
         }
     }

--- a/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
+++ b/Tests/CSharp/MissingSemanticModelInfo/ExpressionTests.cs
@@ -251,24 +251,25 @@ End Class", @"internal partial class TestClass
         }
 
     [Fact]
-    public async Task CharacterizeRaiseEventWithMissingDefinitionActsLikeFunc()
+    public async Task CharacterizeRaiseEventWithMissingDefinitionActsLikeMultiIndexer()
     {
-    await TestConversionCSharpToVisualBasic(
-        @"using System;
-
-class TestClass
-{
-    void TestMethod()
-    {
-        if (MyEvent != null) MyEvent(this, EventArgs.Empty);
-    }
-}", @"Imports System
+    await TestConversionVisualBasicToCSharp(
+        @"Imports System
 
 Friend Class TestClass
     Private Sub TestMethod()
         If MyEvent IsNot Nothing Then MyEvent(Me, EventArgs.Empty)
     End Sub
-End Class");
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        if (MyEvent != null)
+            MyEvent[this, EventArgs.Empty];
+    }
+}");
         }
     }
 }

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -7,7 +7,6 @@ namespace CodeConverter.Tests.CSharp
 {
     public class NamespaceLevelTests : ConverterTestBase
     {
-
         [Fact]
         public async Task TestNamespace()
         {
@@ -812,7 +811,6 @@ internal static partial class Module1
         object vObjectULong = EULong.M1;
     }
 }");
-
         }
 
         [Fact]
@@ -907,6 +905,5 @@ End Class",
     }
 }");
         }
-
     }
 }

--- a/Tests/CSharp/StandaloneStatementTests.cs
+++ b/Tests/CSharp/StandaloneStatementTests.cs
@@ -96,7 +96,8 @@ End Class",
         public async Task SingleAbstractMethod()
         {
             await TestConversionVisualBasicToCSharp(
-                @"Protected MustOverride Sub abs()",
+                @"
+Protected MustOverride Sub abs()",
                 @"protected abstract void abs();");
         }
 

--- a/Tests/CSharp/StandaloneStatementTests.cs
+++ b/Tests/CSharp/StandaloneStatementTests.cs
@@ -98,7 +98,8 @@ End Class",
             await TestConversionVisualBasicToCSharp(
                 @"
 Protected MustOverride Sub abs()",
-                @"protected abstract void abs();");
+                @"
+protected abstract void abs();");
         }
 
         [Fact]

--- a/Tests/CSharp/StandaloneStatementTests.cs
+++ b/Tests/CSharp/StandaloneStatementTests.cs
@@ -96,10 +96,8 @@ End Class",
         public async Task SingleAbstractMethod()
         {
             await TestConversionVisualBasicToCSharp(
-                @"
-Protected MustOverride Sub abs()",
-                @"
-protected abstract void abs();");
+                @"Protected MustOverride Sub abs()",
+                @"protected abstract void abs();");
         }
 
         [Fact]

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1177,64 +1177,18 @@ End Class", @"internal partial class TestClass
         If a = 0 Then Console.WriteLine(1) : Console.WriteLine(2) : Return
         Console.WriteLine(3)
     End Sub
-End Class", @"internal partial class TestClass
+End Class", @"using System;
+
+internal partial class TestClass
 {
-    class _failedMemberConversionMarker1
+    public static void MultiStatement(int a)
     {
+        if (a == 0)
+        {
+            Console.WriteLine(1); Console.WriteLine(2); return;
+        }
+        Console.WriteLine(3);
     }
-#error Cannot convert MethodBlockSyntax - see comment for details
-    /* Cannot convert MethodBlockSyntax, System.NullReferenceException: Object reference not set to an instance of an object.
-       at Microsoft.CodeAnalysis.GreenNode.AdjustFlagsAndWidth(GreenNode node)
-       at Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithTwoChildren..ctor(GreenNode child0, GreenNode child1)
-       at Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.List(GreenNode child0, GreenNode child1)
-       at Microsoft.CodeAnalysis.GreenNode.CreateList(IEnumerable`1 nodes, Boolean alwaysCreateListNode)
-       at Microsoft.CodeAnalysis.SyntaxToken.WithTrailingTrivia(IEnumerable`1 trivia)
-       at ICSharpCode.CodeConverter.Util.SyntaxNodeExtensions.WithConvertedTrailingTriviaFrom(SyntaxToken node, Nullable`1 otherToken) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Util\SyntaxNodeExtensions.cs:line 827
-       at ICSharpCode.CodeConverter.Shared.TriviaConverter.<>c__DisplayClass8_0`1.<WithTrailingTriviaConversions>b__0(SyntaxToken originalToken, SyntaxToken updatedToken) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 133
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.VisitToken(SyntaxToken token)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitExpressionStatement(ExpressionStatementSyntax node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionStatementSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitListElement[TNode](TNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitList[TNode](SyntaxList`1 list)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitBlock(BlockSyntax node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitIfStatement(IfStatementSyntax node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitListElement[TNode](TNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitList[TNode](SyntaxList`1 list)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitBlock(BlockSyntax node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitMethodDeclaration(MethodDeclarationSyntax node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
-       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replace[TNode](SyntaxNode root, IEnumerable`1 nodes, Func`3 computeReplacementNode, IEnumerable`1 tokens, Func`3 computeReplacementToken, IEnumerable`1 trivia, Func`3 computeReplacementTrivia)
-       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ReplaceCore[TNode](IEnumerable`1 nodes, Func`3 computeReplacementNode, IEnumerable`1 tokens, Func`3 computeReplacementToken, IEnumerable`1 trivia, Func`3 computeReplacementTrivia)
-       at Microsoft.CodeAnalysis.SyntaxNodeExtensions.ReplaceTokens[TRoot](TRoot root, IEnumerable`1 tokens, Func`3 computeReplacementToken)
-       at ICSharpCode.CodeConverter.Shared.TriviaConverter.WithTrailingTriviaConversions[T](T destination, Nullable`1 parentLastToken, Boolean hasVisitedContainingBlock) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 119
-       at ICSharpCode.CodeConverter.Shared.TriviaConverter.PortConvertedTrivia[T](SyntaxNode sourceNode, T destination) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 61
-       at ICSharpCode.CodeConverter.CSharp.CommentConvertingNodesVisitor.<DefaultVisit>d__5.MoveNext() in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\CSharp\CommentConvertingNodesVisitor.cs:line 30
-    --- End of stack trace from previous location where exception was thrown ---
-       at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
-       at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
-       at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
-       at ICSharpCode.CodeConverter.CSharp.DeclarationNodeVisitor.<ConvertMember>d__36.MoveNext() in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\CSharp\DeclarationNodeVisitor.cs:line 229
-
-    Input:
-        Public Shared Sub MultiStatement(a As Integer)
-            If a = 0 Then Global.System.Console.WriteLine(1) : Global.System.Console.WriteLine(2) : Return
-            Global.System.Console.WriteLine(3)
-        End Sub
-
-     */
 }");
         }
 

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1111,7 +1111,6 @@ public partial class AcmeClass
 }}");
         }
 
-
         [Fact]
         public async Task DeclareStatementWithAttributes()
         {

--- a/Tests/CSharp/StatementTests.cs
+++ b/Tests/CSharp/StatementTests.cs
@@ -1177,18 +1177,64 @@ End Class", @"internal partial class TestClass
         If a = 0 Then Console.WriteLine(1) : Console.WriteLine(2) : Return
         Console.WriteLine(3)
     End Sub
-End Class", @"using System;
-
-internal partial class TestClass
+End Class", @"internal partial class TestClass
 {
-    public static void MultiStatement(int a)
+    class _failedMemberConversionMarker1
     {
-        if (a == 0)
-        {
-            Console.WriteLine(1); Console.WriteLine(2); return;
-        }
-        Console.WriteLine(3);
     }
+#error Cannot convert MethodBlockSyntax - see comment for details
+    /* Cannot convert MethodBlockSyntax, System.NullReferenceException: Object reference not set to an instance of an object.
+       at Microsoft.CodeAnalysis.GreenNode.AdjustFlagsAndWidth(GreenNode node)
+       at Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.WithTwoChildren..ctor(GreenNode child0, GreenNode child1)
+       at Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList.List(GreenNode child0, GreenNode child1)
+       at Microsoft.CodeAnalysis.GreenNode.CreateList(IEnumerable`1 nodes, Boolean alwaysCreateListNode)
+       at Microsoft.CodeAnalysis.SyntaxToken.WithTrailingTrivia(IEnumerable`1 trivia)
+       at ICSharpCode.CodeConverter.Util.SyntaxNodeExtensions.WithConvertedTrailingTriviaFrom(SyntaxToken node, Nullable`1 otherToken) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Util\SyntaxNodeExtensions.cs:line 827
+       at ICSharpCode.CodeConverter.Shared.TriviaConverter.<>c__DisplayClass8_0`1.<WithTrailingTriviaConversions>b__0(SyntaxToken originalToken, SyntaxToken updatedToken) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 133
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.VisitToken(SyntaxToken token)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitExpressionStatement(ExpressionStatementSyntax node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionStatementSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitListElement[TNode](TNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitList[TNode](SyntaxList`1 list)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitBlock(BlockSyntax node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitIfStatement(IfStatementSyntax node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.IfStatementSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitListElement[TNode](TNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitList[TNode](SyntaxList`1 list)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitBlock(BlockSyntax node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitMethodDeclaration(MethodDeclarationSyntax node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax.Accept[TResult](CSharpSyntaxVisitor`1 visitor)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replacer`1.Visit(SyntaxNode node)
+       at Microsoft.CodeAnalysis.CSharp.Syntax.SyntaxReplacer.Replace[TNode](SyntaxNode root, IEnumerable`1 nodes, Func`3 computeReplacementNode, IEnumerable`1 tokens, Func`3 computeReplacementToken, IEnumerable`1 trivia, Func`3 computeReplacementTrivia)
+       at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ReplaceCore[TNode](IEnumerable`1 nodes, Func`3 computeReplacementNode, IEnumerable`1 tokens, Func`3 computeReplacementToken, IEnumerable`1 trivia, Func`3 computeReplacementTrivia)
+       at Microsoft.CodeAnalysis.SyntaxNodeExtensions.ReplaceTokens[TRoot](TRoot root, IEnumerable`1 tokens, Func`3 computeReplacementToken)
+       at ICSharpCode.CodeConverter.Shared.TriviaConverter.WithTrailingTriviaConversions[T](T destination, Nullable`1 parentLastToken, Boolean hasVisitedContainingBlock) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 119
+       at ICSharpCode.CodeConverter.Shared.TriviaConverter.PortConvertedTrivia[T](SyntaxNode sourceNode, T destination) in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\Shared\TriviaConverter.cs:line 61
+       at ICSharpCode.CodeConverter.CSharp.CommentConvertingNodesVisitor.<DefaultVisit>d__5.MoveNext() in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\CSharp\CommentConvertingNodesVisitor.cs:line 30
+    --- End of stack trace from previous location where exception was thrown ---
+       at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
+       at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
+       at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
+       at ICSharpCode.CodeConverter.CSharp.DeclarationNodeVisitor.<ConvertMember>d__36.MoveNext() in C:\Users\Graham\Documents\GitHub\CodeConverter\ICSharpCode.CodeConverter\CSharp\DeclarationNodeVisitor.cs:line 229
+
+    Input:
+        Public Shared Sub MultiStatement(a As Integer)
+            If a = 0 Then Global.System.Console.WriteLine(1) : Global.System.Console.WriteLine(2) : Return
+            Global.System.Console.WriteLine(3)
+        End Sub
+
+     */
 }");
         }
 

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -282,12 +282,10 @@ End Class" + Environment.NewLine, @"internal partial class Class1
         public async Task CastConstantNumberToCharacterW()
         {
             await TestConversionVisualBasicToCSharp(
-                @"
-Private Sub Test()
+                @"Private Sub Test()
     Dim CR = ChrW(&HD)
 End Sub
-", @"
-private void Test()
+", @"private void Test()
 {
     char CR = (char)0xD;
 }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -286,7 +286,8 @@ End Class" + Environment.NewLine, @"internal partial class Class1
 Private Sub Test()
     Dim CR = ChrW(&HD)
 End Sub
-", @"private void Test()
+", @"
+private void Test()
 {
     char CR = (char)0xD;
 }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -282,7 +282,8 @@ End Class" + Environment.NewLine, @"internal partial class Class1
         public async Task CastConstantNumberToCharacterW()
         {
             await TestConversionVisualBasicToCSharp(
-                @"Private Sub Test()
+                @"
+Private Sub Test()
     Dim CR = ChrW(&HD)
 End Sub
 ", @"private void Test()

--- a/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
+++ b/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
@@ -11,7 +11,6 @@ namespace CodeConverter.Tests.LanguageAgnostic
 {
     public class ProjectFileTextEditorTests
     {
-
         [Fact]
         public void TogglesExistingValue()
         {

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/Properties/AssemblyInfo.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/Properties/AssemblyInfo.vb
@@ -1,15 +1,40 @@
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 
+
+' General Information about an assembly is controlled through the following
+' set of attributes. Change these attribute values to modify the information
+' associated with an assembly.
 <Assembly: AssemblyTitle("ConsoleApp2")>
-<Assembly: AssemblyDescription("")>
+<
+Assembly: AssemblyDescription("")>
 <Assembly: AssemblyConfiguration("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("ConsoleApp2")>
 <Assembly: AssemblyCopyright("Copyright ©  2018")>
 <Assembly: AssemblyTrademark("")>
 <Assembly: AssemblyCulture("")>
+
+' Setting ComVisible to false makes the types in this assembly not visible
+' to COM components.  If you need to access a type in this assembly from
+' COM, set the ComVisible attribute to true on that type.
 <Assembly: ComVisible(False)>
-<Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
-<Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("1.0.0.0")>
+
+' The following GUID is for the ID of the typelib if this project is exposed to COM
+<
+Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
+
+' Version information for an assembly consists of the following four values:
+' 
+' Major Version
+' Minor Version
+' Build Number
+' Revision
+' 
+' You can specify all the values or you can default the Build and Revision Numbers
+' by using the '*' as shown below:
+' [assembly: AssemblyVersion("1.0.*")]
+<
+Assembly: AssemblyVersion("1.0.0.0")>
+<
+Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/Properties/AssemblyInfo.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/Properties/AssemblyInfo.vb
@@ -6,8 +6,7 @@ Imports System.Runtime.InteropServices
 ' set of attributes. Change these attribute values to modify the information
 ' associated with an assembly.
 <Assembly: AssemblyTitle("ConsoleApp2")>
-<
-Assembly: AssemblyDescription("")>
+<Assembly: AssemblyDescription("")>
 <Assembly: AssemblyConfiguration("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("ConsoleApp2")>
@@ -21,8 +20,7 @@ Assembly: AssemblyDescription("")>
 <Assembly: ComVisible(False)>
 
 ' The following GUID is for the ID of the typelib if this project is exposed to COM
-<
-Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
+<Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
 
 ' Version information for an assembly consists of the following four values:
 ' 
@@ -34,7 +32,5 @@ Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
 ' You can specify all the values or you can default the Build and Revision Numbers
 ' by using the '*' as shown below:
 ' [assembly: AssemblyVersion("1.0.*")]
-<
-Assembly: AssemblyVersion("1.0.0.0")>
-<
-Assembly: AssemblyFileVersion("1.0.0.0")>
+<Assembly: AssemblyVersion("1.0.0.0")>
+<Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/ユニコードのプログラム.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/ユニコードのプログラム.vb
@@ -5,6 +5,7 @@ Namespace ConsoleApp2
     Public Class ユニコードのプログラム
         Public Shared Sub Main()
             For Each process In Process.GetProcesses.Where(Function(p) String.IsNullOrEmpty(p.MainWindowTitle)).Take(1)
+                ' Here's a comment
                 Console.WriteLine(-1)
             Next
         End Sub

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/Properties/AssemblyInfo.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/Properties/AssemblyInfo.vb
@@ -1,15 +1,40 @@
 Imports System.Reflection
 Imports System.Runtime.InteropServices
 
+
+' General Information about an assembly is controlled through the following
+' set of attributes. Change these attribute values to modify the information
+' associated with an assembly.
 <Assembly: AssemblyTitle("ConsoleApp2")>
-<Assembly: AssemblyDescription("")>
+<
+Assembly: AssemblyDescription("")>
 <Assembly: AssemblyConfiguration("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("ConsoleApp2")>
 <Assembly: AssemblyCopyright("Copyright ©  2018")>
 <Assembly: AssemblyTrademark("")>
 <Assembly: AssemblyCulture("")>
+
+' Setting ComVisible to false makes the types in this assembly not visible
+' to COM components.  If you need to access a type in this assembly from
+' COM, set the ComVisible attribute to true on that type.
 <Assembly: ComVisible(False)>
-<Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
-<Assembly: AssemblyVersion("1.0.0.0")>
-<Assembly: AssemblyFileVersion("1.0.0.0")>
+
+' The following GUID is for the ID of the typelib if this project is exposed to COM
+<
+Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
+
+' Version information for an assembly consists of the following four values:
+' 
+' Major Version
+' Minor Version
+' Build Number
+' Revision
+' 
+' You can specify all the values or you can default the Build and Revision Numbers
+' by using the '*' as shown below:
+' [assembly: AssemblyVersion("1.0.*")]
+<
+Assembly: AssemblyVersion("1.0.0.0")>
+<
+Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/Properties/AssemblyInfo.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/Properties/AssemblyInfo.vb
@@ -6,8 +6,7 @@ Imports System.Runtime.InteropServices
 ' set of attributes. Change these attribute values to modify the information
 ' associated with an assembly.
 <Assembly: AssemblyTitle("ConsoleApp2")>
-<
-Assembly: AssemblyDescription("")>
+<Assembly: AssemblyDescription("")>
 <Assembly: AssemblyConfiguration("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("ConsoleApp2")>
@@ -21,8 +20,7 @@ Assembly: AssemblyDescription("")>
 <Assembly: ComVisible(False)>
 
 ' The following GUID is for the ID of the typelib if this project is exposed to COM
-<
-Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
+<Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
 
 ' Version information for an assembly consists of the following four values:
 ' 
@@ -34,7 +32,5 @@ Assembly: Guid("b7602e54-8f45-4dc4-88b5-e11cdc7e8b41")>
 ' You can specify all the values or you can default the Build and Revision Numbers
 ' by using the '*' as shown below:
 ' [assembly: AssemblyVersion("1.0.*")]
-<
-Assembly: AssemblyVersion("1.0.0.0")>
-<
-Assembly: AssemblyFileVersion("1.0.0.0")>
+<Assembly: AssemblyVersion("1.0.0.0")>
+<Assembly: AssemblyFileVersion("1.0.0.0")>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/ユニコードのプログラム.vb
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/ユニコードのプログラム.vb
@@ -5,6 +5,7 @@ Namespace ConsoleApp2
     Public Class ユニコードのプログラム
         Public Shared Sub Main()
             For Each process In Process.GetProcesses.Where(Function(p) String.IsNullOrEmpty(p.MainWindowTitle)).Take(1)
+                ' Here's a comment
                 Console.WriteLine(-1)
             Next
         End Sub

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/Settings.Designer.cs
@@ -20,7 +20,7 @@ namespace VbLibrary.My
     {
         private static MySettings defaultInstance = (MySettings)Synchronized(new MySettings());
 
-        /* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia */
+        /* TODO ERROR: Skipped RegionDirectiveTrivia *//* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia *//* TODO ERROR: Skipped EndRegionDirectiveTrivia */
         public static MySettings Default
         {
             get

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/Settings.Designer.cs
@@ -20,7 +20,7 @@ namespace VbLibrary.My
     {
         private static MySettings defaultInstance = (MySettings)Synchronized(new MySettings());
 
-        /* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia */
+        /* TODO ERROR: Skipped RegionDirectiveTrivia *//* TODO ERROR: Skipped IfDirectiveTrivia *//* TODO ERROR: Skipped DisabledTextTrivia *//* TODO ERROR: Skipped EndIfDirectiveTrivia *//* TODO ERROR: Skipped EndRegionDirectiveTrivia */
         public static MySettings Default
         {
             get

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -164,7 +164,7 @@ End Sub";
             var lines = Utils.HomogenizeEol(code).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             var lineNumbersAdded = new List<string>();
             var newLines = lines.Select((line, i) => {
-                var lineNumber = (i + 1).ToString();
+                var lineNumber = i.ToString();
                 var potentialExistingComments = line.Split(new[] { singleLineCommentStart }, StringSplitOptions.None).Skip(1);
                 if (potentialExistingComments.Count() == 1 || !lineCanHaveComment(line)) return line;
                 lineNumbersAdded.Add(lineNumber);

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -158,7 +158,7 @@ End Sub";
         }
 
 
-
+        /// <remarks>Currently puts comments in multi-line comments which then don't get converted</remarks>
         private static (IReadOnlyCollection<string> Lines, IReadOnlyCollection<string> LineNumbersAdded) AddLineNumberComments(string code, string singleLineCommentStart, string commentPrefix, Func<string, bool> lineCanHaveComment)
         {
             var lines = Utils.HomogenizeEol(code).Split(new[] { Environment.NewLine }, StringSplitOptions.None);

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -61,7 +61,7 @@ namespace CodeConverter.Tests.TestRunners
         /// </summary>
         private async Task AssertLineCommentsConvertedInSameOrder(string source, TextConversionOptions conversion, string singleLineCommentStart)
         {
-            var (sourceLinesWithComments, lineNumbersAdded) = AddLineNumberComments(source, singleLineCommentStart + AutoTestCommentPrefix);
+            var (sourceLinesWithComments, lineNumbersAdded) = AddLineNumberComments(source, singleLineCommentStart, AutoTestCommentPrefix);
             string sourceWithComments = string.Join(Environment.NewLine, sourceLinesWithComments);
             var convertedCode = await Convert<CSToVBConversion>(sourceWithComments, conversion);
             var convertedCommentLineNumbers = convertedCode.Split(new[] { AutoTestCommentPrefix }, StringSplitOptions.None)
@@ -145,15 +145,16 @@ End Sub";
 
 
 
-        private static (IReadOnlyCollection<string> Lines, IReadOnlyCollection<string> LineNumbersAdded) AddLineNumberComments(string code, string singleLineCommentStart)
+        private static (IReadOnlyCollection<string> Lines, IReadOnlyCollection<string> LineNumbersAdded) AddLineNumberComments(string code, string singleLineCommentStart, string commentPrefix)
         {
             var lines = Utils.HomogenizeEol(code).Split(new[] { Environment.NewLine }, StringSplitOptions.None);
             var lineNumbersAdded = new List<string>();
             var newLines = lines.Select((s, i) => {
+                var lineNumber = (i + 1).ToString();
                 var potentialExistingComments = s.Split(new[] { singleLineCommentStart }, StringSplitOptions.None).Skip(1);
                 if (potentialExistingComments.Count() == 1) return s;
-                lineNumbersAdded.Add(i.ToString());
-                return s + singleLineCommentStart + i.ToString();
+                lineNumbersAdded.Add(lineNumber);
+                return s + singleLineCommentStart + commentPrefix + lineNumber;
             }).ToArray();
             return (newLines, lineNumbersAdded);
         }

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -71,7 +71,16 @@ namespace CodeConverter.Tests.TestRunners
             var convertedCode = await Convert<CSToVBConversion>(sourceWithComments, conversion);
             var convertedCommentLineNumbers = convertedCode.Split(new[] { AutoTestCommentPrefix }, StringSplitOptions.None)
                 .Skip(1).Select(afterPrefix => afterPrefix.Split('\n')[0].TrimEnd()).ToList();
-            Assert.Equal(lineNumbersAdded, convertedCommentLineNumbers);
+            var missingSourceLineNumbers = lineNumbersAdded.Except(convertedCommentLineNumbers);
+            if (missingSourceLineNumbers.Any()) {
+                Assert.False(true, "Comments not converted from source lines: " + string.Join(", ", missingSourceLineNumbers) + GetSourceAndConverted(sourceWithComments, convertedCode));
+            }
+            Assert.Equal(string.Join(", ", lineNumbersAdded), string.Join(", ", convertedCommentLineNumbers));
+        }
+
+        private static string GetSourceAndConverted(string sourceLinesWithComments, string convertedCode)
+        {
+            return "\r\n\r\nSource:\r\n" + sourceLinesWithComments + "\r\n-------------------\r\nConverted:\r\n" + convertedCode;
         }
 
         private static string AddSurroundingMethodBlock(string expectedVisualBasicCode, bool expectSurroundingBlock)

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -75,7 +75,7 @@ namespace CodeConverter.Tests.TestRunners
             if (missingSourceLineNumbers.Any()) {
                 Assert.False(true, "Comments not converted from source lines: " + string.Join(", ", missingSourceLineNumbers) + GetSourceAndConverted(sourceWithComments, convertedCode));
             }
-            Assert.Equal(string.Join(", ", lineNumbersAdded), string.Join(", ", convertedCommentLineNumbers));
+            OurAssert.Equal(string.Join(", ", lineNumbersAdded), string.Join(", ", convertedCommentLineNumbers), () => GetSourceAndConverted(sourceWithComments, convertedCode));
         }
 
         private static string GetSourceAndConverted(string sourceLinesWithComments, string convertedCode)
@@ -145,7 +145,7 @@ End Sub";
 
         private static void AssertCodeEqual(string originalSource, string expectedConversion, string actualConversion)
         {
-            OurAssert.StringsEqualIgnoringNewlines(expectedConversion, actualConversion, () =>
+            OurAssert.EqualIgnoringNewlines(expectedConversion, actualConversion, () =>
             {
                 StringBuilder sb = OurAssert.DescribeStringDiff(expectedConversion, actualConversion);
                 sb.AppendLine();

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -80,7 +80,7 @@ namespace CodeConverter.Tests.TestRunners
 
         private static string GetSourceAndConverted(string sourceLinesWithComments, string convertedCode)
         {
-            return "\r\n\r\nSource:\r\n" + sourceLinesWithComments + "\r\n-------------------\r\nConverted:\r\n" + convertedCode;
+            return "\r\n-------------------\r\nConverted:\r\n" + convertedCode + "\r\n\r\nSource:\r\n" + sourceLinesWithComments;
         }
 
         private static string AddSurroundingMethodBlock(string expectedVisualBasicCode, bool expectSurroundingBlock)

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -127,7 +127,6 @@ End Sub";
             bool started = false;
 
             var newLines = lines.Select((s, i) => {
-
                 var prevLine = i > 0 ? lines[i - 1] : "";
                 var nextLine = i < lines.Length - 1 ? lines[i + 1] : "";
 

--- a/Tests/TestRunners/MultiFileTestFixture.cs
+++ b/Tests/TestRunners/MultiFileTestFixture.cs
@@ -201,7 +201,7 @@ namespace CodeConverter.Tests.TestRunners
             var conversionResult = conversionResults[convertedFilePath];
             var actualText = conversionResult.ConvertedCode ?? "" + conversionResult.GetExceptionsAsString() ?? "";
 
-            OurAssert.StringsEqualIgnoringNewlines(expectedText, actualText);
+            OurAssert.EqualIgnoringNewlines(expectedText, actualText);
             Assert.Equal(GetEncoding(expectedFile.FullName), GetEncoding(conversionResult));
         }
 

--- a/Tests/TestRunners/OurAssert.cs
+++ b/Tests/TestRunners/OurAssert.cs
@@ -12,9 +12,9 @@ namespace CodeConverter.Tests.TestRunners
             StringBuilder sb = new StringBuilder(l * 4);
             sb.AppendLine("expected:");
             sb.AppendLine(expectedConversion);
-            sb.AppendLine("got:");
+            sb.AppendLine("------------------------------------\r\ngot:");
             sb.AppendLine(actualConversion);
-            sb.AppendLine("diff:");
+            sb.AppendLine("------------------------------------\r\ndiff:");
             for (int i = 0; i < l; i++)
             {
                 if (i >= expectedConversion.Length || i >= actualConversion.Length ||
@@ -24,7 +24,7 @@ namespace CodeConverter.Tests.TestRunners
                     sb.Append(expectedConversion[i]);
             }
 
-            return sb;
+            return sb.AppendLine("------------------------------------");
         }
 
         public static void StringsEqualIgnoringNewlines(string expectedText, string actualText)

--- a/Tests/TestRunners/OurAssert.cs
+++ b/Tests/TestRunners/OurAssert.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace CodeConverter.Tests.TestRunners
 {
-    public class OurAssert
+    public static class OurAssert
     {
         public static StringBuilder DescribeStringDiff(string expectedConversion, string actualConversion)
         {
@@ -27,17 +27,30 @@ namespace CodeConverter.Tests.TestRunners
             return sb.AppendLine("------------------------------------");
         }
 
-        public static void StringsEqualIgnoringNewlines(string expectedText, string actualText)
+        public static void EqualIgnoringNewlines(string expectedText, string actualText)
         {
-            StringsEqualIgnoringNewlines(expectedText, actualText, () => DescribeStringDiff(expectedText, actualText).ToString());
+            EqualIgnoringNewlines(expectedText, actualText, () => DescribeStringDiff(expectedText, actualText).ToString());
         }
 
-        public static void StringsEqualIgnoringNewlines(string expectedText, string actualText, Func<string> getMessage)
+        public static void EqualIgnoringNewlines(string expectedText, string actualText, Func<string> getMessage)
         {
             expectedText = Utils.HomogenizeEol(expectedText);
             actualText = Utils.HomogenizeEol(actualText);
-            if (expectedText.Equals(actualText)) return;
-            Assert.True(false, getMessage());
+            Equal(expectedText, actualText, getMessage);
+        }
+
+        public static void Equal(object expectedText, object actualText, Func<string> getMessage)
+        {
+            WithMessage(() => Assert.Equal(expectedText, actualText), getMessage);
+        }
+
+        public static void WithMessage(Action assertion, Func<string> getMessage)
+        {
+            try {
+                assertion();
+            } catch (Exception e) {
+                throw new Exception(e.Message + "\r\n" + getMessage(), e);
+            }
         }
     }
 }

--- a/Tests/TestRunners/OurAssert.cs
+++ b/Tests/TestRunners/OurAssert.cs
@@ -29,10 +29,7 @@ namespace CodeConverter.Tests.TestRunners
 
         public static void StringsEqualIgnoringNewlines(string expectedText, string actualText)
         {
-            expectedText = Utils.HomogenizeEol(expectedText);
-            actualText = Utils.HomogenizeEol(actualText);
-            if (expectedText.Equals(actualText)) return;
-            Assert.True(false, DescribeStringDiff(expectedText, actualText).ToString());
+            StringsEqualIgnoringNewlines(expectedText, actualText, () => DescribeStringDiff(expectedText, actualText).ToString());
         }
 
         public static void StringsEqualIgnoringNewlines(string expectedText, string actualText, Func<string> getMessage)

--- a/Tests/TestRunners/OurAssert.cs
+++ b/Tests/TestRunners/OurAssert.cs
@@ -9,11 +9,7 @@ namespace CodeConverter.Tests.TestRunners
         public static StringBuilder DescribeStringDiff(string expectedConversion, string actualConversion)
         {
             int l = Math.Max(expectedConversion.Length, actualConversion.Length);
-            StringBuilder sb = new StringBuilder(l * 4);
-            sb.AppendLine("expected:");
-            sb.AppendLine(expectedConversion);
-            sb.AppendLine("------------------------------------\r\ngot:");
-            sb.AppendLine(actualConversion);
+            StringBuilder sb = new StringBuilder(l);
             sb.AppendLine("------------------------------------\r\ndiff:");
             for (int i = 0; i < l; i++)
             {
@@ -29,7 +25,8 @@ namespace CodeConverter.Tests.TestRunners
 
         public static void EqualIgnoringNewlines(string expectedText, string actualText)
         {
-            EqualIgnoringNewlines(expectedText, actualText, () => DescribeStringDiff(expectedText, actualText).ToString());
+            const string splitter = "\r\n------------------------------------\r\n";
+            EqualIgnoringNewlines(expectedText + splitter, actualText + splitter, () => DescribeStringDiff(expectedText, actualText).ToString());
         }
 
         public static void EqualIgnoringNewlines(string expectedText, string actualText, Func<string> getMessage)

--- a/Tests/TestRunners/SelfVerifyingTestFactory.cs
+++ b/Tests/TestRunners/SelfVerifyingTestFactory.cs
@@ -26,7 +26,7 @@ namespace CodeConverter.Tests.TestRunners
         public static IEnumerable<NamedFact> GetSelfVerifyingFacts<TSourceCompiler, TTargetCompiler, TLanguageConversion>(string testFilepath)
             where TSourceCompiler : ICompiler, new() where TTargetCompiler : ICompiler, new() where TLanguageConversion : ILanguageConversion, new()
         {
-            var sourceFileText = File.ReadAllText(testFilepath);
+            var sourceFileText = File.ReadAllText(testFilepath, Encoding.UTF8);
             var sourceCompiler = new TSourceCompiler();
             var syntaxTree = sourceCompiler.CreateTree(sourceFileText).WithFilePath(Path.GetFullPath(testFilepath));
             var compiledSource = sourceCompiler.AssemblyFromCode(syntaxTree, AdditionalReferences);

--- a/Tests/UnicodeNewline.cs
+++ b/Tests/UnicodeNewline.cs
@@ -148,7 +148,6 @@ namespace CodeConverter.Tests
                 } else {
                     length = 1;
                     type = UnicodeNewline.CR;
-
                 }
                 return true;
             }
@@ -201,7 +200,6 @@ namespace CodeConverter.Tests
                 } else {
                     length = 1;
                     type = UnicodeNewline.CR;
-
                 }
                 return true;
             }

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -28,7 +28,7 @@ End Class");
         public async Task StringInterpolationWithDoubleQuotes()
         {
             await TestConversionCSharpToVisualBasic(
-                @"using System;
+                @"using System; //Not required in VB due to global imports
 
 namespace global::InnerNamespace
 {

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -232,7 +232,7 @@ End Class");
         return """";
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private prop As String
     Private prop2 As String
 
@@ -323,7 +323,7 @@ End Class");
         x /= 3;
     }
 }",
-@"Public Class TestClass
+                @"Public Class TestClass
     Private Sub TestMethod()
         Dim x = 10
         x *= 3
@@ -657,7 +657,7 @@ End Class");
     foreach (var n in res)
         Console.WriteLine(n);
 }",
-@"Private Shared Sub SimpleQuery()
+                @"Private Shared Sub SimpleQuery()
     Dim numbers = {7, 9, 5, 3, 6}
     Dim res = From n In numbers Where n > 5 Select n
 
@@ -691,7 +691,7 @@ End Sub");
             }
         }
     }",
-@"Public Shared Sub Linq40()
+                @"Public Shared Sub Linq40()
     Dim numbers = {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
     Dim numberGroups = From n In numbers Group n By __groupByKey1__ = n Mod 5 Into g = Group Select New With {
         .Remainder = __groupByKey1__,
@@ -741,7 +741,7 @@ class Test {
         }
     }
 }",
-@"Friend Class Product
+                @"Friend Class Product
     Public Category As String
     Public ProductName As String
 End Class
@@ -821,7 +821,7 @@ End Sub");
         };
     }
 }",
-@"Public Class TestClass
+                @"Public Class TestClass
     Inherits ObjectModel.ObservableCollection(Of String)
 
     Public Sub New()
@@ -850,7 +850,7 @@ public class TestClass {
         string str = create(this);
     }
 }",
-@"Imports System
+                @"Imports System
 
 Public Class TestClass
     Private create As Func(Of Object, String) = Function(o)

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -24,7 +24,6 @@ World!""
 End Class");
         }
 
-
         [Fact]
         public async Task StringInterpolationWithDoubleQuotes()
         {
@@ -811,7 +810,6 @@ End Sub");
         }
         [Fact]
         public async Task MultilineSubExpressionWithSingleStatement() {
-            
             await TestConversionCSharpToVisualBasic(
 @"public class TestClass : System.Collections.ObjectModel.ObservableCollection<string> {
     public TestClass() {

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -94,7 +94,7 @@ End Class");
 }", @"Public Class Test
     Public ReadOnly Property Foo As Boolean
         Get
-            Return Bar Is Nothing
+            Return Bar Is Nothing ' Crashes conversion to VB
         End Get
     End Property
 

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -115,9 +115,9 @@ End Class");
 
 Friend Class TestClass
     Public Sub TestMethod(Of T As {Class, New}, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3)
-        argument = Nothing
-        argument2 = Nothing
-        argument3 = Nothing
+        argument = Nothing ' 1
+        argument2 = Nothing ' 2
+        argument3 = Nothing ' 3
     End Sub
 End Class");
         }
@@ -875,8 +875,7 @@ End Class");
         {
             await TestConversionCSharpToVisualBasic(
                 @"[DllImport(""kernel32.dll"", SetLastError = true)]
-static extern IntPtr OpenProcess(AccessMask dwDesiredAccess, bool bInheritHandle, uint dwProcessId);", @"
-<DllImport(""kernel32.dll"", SetLastError:=True)>
+static extern IntPtr OpenProcess(AccessMask dwDesiredAccess, bool bInheritHandle, uint dwProcessId);", @"<DllImport(""kernel32.dll"", SetLastError:=True)>
 Private Shared Function OpenProcess(ByVal dwDesiredAccess As AccessMask, ByVal bInheritHandle As Boolean, ByVal dwProcessId As UInteger) As IntPtr
 End Function");
         }

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -1009,8 +1009,7 @@ End Class");
         [Fact]
         public async Task SubscribeEventInPropertySetter() {
             await TestConversionCSharpToVisualBasic(
-@"using System;
-using System.ComponentModel;
+@"using System.ComponentModel;
 
 class TestClass {
     OwnerClass owner;

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -39,7 +39,7 @@ End Class");
     public static string Text { get; private set; };
     public int Count { get; private set; };
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private Shared _Text As String
     Private _Count As Integer
 
@@ -69,7 +69,7 @@ End Class");
 @"static class TestClass {
     public static string Text { get; private set; }
 }",
-@"Friend Module TestClass
+                @"Friend Module TestClass
     Private _Text As String
 
     Public Property Text As String
@@ -417,7 +417,7 @@ End Module", conversion: EmptyNamespaceOptionStrictOff);
         public async Task TestExtensionMethodWithExistingImport()
         {
             await TestConversionCSharpToVisualBasic(
-@"using System;
+@"using System; //Gets simplified away
 using System.Runtime.CompilerServices;
 
 static class TestClass
@@ -489,7 +489,7 @@ public class ShouldNotChange {
     }
 }
 ",
-@"Public Class HasConflictingPropertyAndField
+                @"Public Class HasConflictingPropertyAndField
     Private f_Test As Integer
 
     Public Property Test As Integer
@@ -587,7 +587,7 @@ End Class");
         set { test = value}
     }
 }",
-@"Public Class HasConflictingPropertyAndField
+                @"Public Class HasConflictingPropertyAndField
     Public Function HasConflictingParam(ByVal test As Integer) As Integer
         f_Test = test
         Return test
@@ -620,7 +620,7 @@ End Class");
         return test;
     }
 }",
-@"Public Class HasConflictingPropertyAndField
+                @"Public Class HasConflictingPropertyAndField
     Private f_Test As Integer
 
     Public Property Test As Integer
@@ -661,7 +661,7 @@ public partial class HasConflictingPropertyAndField {
         set { test = value}
     }
 }",
-@"Public Partial Class HasConflictingPropertyAndField
+                @"Public Partial Class HasConflictingPropertyAndField
     Public Function HasConflictingParam(ByVal test As Integer) As Integer
         Dim l_TEST = 0
         f_Test = test + l_TEST
@@ -912,7 +912,7 @@ class TestClass {
         backingField = null;
     }
 }",
-@"Imports System
+                @"Imports System
 
 Friend Class TestClass
     Private backingField As EventHandler
@@ -947,7 +947,7 @@ class TestClass {
         remove { _backingField -= value; }
     }
 }",
-@"Imports System
+                @"Imports System
 
 Friend Class TestClass
     Private _backingField As EventHandler
@@ -1043,7 +1043,7 @@ End Class");
 @"public interface iDisplay {
     object this[int i] { get; set; }
 }",
-@"Public Interface iDisplay
+                @"Public Interface iDisplay
     Default Property Item(ByVal i As Integer) As Object
 End Interface");
         }
@@ -1060,7 +1060,7 @@ class TestClass : IList {
         set { }
     }
 }",
-@"Imports System.Collections
+                @"Imports System.Collections
 
 Friend Class TestClass
     Implements IList
@@ -1084,7 +1084,7 @@ End Class");
         set { }
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Default Public Property Item(ByVal index As Integer) As Object
         Get
         End Get
@@ -1096,12 +1096,12 @@ End Class");
         [Fact]
         public async Task NameMatchesWithTypeDate() {
             await TestConversionCSharpToVisualBasic(
-@"using System;
+@"using System; //Gets simplified away
 
 class TestClass {
     private DateTime date;
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private [date] As Date
 End Class");
         }
@@ -1113,7 +1113,7 @@ End Class");
         return null;
     }
 }",
-@"Public Class TestClass
+                @"Public Class TestClass
     Public Function TestMethod(ByVal param1 As System.Type, ByVal param2 As System.Globalization.CultureInfo) As Object
         Return Nothing
     End Function
@@ -1152,7 +1152,7 @@ End Class", conversion: EmptyNamespaceOptionStrictOff);
         return Equals((MailEmployee)obj);
     }
 }",
-@"Public Class MailEmployee
+                @"Public Class MailEmployee
     Public Property Email As String
 
     Protected Overloads Function Equals(ByVal other As MailEmployee) As Boolean
@@ -1170,7 +1170,7 @@ End Class");
 @"public interface IParametersProvider {
     IEnumerable<object> Parameters { get; }
 }",
-@"Public Interface IParametersProvider
+                @"Public Interface IParametersProvider
     ReadOnly Property Parameters As IEnumerable(Of Object)
 End Interface");
         }
@@ -1180,7 +1180,7 @@ End Interface");
 @"public interface IParametersProvider {
     IEnumerable<object> Parameters { set; }
 }",
-@"Public Interface IParametersProvider
+                @"Public Interface IParametersProvider
     WriteOnly Property Parameters As IEnumerable(Of Object)
 End Interface");
         }

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -100,16 +100,16 @@ End Class");
         }
 
         [Fact]
-        public async Task TestMethod()
+        public async Task TestMethodWithComments()
         {
             await TestConversionCSharpToVisualBasic(
                 @"class TestClass
 {
     public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class, new where T2 : struct
     {
-        argument = null;
-        argument2 = default(T2);
-        argument3 = default(T3);
+        argument = null; //1
+        argument2 = default(T2); //2
+        argument3 = default(T3); //3
     }
 }", @"Imports System.Runtime.InteropServices
 

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -277,13 +277,12 @@ End Namespace");
         {
             await TestConversionCSharpToVisualBasic(
 @"namespace System {
-    using Collections;
+    using Collections; // Moves outside namespace
     public class TestClass {
         public Hashtable Property { get; set; }
     }
 }",
-@"Imports System.Collections
-
+@"Imports System.Collections ' Moves outside namespace
 Namespace System
     Public Class TestClass
         Public Property [Property] As Hashtable

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -99,7 +99,7 @@ namespace Test
     }
 }
 ",
-@"Namespace Test.class
+                @"Namespace Test.class
     Public MustInherit Class TestClass
     End Class
 End Namespace
@@ -253,7 +253,7 @@ class ThisUri
     private MyAlias.SoapAnyUri s;
     private SO so;
 }",
-                        @"Imports MyAlias = System.Runtime.Remoting.Metadata.W3cXsd2001
+                   @"Imports MyAlias = System.Runtime.Remoting.Metadata.W3cXsd2001
 Imports SO = System.Runtime.Remoting.Metadata.SoapOption
 
 Friend Class ThisUri
@@ -266,7 +266,7 @@ End Class");
         public async Task MoveImportsStatement()
         {
             await TestConversionCSharpToVisualBasic("namespace test { using SomeNamespace; }",
-                        @"Imports SomeNamespace
+                @"Imports SomeNamespace
 
 Namespace test
 End Namespace");
@@ -282,7 +282,7 @@ End Namespace");
         public Hashtable Property { get; set; }
     }
 }",
-@"Imports System.Collections ' Moves outside namespace
+                @"Imports System.Collections ' Moves outside namespace
 Namespace System
     Public Class TestClass
         Public Property [Property] As Hashtable
@@ -307,7 +307,7 @@ public interface iDisplay
     string Name { get; set; }
     void DisplayName();
 }",
-@"Public Class ToBeDisplayed
+                @"Public Class ToBeDisplayed
     Implements iDisplay
 
     Public Property Name As String Implements iDisplay.Name
@@ -339,7 +339,7 @@ public interface iDisplay
     string Name { get; set; }
     void DisplayName();
 }",
-@"Public Class ToBeDisplayed
+                @"Public Class ToBeDisplayed
     Implements iDisplay
 
     Private Property Name As String Implements iDisplay.Name
@@ -367,7 +367,7 @@ End Interface");
 public interface iDisplay {
     object this[int i] { get; set; }
 }",
-@"Public Class ToBeDisplayed
+                @"Public Class ToBeDisplayed
     Implements iDisplay
 
     Private Property Item(ByVal i As Integer) As Object Implements iDisplay.Item
@@ -389,7 +389,7 @@ End Interface");
         public async Task ClassImplementsInterface2()
         {
             await TestConversionCSharpToVisualBasic("class test : System.IComparable { }",
-@"Friend Class test
+                @"Friend Class test
     Implements IComparable
 End Class");
         }
@@ -398,7 +398,7 @@ End Class");
         public async Task ClassInheritsClass()
         {
             await TestConversionCSharpToVisualBasic("using System.IO; class test : InvalidDataException { }",
-@"Imports System.IO
+                @"Imports System.IO
 
 Friend Class test
     Inherits InvalidDataException
@@ -409,7 +409,7 @@ End Class");
         public async Task ClassInheritsClass2()
         {
             await TestConversionCSharpToVisualBasic("class test : System.IO.InvalidDataException { }",
-@"Friend Class test
+                @"Friend Class test
     Inherits InvalidDataException
 End Class");
         }
@@ -430,7 +430,7 @@ public static class TestClass<T> where T : Class1, new() {
             return task;
         }
     }",
-@"Imports System.Threading.Tasks
+                @"Imports System.Threading.Tasks
 
 Public MustInherit Class Class1
 End Class
@@ -455,7 +455,7 @@ End Class");
         public static void Initialize() { }
     }
 }",
-@"Public Module Factory
+                @"Public Module Factory
     Friend NotInheritable Class Generator
         Public Shared Sub Initialize()
         End Sub
@@ -473,7 +473,7 @@ End Module");
     internal static void Initialize1() { }
     private static void Initialize2() { }
 }",
-@"Public Module Factory
+                @"Public Module Factory
     Private Const Name = ""a""
     Friend Const Name1 = ""b""
     Public Const Name2 = ""c""
@@ -498,8 +498,8 @@ End Module");
 public class TestClass : ITestInterface<string> {
     public void Method(List<string> list) {
     }
-",
-@"Public Interface ITestInterface(Of T)
+}",
+                @"Public Interface ITestInterface(Of T)
     Sub Method(ByVal list As List(Of T))
 End Interface
 
@@ -516,8 +516,8 @@ End Class");
 @"using System.ComponentModel;
 public class TestClass : INotifyPropertyChanged {
     public event PropertyChangedEventHandler PropertyChanged;
-",
-@"Imports System.ComponentModel
+}",
+                @"Imports System.ComponentModel
 
 Public Class TestClass
     Implements INotifyPropertyChanged

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -38,9 +38,11 @@ public class X
         return s.Empty;
     }
 }",
-                @"Public Class X
-    Private Function GetStr() As String
-        Return String.Empty
+                @"Imports s = System.String
+
+Public Class X
+    Private Function GetStr() As s
+        Return s.Empty
     End Function
 End Class");
         }

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -530,7 +530,7 @@ End Class");
             await TestConversionCSharpToVisualBasic(
 @"public class TestClass : System.ComponentModel.INotifyPropertyChanged {
     public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-",
+}",
 @"Public Class TestClass
     Implements System.ComponentModel.INotifyPropertyChanged
 

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -372,7 +372,7 @@ End Class");
     object aB = 5;
     int Ab = (int) o;
 }",
-@"Private Sub Test()
+                @"Private Sub Test()
     Dim l_AB As Object = 5
     Dim Ab = CInt(o)
 End Sub");
@@ -384,7 +384,7 @@ End Sub");
     object test = 5;
     int tesT = (int) o;
 }",
-@"Private Sub Test()
+                @"Private Sub Test()
     Dim l_Test1 As Object = 5
     Dim l_TesT = CInt(o)
 End Sub");
@@ -399,7 +399,7 @@ End Sub");
         return test;
     }
 }",
-@"Public ReadOnly Property Test As Integer
+                @"Public ReadOnly Property Test As Integer
     Get
         Dim l_Test1 As Object = 5
         Dim l_TesT = CInt(o)
@@ -427,7 +427,7 @@ End Property");
         }
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private f_Test As EventHandler
 
     Public Custom Event Test As EventHandler
@@ -454,7 +454,7 @@ End Class");
     int tesT = (int)test;
     return tesT;
 }",
-@"Private Function Method(ByVal test As Object) As Integer
+                @"Private Function Method(ByVal test As Object) As Integer
     Dim l_TesT As Integer = test
     Return l_TesT
 End Function");
@@ -468,7 +468,7 @@ End Function");
         public int Test { get { return test; } }
     }
 }",
-@"Namespace System
+                @"Namespace System
     Public Class TestClass
         Private f_Test As Integer
 

--- a/Tests/VB/StandaloneStatementTests.cs
+++ b/Tests/VB/StandaloneStatementTests.cs
@@ -58,7 +58,7 @@ obj = Nothing",
         {
             await TestConversionCSharpToVisualBasic(
 @"var x = 3;",
-@"Dim x = 3");
+                @"Dim x = 3");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ obj = Nothing",
         {
             await TestConversionCSharpToVisualBasic(
 @"private int x = 3;",
-@"Private x = 3");
+                @"Private x = 3");
         }
 
         [Fact]
@@ -76,7 +76,7 @@ obj = Nothing",
 @"public class Test
 {
 }",
-@"Public Class Test
+                @"Public Class Test
 End Class");
         }
 
@@ -85,7 +85,7 @@ End Class");
         {
             await TestConversionCSharpToVisualBasic(
 @"protected abstract void abs();",
-@"Protected MustOverride Sub abs()");
+                @"Protected MustOverride Sub abs()");
         }
 
         [Fact]
@@ -95,7 +95,7 @@ End Class");
 @"namespace nam
 {
 }",
-@"Namespace nam
+                @"Namespace nam
 End Namespace");
         }
 
@@ -106,7 +106,7 @@ End Namespace");
 @"this.DataContext = from task in tasks
     where task.Priority == pri
     select task;",
-@"Me.DataContext = From task In tasks Where task.Priority Is pri Select task");
+                @"Me.DataContext = From task In tasks Where task.Priority Is pri Select task");
         }
     }
 }

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -1030,8 +1030,8 @@ End Class");
                 Console.Write(""section 4"");
                 goto default;
             default:
-                Console.Write(""default section"");
-                break;
+                Console.Write(""default section""); // Block moves to end - 1
+                break; // Block moves to end - 2
             case 5:
                 Console.Write(""section 5"");
                 break;
@@ -1053,7 +1053,8 @@ _Select0_Case5:
                 Console.Write(""section 5"")
             Case Else
 _Select0_CaseDefault:
-                Console.Write(""default section"")
+                Console.Write(""default section"") ' Block moves to end - 1
+                ' Block moves to end - 2
         End Select
     End Sub
 End Class");

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -766,7 +766,7 @@ End Class");
         }
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private Sub TestMethod()
         Dim summary = 0
 
@@ -790,7 +790,7 @@ End Class");
     void Draw(double height) {
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private height As Double
 
     Private Sub TestMethod()
@@ -827,7 +827,7 @@ End Class");
         };
     }
 }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private Sub TestMethod(ByVal counts As IEnumerable(Of Integer))
         Dim summary = 0
         Dim action As Action = Sub()

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -682,7 +682,7 @@ End Class");
 {
     void TestMethod()
     {
-        for (int i = 0; unknownCondition; i++) {
+        for (int i = 0; unknownCondition; i++) { // Increment moves to bottom of loop
             b[i] = s[i];
         }
     }
@@ -692,7 +692,7 @@ End Class");
 
         While unknownCondition
             b(i) = s(i)
-            i += 1
+            i += 1 ' Increment moves to bottom of loop
         End While
     End Sub
 End Class");

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -84,22 +84,22 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod(ByVal arg As Integer)
-        While True
+        While True ' Becomes while loop
             If arg = 3 Then Exit While
 
             Select Case arg
-                Case 1
-                Case 2
+                Case 1 ' From switch
+                Case 2 ' From switch
                 Case Else
-                    Continue While
+                    Continue While ' Outer while loop
             End Select
 
-            For i = 0 To arg - 1
-                If arg <> 1 Then Exit For
-                Continue For
+            For i = 0 To arg - 1 ' Becomes For Next loop
+                If arg <> 1 Then Exit For ' From inner for loop
+                Continue For ' Inner for loop
             Next
 
-            Continue While
+            Continue While ' Outer while loop
         End While
     End Sub
 End Class");

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -42,7 +42,12 @@ class CommentTestClass //Don't rename
 } //End of class", @"Imports System.Diagnostics
 Imports System.Runtime.InteropServices
 
-Friend Class CommentTestClass
+' blank line
+
+''' <summary>
+''' class xml doc
+''' </summary>
+Friend Class CommentTestClass ' Don't rename
     ''' <summary>
     ''' method xml doc
     ''' </summary>

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -62,7 +62,7 @@ Namespace ANamespace ' namespace
         Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
 #If true
             argument = Nothing ' 1
-#Region Arg2
+#Region ""Arg2""
             argument2 = Nothing ' 2
 #End Region
             If argument IsNot Nothing Then ' never

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -45,15 +45,22 @@ Imports System.Runtime.InteropServices
     
 Friend Class CommentTestClass
     ''' <summary>
-    ''' /// method xml doc
-    ''' /// </summary>    Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
-        ' TODO ERROR: Skipped #if true
+    ''' method xml doc
+    ''' </summary>
+    Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
+#If true
         argument = Nothing ' 1
+#Region Arg2
         argument2 = Nothing ' 2
+#End Region
         If argument IsNot Nothing Then ' never
             Debug.WriteLine(1) ' Check debug window
-        End If
+        End If ' argument1 != null
         argument3 = Nothing ' 3
+#Else
+' Skipped during conversion:         argument = new object();
+#End If
+        Console.Write()
     End Sub
 End Class");
         }

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -93,11 +93,11 @@ End Namespace' Last line comment");
             await TestConversionCSharpToVisualBasic(
                 @"//leading
 namespace ANamespace //namespace
-{ //BUG: Block start loses comments
+{ // start of block - namespace
 } //end namespace
 // Last line comment", @"' leading
 Namespace ANamespace ' namespace
-    ' BUG: Block start loses comments
+    ' start of block - namespace
 End Namespace ' end namespace
 ' Last line comment");
         }

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -70,6 +70,7 @@ Namespace ANamespace ' namespace
 #Region ""Arg2""
             argument2 = Nothing ' 2
 #End Region
+
             If argument IsNot Nothing Then ' never
                 ' Block start - if
                 ' leading trivia for the next line

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -16,7 +16,7 @@ using System.Diagnostics; //Using statement
 //blank line
 
 namespace ANamespace //namespace
-{ //BUG: Block start loses comments
+{ // Block start - namespace
     /// <summary>
     /// class xml doc
     /// </summary>
@@ -26,15 +26,15 @@ namespace ANamespace //namespace
         /// method xml doc
         /// </summary>
         public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class where T2 : struct //Only for structs
-        { //BUG: Block start loses comments
+        { // Block start - method
     #if true //BUG: IfDirective loses comments
             argument = null; //1
     #region Arg2
             argument2 = default(T2); //2
-    #endregion //BUG: EndRegion loses comments
+    #endregion // EndRegion loses comments
             if (argument != null) //never
-            { //BUG: Block start loses comments
-             //This works because it's leading trivia for the next line
+            { // Block start - if
+             // leading trivia for the next line
                 Debug.WriteLine(1); // Check debug window
                 Debug.WriteLine(2);
             } //argument1 != null
@@ -54,21 +54,25 @@ Imports System.Runtime.InteropServices
 ' blank line
 
 Namespace ANamespace ' namespace
+    ' Block start - namespace
     ''' <summary>
     ''' class xml doc
     ''' </summary>
     Friend Class CommentTestClass ' Don't rename
+        ' Keep this method at the top
         ''' <summary>
         ''' method xml doc
         ''' </summary>
         Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
+            ' Block start - method
 #If true
             argument = Nothing ' 1
 #Region ""Arg2""
             argument2 = Nothing ' 2
 #End Region
             If argument IsNot Nothing Then ' never
-                ' This works because it's leading trivia for the next line
+                ' Block start - if
+                ' leading trivia for the next line
                 Debug.WriteLine(1) ' Check debug window
                 Debug.WriteLine(2)
             End If ' argument1 != null
@@ -92,6 +96,7 @@ namespace ANamespace //namespace
 } //end namespace
 // Last line comment", @"' leading
 Namespace ANamespace ' namespace
+    ' BUG: Block start loses comments
 End Namespace ' end namespace
 ' Last line comment");
         }

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -6,7 +6,6 @@ namespace CodeConverter.Tests.VB
 {
     public class TriviaTests : ConverterTestBase
     {
-
         [Fact]
         public async Task TestMethodWithComments()
         {

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Threading.Tasks;
+using CodeConverter.Tests.TestRunners;
+using Xunit;
+
+namespace CodeConverter.Tests.VB
+{
+    public class TriviaTests : ConverterTestBase
+    {
+
+        [Fact]
+        public async Task TestMethodWithComments()
+        {
+            await TestConversionCSharpToVisualBasic(
+                @"using System.Diagnostics; //using statement
+// blank line
+
+/// <summary>
+/// class xml doc
+/// </summary>
+class CommentTestClass //Don't rename
+{ //Keep this method at the top
+    /// <summary>
+    /// method xml doc
+    /// </summary>
+    public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class where T2 : struct //Only for structs
+    { //Start of method
+#if true
+        argument = null; //1
+#region Arg2
+        argument2 = default(T2); //2
+#endregion
+        if (argument != null) //never
+        {//Just for debug
+
+            Debug.WriteLine(1); // Check debug window
+        } //argument1 != null
+        argument3 = default(T3); //3
+#else
+        argument = new object();
+#endif
+        Console.Write();
+    } //End of method
+} //End of class", @"Imports System.Diagnostics
+Imports System.Runtime.InteropServices
+    
+Friend Class CommentTestClass
+    ''' <summary>
+    ''' /// method xml doc
+    ''' /// </summary>    Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
+        ' TODO ERROR: Skipped #if true
+        argument = Nothing ' 1
+        argument2 = Nothing ' 2
+        If argument IsNot Nothing Then ' never
+            Debug.WriteLine(1) ' Check debug window
+        End If
+        argument3 = Nothing ' 3
+    End Sub
+End Class");
+        }
+    }
+}

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -39,8 +39,7 @@ class CommentTestClass //Don't rename
 #endif
         Console.Write();
     } //End of method
-} //End of class", @"Imports System.Diagnostics
-Imports System.Runtime.InteropServices
+} //End of class", @"Imports System.Runtime.InteropServices
 
 ' blank line
 

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -10,62 +10,73 @@ namespace CodeConverter.Tests.VB
         public async Task TestMethodWithComments()
         {
             await TestConversionCSharpToVisualBasic(
-                @"using System.Diagnostics; //using statement
-// blank line
+                @"using System.Diagnostics; //Using statement
 
-/// <summary>
-/// class xml doc
-/// </summary>
-class CommentTestClass //Don't rename
-{ //Keep this method at the top
+//blank line
+
+namespace ANamespace //namespace
+{ //BUG: Open brackets lose comments
     /// <summary>
-    /// method xml doc
+    /// class xml doc
     /// </summary>
-    public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class where T2 : struct //Only for structs
-    { //Start of method
-#if true
-        argument = null; //1
-#region Arg2
-        argument2 = default(T2); //2
-#endregion
-        if (argument != null) //never
-        {//Just for debug
+    class CommentTestClass //Don't rename
+    { //Keep this method at the top
+        /// <summary>
+        /// method xml doc
+        /// </summary>
+        public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class where T2 : struct //Only for structs
+        { //BUG: Open brackets lose comments
+    #if true //BUG: IfDirective loses comments
+            argument = null; //1
+    #region Arg2
+            argument2 = default(T2); //2
+    #endregion //BUG: EndRegion loses comments
+            if (argument != null) //never
+            {//BUG: Open brackets lose comments
+             //BUG: Open brackets lose comments
+                Debug.WriteLine(1); // Check debug window
+                Debug.WriteLine(2);
+            } //argument1 != null
+            argument3 = default(T3); //3
+    #else //BUG: ElseDirective loses comments
+            argument = new object();
+    #endif //BUG: EndIfDirective loses comments
+            Console.Write(3);
+        } //End of method
+    } //End of class
+}
+//BUG: Last line loses comments", @"Imports System.Diagnostics ' Using statement
+Imports System.Runtime.InteropServices
 
-            Debug.WriteLine(1); // Check debug window
-        } //argument1 != null
-        argument3 = default(T3); //3
-#else
-        argument = new object();
-#endif
-        Console.Write();
-    } //End of method
-} //End of class", @"Imports System.Runtime.InteropServices
 
 ' blank line
 
-''' <summary>
-''' class xml doc
-''' </summary>
-Friend Class CommentTestClass ' Don't rename
+Namespace ANamespace ' namespace
     ''' <summary>
-    ''' method xml doc
+    ''' class xml doc
     ''' </summary>
-    Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
+    Friend Class CommentTestClass ' Don't rename
+        ''' <summary>
+        ''' method xml doc
+        ''' </summary>
+        Public Sub TestMethod(Of T As Class, T2 As Structure, T3)(<Out> ByRef argument As T, ByRef argument2 As T2, ByVal argument3 As T3) ' Only for structs
 #If true
-        argument = Nothing ' 1
+            argument = Nothing ' 1
 #Region Arg2
-        argument2 = Nothing ' 2
+            argument2 = Nothing ' 2
 #End Region
-        If argument IsNot Nothing Then ' never
-            Debug.WriteLine(1) ' Check debug window
-        End If ' argument1 != null
-        argument3 = Nothing ' 3
+            If argument IsNot Nothing Then ' never
+                Debug.WriteLine(1) ' Check debug window
+                Debug.WriteLine(2)
+            End If ' argument1 != null
+            argument3 = Nothing ' 3
 #Else
-' Skipped during conversion:         argument = new object();
+' Skipped during conversion:             argument = new object();
 #End If
-        Console.Write()
-    End Sub
-End Class");
+            Console.Write(3)
+        End Sub ' End of method
+    End Class ' End of class
+End Namespace");
         }
     }
 }

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -10,7 +10,8 @@ namespace CodeConverter.Tests.VB
         public async Task TestMethodWithComments()
         {
             await TestConversionCSharpToVisualBasic(
-                @"using System.Diagnostics; //Using statement
+                @"using System;
+using System.Diagnostics; //Using statement
 
 //blank line
 
@@ -33,7 +34,7 @@ namespace ANamespace //namespace
     #endregion //BUG: EndRegion loses comments
             if (argument != null) //never
             {//BUG: Open brackets lose comments
-             //BUG: Open brackets lose comments
+             //This works because it's leading trivia for the next line
                 Debug.WriteLine(1); // Check debug window
                 Debug.WriteLine(2);
             } //argument1 != null
@@ -45,7 +46,8 @@ namespace ANamespace //namespace
         } //End of method
     } //End of class
 }
-//BUG: Last line loses comments", @"Imports System.Diagnostics ' Using statement
+//BUG: Last line loses comments", @"Imports System
+Imports System.Diagnostics ' Using statement
 Imports System.Runtime.InteropServices
 
 
@@ -66,6 +68,7 @@ Namespace ANamespace ' namespace
             argument2 = Nothing ' 2
 #End Region
             If argument IsNot Nothing Then ' never
+                ' This works because it's leading trivia for the next line
                 Debug.WriteLine(1) ' Check debug window
                 Debug.WriteLine(2)
             End If ' argument1 != null

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -7,7 +7,7 @@ namespace CodeConverter.Tests.VB
     public class TriviaTests : ConverterTestBase
     {
         [Fact]
-        public async Task TestMethodWithComments()
+        public async Task MethodWithComments()
         {
             await TestConversionCSharpToVisualBasic(
                 @"using System;
@@ -16,7 +16,7 @@ using System.Diagnostics; //Using statement
 //blank line
 
 namespace ANamespace //namespace
-{ //BUG: Open brackets lose comments
+{ //BUG: Block start loses comments
     /// <summary>
     /// class xml doc
     /// </summary>
@@ -26,14 +26,14 @@ namespace ANamespace //namespace
         /// method xml doc
         /// </summary>
         public void TestMethod<T, T2, T3>(out T argument, ref T2 argument2, T3 argument3) where T : class where T2 : struct //Only for structs
-        { //BUG: Open brackets lose comments
+        { //BUG: Block start loses comments
     #if true //BUG: IfDirective loses comments
             argument = null; //1
     #region Arg2
             argument2 = default(T2); //2
     #endregion //BUG: EndRegion loses comments
             if (argument != null) //never
-            {//BUG: Open brackets lose comments
+            { //BUG: Block start loses comments
              //This works because it's leading trivia for the next line
                 Debug.WriteLine(1); // Check debug window
                 Debug.WriteLine(2);
@@ -46,7 +46,7 @@ namespace ANamespace //namespace
         } //End of method
     } //End of class
 }
-//BUG: Last line loses comments", @"Imports System
+// Last line comment", @"Imports System
 Imports System.Diagnostics ' Using statement
 Imports System.Runtime.InteropServices
 
@@ -79,7 +79,21 @@ Namespace ANamespace ' namespace
             Console.Write(3)
         End Sub ' End of method
     End Class ' End of class
-End Namespace");
+End Namespace' Last line comment");
+        }
+
+        [Fact]
+        public async Task TrailingAndEndOfFileLineComments()
+        {
+            await TestConversionCSharpToVisualBasic(
+                @"//leading
+namespace ANamespace //namespace
+{ //BUG: Block start loses comments
+} //end namespace
+// Last line comment", @"' leading
+Namespace ANamespace ' namespace
+End Namespace ' end namespace
+' Last line comment");
         }
     }
 }

--- a/Tests/VB/TriviaTests.cs
+++ b/Tests/VB/TriviaTests.cs
@@ -42,7 +42,7 @@ class CommentTestClass //Don't rename
     } //End of method
 } //End of class", @"Imports System.Diagnostics
 Imports System.Runtime.InteropServices
-    
+
 Friend Class CommentTestClass
     ''' <summary>
     ''' method xml doc

--- a/Tests/VB/TypeCastTests.cs
+++ b/Tests/VB/TypeCastTests.cs
@@ -9,8 +9,10 @@ namespace CodeConverter.Tests.VB
         [Fact]
         public async Task CastObjectToInteger()
         {
+            // The leading and trailing newlines check that surrounding trivia is selected as part of this (in the comments auto-testing)
             await TestConversionCSharpToVisualBasic(
-                @"void Test()
+                @"
+void Test()
 {
     object o = 5;
     int i = (int) o;
@@ -30,12 +32,10 @@ End Sub
 {
     object o = ""Test"";
     string s = (string) o;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = ""Test""
     Dim s = CStr(o)
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -46,12 +46,10 @@ End Sub
 {
     object o = new System.Collections.Generic.List<int>();
     System.Collections.Generic.List<int> l = (System.Collections.Generic.List<int>) o;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = New System.Collections.Generic.List(Of Integer)()
     Dim l = CType(o, System.Collections.Generic.List(Of Integer))
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -62,12 +60,10 @@ End Sub
 {
     object o = 5;
     System.Nullable<int> i = o as int?;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = 5
     Dim i As Integer? = o
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -78,12 +74,10 @@ End Sub
 {
     object o = new System.Collections.Generic.List<int>();
     System.Collections.Generic.List<int> l = o as System.Collections.Generic.List<int>;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = New System.Collections.Generic.List(Of Integer)()
     Dim l = TryCast(o, System.Collections.Generic.List(Of Integer))
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -93,11 +87,9 @@ End Sub
                 @"void Test()
 {
     object o = 5L;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = 5L
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -107,11 +99,9 @@ End Sub
                 @"void Test()
 {
     object o = 5.0f;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = 5.0F
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -121,11 +111,9 @@ End Sub
                 @"void Test()
 {
     object o = 5.0m;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim o As Object = 5.0D
-End Sub
-");
+End Sub");
         }
 
         [Fact]
@@ -135,11 +123,9 @@ End Sub
                 @"void Test()
 {
     char CR = (char)0xD;
-}
-", @"Private Sub Test()
+}", @"Private Sub Test()
     Dim CR = ChrW(&HD)
-End Sub
-");
+End Sub");
         }
         [Fact]
         public async Task MethodInvocation() {
@@ -152,7 +138,7 @@ public class Test2 {
         ((Test)o).TestMethod();
     }
 }",
-@"Public Class Test
+                @"Public Class Test
     Public Sub TestMethod()
     End Sub
 End Class
@@ -174,7 +160,7 @@ public class Test2 {
         (o as Test).TestMethod();
     }
 }",
-@"Public Class Test
+                @"Public Class Test
     Public Sub TestMethod()
     End Sub
 End Class


### PR DESCRIPTION
* A rewrite of comment conversion code which could handle VB -> C# and C# -> VB, but not very reliably, so was never activated for C# -> VB in production.
* This PR will focus on implementing a conversion for C# -> VB - fixes #8 
* A later PR will replace the VB -> C# comment conversion with the same mechanism used here

The focus here is not losing any comments - getting all of them into the result in roughly the order, and within a line or so of where they were in the source. To understand why this is a bit vague, take the example of a for loop in C#, which sometimes needs to turn into a while loop in VB:

Some source code:
```csharp
for(double y = 0d; y < height; y += 10d) // 10 is the same amount we used earlier
    Draw(y);

for(double y = 0d; y < height; y += 10d) // don't go past height
    Draw(y);
```

The conversion we might hope for:
```vbnet
While y < height
    Draw(y)
    y += 10R ' 10 is the same amount we used earlier
End While

While y < height ' don't go past height
    Draw(y)
    y += 10R
End While
```

Obviously we can't know whether the comment was regarding the condition or the increment expression. This PR keeps the comment with the closest expression wherever possible. (i.e. the first case will work, the second will look a bit wrong)

### To do
* [x] Handle method body comments
* [x] Source mapping markers for identifiers
* [x] Implement new test helper (add a line comment on every line, assert the output contains all the line comments on their own line and in order)
* [x] Source mapping markers for statements (to get ends of blocks working)
* [x] Source mapping for imports
* [x] Deal with multiple source lines mapping to the same target line
* [x] Tidy up any obvious edge cases, put others out of scope