### PR TITLE
C# -> VB: shared modifier for backing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### C# -> VB
 
 * Rename local symbols differing only in case [#80](https://github.com/icsharpcode/CodeConverter/issues/80)
+* Remove erroneous event modifier from delegates
+* Add Implements clause for event fields
+* Add Overloads modifier where needed in VB
+* Add ReadOnly/WriteOnly modifier for interface properties that need it
+* Fix bug which led to nested modules
+* Fix accessibility of converted public static classes
 
 ## [7.6.0] - 2020-01-11
 

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -122,8 +122,9 @@ namespace ICSharpCode.CodeConverter.VB
             var shared = variableDeclaratorSyntaxs.Where(x => x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
             var instance = variableDeclaratorSyntaxs.Where(x => !x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
             var privateTokens = SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+            var privateSharedTokens = !isModule ? privateTokens.Add(SyntaxFactory.Token(SyntaxKind.SharedKeyword)) : privateTokens;
             return new[] {
-                CreateLocalDeclarationStatement(!isModule ? privateTokens.Add(SyntaxFactory.Token(SyntaxKind.SharedKeyword)) : privateTokens, shared.ToArray()),
+                CreateLocalDeclarationStatement(privateSharedTokens, shared.ToArray()),
                 CreateLocalDeclarationStatement(privateTokens, instance.ToArray())
             }.Where(x => x != null);
         }

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -98,17 +98,13 @@ namespace ICSharpCode.CodeConverter.VB
         }
 
         public SyntaxList<StatementSyntax> InsertGeneratedClassMemberDeclarations(
-            SyntaxList<StatementSyntax> convertedStatements, CS.CSharpSyntaxNode originaNode)
+            SyntaxList<StatementSyntax> convertedStatements, CS.CSharpSyntaxNode originaNode, bool isModule)
         {
             var descendantNodes = originaNode.DescendantNodes().ToList();
             var propertyBlocks = descendantNodes.OfType<CSS.PropertyDeclarationSyntax>()
                 .Where(e => e.AccessorList != null && e.AccessorList.Accessors.Any(a => a.Body == null && a.ExpressionBody == null && a.Modifiers.ContainsDeclaredVisibility()))
                 .ToList();
-            if (propertyBlocks.Any()) {
-                convertedStatements = convertedStatements.Insert(0, ConvertToDeclarationStatement(propertyBlocks));
-            }
-
-            return convertedStatements;
+            return convertedStatements.InsertRange(0, ConvertToDeclarationStatement(propertyBlocks, isModule));
         }
 
         private IEnumerable<StatementSyntax> ConvertToDeclarationStatement(List<CSS.DeclarationExpressionSyntax> des,
@@ -120,10 +116,16 @@ namespace ICSharpCode.CodeConverter.VB
             return variableDeclaratorSyntaxes.Any() ? new StatementSyntax[]{CreateLocalDeclarationStatement(variableDeclaratorSyntaxes)} : Enumerable.Empty<StatementSyntax>();
         }
 
-        private StatementSyntax ConvertToDeclarationStatement(List<CSS.PropertyDeclarationSyntax> propertyBlocks)
+        private IEnumerable<StatementSyntax> ConvertToDeclarationStatement(List<CSS.PropertyDeclarationSyntax> propertyBlocks, bool isModule)
         {
-            IEnumerable<VariableDeclaratorSyntax> variableDeclaratorSyntaxs = propertyBlocks.Select(ConvertToVariableDeclarator);
-            return CreateLocalDeclarationStatement(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword)), variableDeclaratorSyntaxs.ToArray());
+            var variableDeclaratorSyntaxs = propertyBlocks.GroupBy(x => x.Modifiers.Any(CSSyntaxKind.StaticKeyword)).ToList();
+            var shared = variableDeclaratorSyntaxs.Where(x => x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
+            var other = variableDeclaratorSyntaxs.Where(x => !x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
+            var tokens = SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+            return new[] {
+                CreateLocalDeclarationStatement(!isModule ? tokens.Add(SyntaxFactory.Token(SyntaxKind.SharedKeyword)) : tokens, shared.ToArray()),
+                CreateLocalDeclarationStatement(tokens, other.ToArray())
+            }.Where(x => x != null);
         }
 
         public static StatementSyntax CreateLocalDeclarationStatement(params VariableDeclaratorSyntax[] variableDeclarators)
@@ -135,6 +137,8 @@ namespace ICSharpCode.CodeConverter.VB
 
         public static StatementSyntax CreateLocalDeclarationStatement(SyntaxTokenList syntaxTokenList, params VariableDeclaratorSyntax[] DimVariableDeclarators)
         {
+            if (DimVariableDeclarators.Length == 0)
+                return null;
             var declarators = SyntaxFactory.SeparatedList(DimVariableDeclarators);
             return SyntaxFactory.LocalDeclarationStatement(syntaxTokenList, declarators);
         }

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -120,11 +120,11 @@ namespace ICSharpCode.CodeConverter.VB
         {
             var variableDeclaratorSyntaxs = propertyBlocks.GroupBy(x => x.Modifiers.Any(CSSyntaxKind.StaticKeyword)).ToList();
             var shared = variableDeclaratorSyntaxs.Where(x => x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
-            var other = variableDeclaratorSyntaxs.Where(x => !x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
-            var tokens = SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+            var instance = variableDeclaratorSyntaxs.Where(x => !x.Key).SelectMany(x => x.Select(ConvertToVariableDeclarator));
+            var privateTokens = SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
             return new[] {
-                CreateLocalDeclarationStatement(!isModule ? tokens.Add(SyntaxFactory.Token(SyntaxKind.SharedKeyword)) : tokens, shared.ToArray()),
-                CreateLocalDeclarationStatement(tokens, other.ToArray())
+                CreateLocalDeclarationStatement(!isModule ? privateTokens.Add(SyntaxFactory.Token(SyntaxKind.SharedKeyword)) : privateTokens, shared.ToArray()),
+                CreateLocalDeclarationStatement(privateTokens, instance.ToArray())
             }.Where(x => x != null);
         }
 

--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -239,7 +239,7 @@ namespace ICSharpCode.CodeConverter.VB
         private IEnumerable<StatementSyntax> ConvertMembers(CSS.TypeDeclarationSyntax node)
         {
             var members = node.Members.Select(m => (StatementSyntax)m.Accept(TriviaConvertingVisitor));
-            var newmembers = _commonConversions.InsertGeneratedClassMemberDeclarations(SyntaxFactory.List(members), node);
+            var newmembers = _commonConversions.InsertGeneratedClassMemberDeclarations(SyntaxFactory.List(members), node, CanBeModule(node));
             return newmembers;
         }
 

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -16,9 +16,8 @@ namespace CodeConverter.Tests.VB
         public async Task TestPropertyWithModifier()
         {
             await TestConversionCSharpToVisualBasic(
-                @"class TestClass
-{
-    public string Text { get; private set; };
+@"class TestClass {
+    public string Text { get; private set; }
 }", @"Friend Class TestClass
     Private _Text As String
 
@@ -31,6 +30,57 @@ namespace CodeConverter.Tests.VB
         End Set
     End Property
 End Class");
+        }
+
+        [Fact]
+        public async Task TestProperty_StaticInferred() {
+            await TestConversionCSharpToVisualBasic(
+@"class TestClass {
+    public static string Text { get; private set; };
+    public int Count { get; private set; };
+}",
+@"Friend Class TestClass
+    Private Shared _Text As String
+    Private _Count As Integer
+
+    Public Shared Property Text As String
+        Get
+            Return _Text
+        End Get
+        Private Set(ByVal value As String)
+            _Text = value
+        End Set
+    End Property
+
+    Public Property Count As Integer
+        Get
+            Return _Count
+        End Get
+        Private Set(ByVal value As Integer)
+            _Count = value
+        End Set
+    End Property
+End Class");
+        }
+
+        [Fact]
+        public async Task TestProperty_StaticInferredInModule() {
+            await TestConversionCSharpToVisualBasic(
+@"static class TestClass {
+    public static string Text { get; private set; }
+}",
+@"Friend Module TestClass
+    Private _Text As String
+
+    Public Property Text As String
+        Get
+            Return _Text
+        End Get
+        Private Set(ByVal value As String)
+            _Text = value
+        End Set
+    End Property
+End Module");
         }
 
         [Fact]


### PR DESCRIPTION
correct shared modifier for backing fields, created via conversion of static inferred properties