### PR TITLE
Merge pull request #516 from Alexilia/master

### DIFF
--- a/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/VB/NodesVisitor.cs
@@ -492,12 +492,7 @@ namespace ICSharpCode.CodeConverter.VB
         }
         private ImplementsClauseSyntax CreateImplementsClauseSyntax(IEnumerable<ISymbol> implementors, SyntaxToken id) {
             return SyntaxFactory.ImplementsClause(implementors.Select(x => {
-                    var namedTypeSymbol = x.ContainingSymbol as INamedTypeSymbol;
-                    NameSyntax nameSyntax = null;
-                    if(namedTypeSymbol == null || !namedTypeSymbol.IsGenericType)
-                        nameSyntax = SyntaxFactory.IdentifierName(x.ContainingSymbol.Name);
-                    else
-                        nameSyntax = SyntaxFactory.GenericName(x.ContainingSymbol.Name, SyntaxFactory.TypeArgumentList(namedTypeSymbol.TypeArguments.Select(y => GetTypeSyntax(y)).ToArray()));
+                    NameSyntax nameSyntax = _commonConversions.GetFullyQualifiedNameSyntax(x.ContainingSymbol as INamedTypeSymbol);
                     return SyntaxFactory.QualifiedName(nameSyntax, SyntaxFactory.IdentifierName(id));
                 }).ToArray()
             );

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -73,7 +73,7 @@ End Namespace");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
-        Dim result = If(str Is """", True, False)
+        Dim result As Boolean = If(str Is """", True, False)
     End Sub
 End Class");
         }
@@ -171,7 +171,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
-        Dim result = If(str Is """", CSharpImpl.__Throw(Of Boolean)(New Exception(""empty"")), False)
+        Dim result As Boolean = If(str Is """", CSharpImpl.__Throw(Of Boolean)(New Exception(""empty"")), False)
     End Sub
 
     Private Class CSharpImpl
@@ -194,7 +194,7 @@ End Class");
     {
     }
 }", @"Friend Class TestClass
-    Private n = NameOf(TestMethod)
+    Private n As String = NameOf(TestMethod)
 
     Private Sub TestMethod()
     End Sub
@@ -306,7 +306,7 @@ End Class");
 	}
 }", @"Public Class Test
     Public Shared Sub Main()
-        Dim y = 1
+        Dim y As Integer = 1
         y <<= 1
         y >>= 1
         y = y << 1
@@ -326,7 +326,7 @@ End Class");
 }",
 @"Public Class TestClass
     Private Sub TestMethod()
-        Dim x = 10
+        Dim x As Integer = 10
         x *= 3
         x /= 3
     End Sub
@@ -347,7 +347,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
-        Dim length = If(str?.Length, -1)
+        Dim length As Integer = If(str?.Length, -1)
         Console.WriteLine(length)
         Console.ReadKey()
         Dim redirectUri As String = context.OwinContext.Authentication?.AuthenticationResponseChallenge?.Properties?.RedirectUri
@@ -585,7 +585,7 @@ static class Program
 
 Friend Module Program
     Private Sub Main(ByVal args As String())
-        Dim x = (Sub(__) Environment.Exit(0))
+        Dim x As Action(Of String) = (Sub(__) Environment.Exit(0))
     End Sub
 End Module");
         }
@@ -638,7 +638,7 @@ End Class");
     End Function
 
     Private Async Sub TestMethod()
-        Dim result = Await SomeAsyncMethod
+        Dim result As Integer = Await SomeAsyncMethod
         Console.WriteLine(result)
     End Sub
 End Class");
@@ -659,7 +659,7 @@ End Class");
         Console.WriteLine(n);
 }",
 @"Private Shared Sub SimpleQuery()
-    Dim numbers = {7, 9, 5, 3, 6}
+    Dim numbers As Integer() = {7, 9, 5, 3, 6}
     Dim res = From n In numbers Where n > 5 Select n
 
     For Each n In res
@@ -693,7 +693,7 @@ End Sub");
         }
     }",
 @"Public Shared Sub Linq40()
-    Dim numbers = {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
+    Dim numbers As Integer() = {5, 4, 1, 3, 9, 8, 6, 7, 2, 0}
     Dim numberGroups = From n In numbers Group n By __groupByKey1__ = n Mod 5 Into g = Group Select New With {
         .Remainder = __groupByKey1__,
         .Numbers = g
@@ -749,7 +749,7 @@ End Class
 
 Friend Class Test
     Public Sub Linq102()
-        Dim categories = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
+        Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
         Dim products As Product() = GetProductList()
         Dim q = From c In categories Join p In products On c Equals p.Category Select New With {
             .Category = c, p.ProductName
@@ -793,7 +793,7 @@ End Class");
         }
     }
 }", @"Public Sub Linq103()
-    Dim categories = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
+    Dim categories As String() = New String() {""Beverages"", ""Condiments"", ""Vegetables"", ""Dairy Products"", ""Seafood""}
     Dim products = GetProductList()
     Dim q = From c In categories Group Join p In products On c Equals p.Category Into ps = Group Select New With {
         .Category = c,
@@ -864,7 +864,7 @@ Public Class TestClass
                                                 End Function
 
     Public Sub New()
-        Dim str = create(Me)
+        Dim str As String = create(Me)
     End Sub
 End Class");
         }

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -93,9 +93,19 @@ End Module");
     int value = 10;
     readonly int v = 15;
 }", @"Friend Class TestClass
-    Const answer = 42
-    Private value = 10
-    Private ReadOnly v = 15
+    Const answer As Integer = 42
+    Private value As Integer = 10
+    Private ReadOnly v As Integer = 15
+End Class");
+        }
+        [Fact]
+        public async Task DoNotSimplifyArrayTypeInFieldDeclarations() {
+            await TestConversionCSharpToVisualBasic(
+@"class TestClass {
+    int[] answer = { 1, 2 };
+}",
+@"Friend Class TestClass
+    Private answer As Integer() = {1, 2}
 End Class");
         }
 
@@ -663,7 +673,7 @@ public partial class HasConflictingPropertyAndField {
 }",
 @"Public Partial Class HasConflictingPropertyAndField
     Public Function HasConflictingParam(ByVal test As Integer) As Integer
-        Dim l_TEST = 0
+        Dim l_TEST As Integer = 0
         f_Test = test + l_TEST
         Return test
     End Function
@@ -674,7 +684,7 @@ Public Partial Class HasConflictingPropertyAndField
 
     Public Property Test As Integer
         Get
-            Dim l_TEST = 0
+            Dim l_TEST As Integer = 0
             Return f_Test + l_TEST
         End Get
         Set(ByVal value As Integer)

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -473,9 +473,9 @@ End Module");
     private static void Initialize2() { }
 }",
 @"Public Module Factory
-    Private Const Name = ""a""
-    Friend Const Name1 = ""b""
-    Public Const Name2 = ""c""
+    Private Const Name As String = ""a""
+    Friend Const Name1 As String = ""b""
+    Public Const Name2 As String = ""c""
 
     Public Sub Initialize()
     End Sub

--- a/Tests/VB/NamespaceLevelTests.cs
+++ b/Tests/VB/NamespaceLevelTests.cs
@@ -524,5 +524,17 @@ Public Class TestClass
     Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
 End Class");
         }
+        [Fact]
+        public async Task FullQualificationInImplements() {
+            await TestConversionCSharpToVisualBasic(
+@"public class TestClass : System.ComponentModel.INotifyPropertyChanged {
+    public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+",
+@"Public Class TestClass
+    Implements System.ComponentModel.INotifyPropertyChanged
+
+    Public Event PropertyChanged As System.ComponentModel.PropertyChangedEventHandler Implements System.ComponentModel.INotifyPropertyChanged.PropertyChanged
+End Class", conversion: EmptyNamespaceOptionStrictOff);
+        }
     }
 }

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -47,7 +47,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b As Integer, a = 5
+        Dim b As Integer, a As Integer = 5
         b = Math.Min(Threading.Interlocked.Increment(a), a - 1)
     End Sub
 End Class");
@@ -361,7 +361,7 @@ End Module");
 {
     public int CR = 0x0D * 0b1;
 }", @"Friend Class Test
-    Public CR = &H0D * &B1
+    Public CR As Integer = &H0D * &B1
 End Class");
         }
 
@@ -374,7 +374,7 @@ End Class");
 }",
 @"Private Sub Test()
     Dim l_AB As Object = 5
-    Dim Ab = CInt(o)
+    Dim Ab As Integer = CInt(o)
 End Sub");
         }
         [Fact]
@@ -386,7 +386,7 @@ End Sub");
 }",
 @"Private Sub Test()
     Dim l_Test1 As Object = 5
-    Dim l_TesT = CInt(o)
+    Dim l_TesT As Integer = CInt(o)
 End Sub");
         }
         [Fact]
@@ -402,7 +402,7 @@ End Sub");
 @"Public ReadOnly Property Test As Integer
     Get
         Dim l_Test1 As Object = 5
-        Dim l_TesT = CInt(o)
+        Dim l_TesT As Integer = CInt(o)
         Return l_Test1
     End Get
 End Property");
@@ -433,12 +433,12 @@ End Property");
     Public Custom Event Test As EventHandler
         AddHandler(ByVal value As EventHandler)
             Dim l_TeSt1 As Object = 5
-            Dim l_TesT = CInt(o)
+            Dim l_TesT As Integer = CInt(o)
             f_Test = [Delegate].Combine(f_Test, value)
         End AddHandler
         RemoveHandler(ByVal value As EventHandler)
             Dim l_TeSt1 As Object = 5
-            Dim l_TesT = CInt(o)
+            Dim l_TesT As Integer = CInt(o)
             f_Test = [Delegate].Remove(f_Test, value)
         End RemoveHandler
         RaiseEvent(ByVal sender As Object, ByVal e As EventArgs)

--- a/Tests/VB/StandaloneStatementTests.cs
+++ b/Tests/VB/StandaloneStatementTests.cs
@@ -12,7 +12,7 @@ namespace CodeConverter.Tests.VB
             await TestConversionCSharpToVisualBasic(
 @"int num = 4;
 num = 5;",
-@"Dim num = 4
+@"Dim num As Integer = 4
 num = 5",
 expectSurroundingMethodBlock: true);
         }
@@ -66,7 +66,7 @@ obj = Nothing",
         {
             await TestConversionCSharpToVisualBasic(
 @"private int x = 3;",
-@"Private x = 3");
+@"Private x As Integer = 3");
         }
 
         [Fact]

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -84,7 +84,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = 0
+        Dim b As Integer = 0
     End Sub
 End Class");
         }
@@ -182,7 +182,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = {1, 2, 3}
+        Dim b As Integer() = {1, 2, 3}
     End Sub
 End Class");
         }
@@ -214,7 +214,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer() {1, 2, 3}
+        Dim b As Integer() = New Integer() {1, 2, 3}
     End Sub
 End Class");
         }
@@ -230,7 +230,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer(2) {1, 2, 3}
+        Dim b As Integer() = New Integer(2) {1, 2, 3}
     End Sub
 End Class");
         }
@@ -265,7 +265,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = {
+        Dim b As Integer(,) = {
         {1, 2},
         {3, 4}}
     End Sub
@@ -286,7 +286,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer(,) {
+        Dim b As Integer(,) = New Integer(,) {
         {1, 2},
         {3, 4}}
     End Sub
@@ -307,7 +307,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer(1, 1) {
+        Dim b As Integer(,) = New Integer(1, 1) {
         {1, 2},
         {3, 4}}
     End Sub
@@ -341,7 +341,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = {New Integer() {1, 2}, New Integer() {3, 4}}
+        Dim b As Integer()() = {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
 End Class");
         }
@@ -357,7 +357,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer()() {New Integer() {1, 2}, New Integer() {3, 4}}
+        Dim b As Integer()() = New Integer()() {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
 End Class");
         }
@@ -373,7 +373,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim b = New Integer(1)() {New Integer() {1, 2}, New Integer() {3, 4}}
+        Dim b As Integer()() = New Integer(1)() {New Integer() {1, 2}, New Integer() {3, 4}}
     End Sub
 End Class");
         }
@@ -394,8 +394,8 @@ the_beginning:
 }", @"Friend Class Test
     Private Sub TestMethod()
 the_beginning:
-        Dim value = 1
-        Const myPIe = Math.PI
+        Dim value As Integer = 1
+        Const myPIe As Double = Math.PI
         Dim text = ""This is my text!""
         GoTo the_beginning
     End Sub
@@ -611,7 +611,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod(ByVal values As Integer())
-        For Each val In values
+        For Each val As Integer In values
             If val = 2 Then Continue For
             If val = 3 Then Exit For
         Next
@@ -703,7 +703,7 @@ End Class");
     }
 }", @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim i = 0
+        Dim i As Integer = 0
 
         While unknownCondition
             b(i) = s(i)
@@ -770,7 +770,7 @@ End Class");
     End Sub
 End Class");
         }
-        [Fact(Skip = "month As Integer is reduced by Simplifier, and month threated as Date.Month method")]
+        [Fact]
         public async Task ForWithDateTimeVariables() {
             await TestConversionCSharpToVisualBasic(
 @"class TestClass {
@@ -783,7 +783,7 @@ End Class");
 }",
 @"Friend Class TestClass
     Private Sub TestMethod()
-        Dim summary = 0
+        Dim summary As Integer = 0
 
         For month As Integer = 1 To 12
             summary += month
@@ -844,7 +844,7 @@ End Class");
 }",
 @"Friend Class TestClass
     Private Sub TestMethod(ByVal counts As IEnumerable(Of Integer))
-        Dim summary = 0
+        Dim summary As Integer = 0
         Dim action As Action = Sub()
                                    For Each c In counts
                                        Dim current = c
@@ -927,13 +927,13 @@ End Class");
         }
     }", @"Friend Class GotoTest1
     Private Shared Sub Main()
-        Dim x = 200, y = 4
-        Dim count = 0
-        Dim array = New String(x - 1, y - 1) {}
+        Dim x As Integer = 200, y As Integer = 4
+        Dim count As Integer = 0
+        Dim array As String(,) = New String(x - 1, y - 1) {}
 
-        For i = 0 To x - 1
+        For i As Integer = 0 To x - 1
 
-            For j = 0 To y - 1
+            For j As Integer = 0 To y - 1
                 array(i, j) = (System.Threading.Interlocked.Increment(count)).ToString()
             Next
         Next
@@ -941,9 +941,9 @@ End Class");
         Console.Write(""Enter the number to search for: "")
         Dim myNumber As String = Console.ReadLine()
 
-        For i = 0 To x - 1
+        For i As Integer = 0 To x - 1
 
-            For j = 0 To y - 1
+            For j As Integer = 0 To y - 1
 
                 If array(i, j).Equals(myNumber) Then
                     GoTo Found
@@ -1249,7 +1249,7 @@ End Class");
     Private Iterator Function TestMethod(ByVal number As Integer) As IEnumerable(Of Integer)
         If number < 0 Then Return
 
-        For i = 0 To number - 1
+        For i As Integer = 0 To number - 1
             Yield i
         Next
     End Function

--- a/Tests/VB/TypeCastTests.cs
+++ b/Tests/VB/TypeCastTests.cs
@@ -33,7 +33,7 @@ End Sub
 }
 ", @"Private Sub Test()
     Dim o As Object = ""Test""
-    Dim s = CStr(o)
+    Dim s As String = CStr(o)
 End Sub
 ");
         }
@@ -49,7 +49,7 @@ End Sub
 }
 ", @"Private Sub Test()
     Dim o As Object = New System.Collections.Generic.List(Of Integer)()
-    Dim l = CType(o, System.Collections.Generic.List(Of Integer))
+    Dim l As List(Of Integer) = CType(o, System.Collections.Generic.List(Of Integer))
 End Sub
 ");
         }
@@ -81,7 +81,7 @@ End Sub
 }
 ", @"Private Sub Test()
     Dim o As Object = New System.Collections.Generic.List(Of Integer)()
-    Dim l = TryCast(o, System.Collections.Generic.List(Of Integer))
+    Dim l As List(Of Integer) = TryCast(o, System.Collections.Generic.List(Of Integer))
 End Sub
 ");
         }
@@ -137,7 +137,7 @@ End Sub
     char CR = (char)0xD;
 }
 ", @"Private Sub Test()
-    Dim CR = ChrW(&HD)
+    Dim CR As Char = ChrW(&HD)
 End Sub
 ");
         }


### PR DESCRIPTION
### Problem
  If a field declared with an initializer, Simplifier reduce the declaration, and variable's type is omitted.

private int aVariable = 1;

converted to

Private aVariable = 1

  In the case, aVariable's type became Object, which can be a reason of many compile-time and run-time errors.

### Solution
  I am using SimplificationOptions.PreferImplicitTypeInLocalDeclaration option is set to false. But I had to fix about 50 tests.
  As side effect, the ForWithDateTimeVariables test is passing now