### PR TITLE
Get the events from syntax that have been optimized away

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CommonConversions.cs
@@ -242,7 +242,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public ExpressionSyntax Literal(object o, string textForUser = null) => LiteralConversions.GetLiteralExpression(o, textForUser);
 
-        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id, bool isAttribute = false, SourceTriviaMapKind sourceTriviaMapKind = SourceTriviaMapKind.All)
         {
             string text = id.ValueText;
 
@@ -268,7 +268,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                         text = "_" + text;
                     }
                 }
-                return CsEscapedIdentifier(text).WithSourceMappingFrom(id);
+                var csId = CsEscapedIdentifier(text);
+                return sourceTriviaMapKind != SourceTriviaMapKind.None ? csId : csId.WithSourceMappingFrom(id);
             } else {
                 text = text.WithHalfWidthLatinCharacters();
             }

--- a/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -568,7 +568,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 .Where(m => HandledEvents(m).Any())
                 .Select(m => {
                     var ids = HandledEvents(m)
-                        .Select(p => (SyntaxFactory.Identifier(GetCSharpIdentifierText(p.EventContainer)), CommonConversions.ConvertIdentifier(p.EventMember.Identifier)))
+                        .Select(p => (SyntaxFactory.Identifier(GetCSharpIdentifierText(p.EventContainer)), CommonConversions.ConvertIdentifier(p.EventMember.Identifier, sourceTriviaMapKind: SourceTriviaMapKind.None)))
                         .ToList();
                     var csFormIds = ids.Where(id => id.Item1.Text == "this" || id.Item1.Text == "base").ToList();
                     var csPropIds = ids.Except(csFormIds).ToList();

--- a/ICSharpCode.CodeConverter/VB/CommonConversions.cs
+++ b/ICSharpCode.CodeConverter/VB/CommonConversions.cs
@@ -31,6 +31,7 @@ using SyntaxKind = Microsoft.CodeAnalysis.VisualBasic.SyntaxKind;
 using TypeSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax;
 using VariableDeclaratorSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.VariableDeclaratorSyntax;
 using YieldStatementSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.YieldStatementSyntax;
+using ICSharpCode.CodeConverter.CSharp;
 
 namespace ICSharpCode.CodeConverter.VB
 {
@@ -505,7 +506,7 @@ namespace ICSharpCode.CodeConverter.VB
             return SyntaxFactory.ModifiedIdentifier(ConvertIdentifier(v.Identifier));
         }
 
-        public SyntaxToken ConvertIdentifier(SyntaxToken id)
+        public SyntaxToken ConvertIdentifier(SyntaxToken id, SourceTriviaMapKind sourceTriviaMapKind = SourceTriviaMapKind.All)
         {
             var parent = (CS.CSharpSyntaxNode)id.Parent;
             var idText = AdjustIfEventIdentifier(id.ValueText, parent);
@@ -521,7 +522,7 @@ namespace ICSharpCode.CodeConverter.VB
                     break;
             }
             var identifier = Identifier(idText, keywordRequiresEscaping);
-            return id.SyntaxTree == _semanticModel.SyntaxTree ? identifier.WithSourceMappingFrom(id) : identifier;
+            return id.SyntaxTree == _semanticModel.SyntaxTree && sourceTriviaMapKind != SourceTriviaMapKind.None ? identifier.WithSourceMappingFrom(id) : identifier;
         }
 
         private string AdjustIfEventIdentifier(string valueText, CS.CSharpSyntaxNode parent)

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -1374,6 +1374,94 @@ public partial class Class1
         }
 
         [Fact]
+        public async Task TestInitializeComponentAddsEventHandlers()
+        {
+            await TestConversionVisualBasicToCSharp(@"Imports System.Windows.Forms
+Imports Microsoft.VisualBasic.CompilerServices
+
+<DesignerGenerated>
+Partial Public Class TestHandlesAdded
+
+    Sub InitializeComponent()
+        '
+        'POW_btnV2DBM
+        '
+        Me.POW_btnV2DBM.Location = New System.Drawing.Point(207, 15)
+        Me.POW_btnV2DBM.Name = ""POW_btnV2DBM""
+        Me.POW_btnV2DBM.Size = New System.Drawing.Size(42, 23)
+        Me.POW_btnV2DBM.TabIndex = 3
+        Me.POW_btnV2DBM.Text = "">>""
+        Me.POW_btnV2DBM.UseVisualStyleBackColor = True
+    End Sub
+
+End Class
+
+Partial Public Class TestHandlesAdded
+    Dim WithEvents POW_btnV2DBM As Button
+
+    Public Sub POW_btnV2DBM_Click() Handles POW_btnV2DBM.Click
+
+    End Sub
+End Class", @"using System.Runtime.CompilerServices;
+using Microsoft.VisualBasic.CompilerServices;
+
+[DesignerGenerated]
+public partial class TestHandlesAdded
+{
+    public TestHandlesAdded()
+    {
+        InitializeComponent();
+    }
+
+    public void InitializeComponent()
+    {
+        // 
+        // POW_btnV2DBM
+        // 
+        _POW_btnV2DBM.Location = new System.Drawing.Point(207, 15);
+        _POW_btnV2DBM.Name = ""POW_btnV2DBM"";
+        _POW_btnV2DBM.Size = new System.Drawing.Size(42, 23);
+        _POW_btnV2DBM.TabIndex = 3;
+        _POW_btnV2DBM.Text = "">>"";
+        _POW_btnV2DBM.UseVisualStyleBackColor = true;
+    }
+}
+
+public partial class TestHandlesAdded
+{
+    private Button _POW_btnV2DBM;
+
+    private Button POW_btnV2DBM
+    {
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        get
+        {
+            return _POW_btnV2DBM;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        set
+        {
+            if (_POW_btnV2DBM != null)
+            {
+                _POW_btnV2DBM.Click -= POW_btnV2DBM_Click;
+            }
+
+            _POW_btnV2DBM = value;
+            if (_POW_btnV2DBM != null)
+            {
+                _POW_btnV2DBM.Click += POW_btnV2DBM_Click;
+            }
+        }
+    }
+
+    public void POW_btnV2DBM_Click()
+    {
+    }
+}");
+        }
+
+        [Fact]
         public async Task SynthesizedBackingFieldAccess()
         {
             await TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -972,7 +972,7 @@ Module Module1
 
     Sub PrintTestMessage2() Handles EventClassInstance.TestEvent, EventClassInstance2.TestEvent
     End Sub
-
+    ' Comment bug: This comment moves due to the Handles transformation
     Sub PrintTestMessage3() Handles EventClassInstance.TestEvent
     End Sub
 End Module", @"using System.Runtime.CompilerServices;
@@ -1013,6 +1013,7 @@ internal static partial class Module1
             if (_EventClassInstance != null)
             {
                 _EventClassInstance.TestEvent -= PrintTestMessage2;
+                // Comment bug: This comment moves due to the Handles transformation
                 _EventClassInstance.TestEvent -= PrintTestMessage3;
             }
 
@@ -1376,8 +1377,7 @@ public partial class Class1
         [Fact]
         public async Task TestInitializeComponentAddsEventHandlers()
         {
-            await TestConversionVisualBasicToCSharp(@"Imports System.Windows.Forms
-Imports Microsoft.VisualBasic.CompilerServices
+            await TestConversionVisualBasicToCSharp(@"Imports Microsoft.VisualBasic.CompilerServices
 
 <DesignerGenerated>
 Partial Public Class TestHandlesAdded

--- a/Tests/CSharp/NamespaceLevelTests.cs
+++ b/Tests/CSharp/NamespaceLevelTests.cs
@@ -852,7 +852,7 @@ public partial class Bar<x> where x : Foo, new()
         public async Task MyClassVirtualCallMethod()
         {
             await TestConversionVisualBasicToCSharp(@"Public Class A
-    Overridable Function F1() As Integer ' Becomes delegating method
+    Overridable Function F1() As Integer
         Return 1
     End Function
     MustOverride Function F2() As Integer
@@ -871,7 +871,7 @@ public partial class A
         return 1;
     }
 
-    public virtual int F1() => MyClassF1(); // Becomes delegating method
+    public virtual int F1() => MyClassF1();
     public abstract int F2();
 
     public void TestMethod()


### PR DESCRIPTION
Fixes #528

I have found a problem, which is very likely the cause of #528. The compiler's semantic model doesn't list the event as handled by the method. This may be a bug, or a subtlety in the API.
I've got a workaround for this but it's causing some comment related test failures which needs investigating
