### PR TITLE
C# -> VB: Global qualification problem

### DIFF
--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -695,7 +695,12 @@ namespace ICSharpCode.CodeConverter.VB
             {
                 case ITypeSymbol ts:
                     var nameSyntax = (NameSyntax)VbSyntaxGenerator.TypeExpression(ts);
-                    return !allowGlobalPrefix && nameSyntax is QualifiedNameSyntax qns && qns.Left is GlobalNameSyntax ? qns.Right : nameSyntax;
+                    if (allowGlobalPrefix)
+                        return nameSyntax;
+                    var globalNameNode = nameSyntax.DescendantNodes().OfType<GlobalNameSyntax>().FirstOrDefault();
+                    if (globalNameNode != null)
+                        nameSyntax = nameSyntax.ReplaceNodes((globalNameNode.Parent as QualifiedNameSyntax).Yield(), (orig, rewrite) => orig.Right);
+                    return nameSyntax;
                 case INamespaceSymbol ns:
                     return SyntaxFactory.ParseName(ns.GetFullMetadataName());
                 default:


### PR DESCRIPTION
GlobalNameSyntax contains in the last leaf of QualifiedNameSyntax's nodes tree.

Simplier reduces erroneous Global syntax in Imports. So, the issue doesn't covered by the GlobalImportsStatement test. Simplifier fails on some code files, while code are compiling and properly running.