### PR TITLE
Reproduce 16.7 Visual Studio issue

### DIFF
--- a/CodeConverter/CSharp/ReproIssue.cs
+++ b/CodeConverter/CSharp/ReproIssue.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Shared;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Rename;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+    public class ReproIssue
+    {
+        public static async Task<CSharpCompilationOptions> ReproAsync(Project realVbProjectInVsWorkspace)
+        {
+            string namespaceToRename = "TheNamespaceToRename";
+            var originalDocPath = "something.cs";
+
+            var cSharpCompilationOptions = CreateCsProjectInfo(realVbProjectInVsWorkspace, out var projectInfo);
+
+            var convertedCsProject = realVbProjectInVsWorkspace.Solution.RemoveProject(realVbProjectInVsWorkspace.Id).AddProject(projectInfo)
+                .GetProject(realVbProjectInVsWorkspace.Id);
+
+            var docId = DocumentId.CreateNewId(convertedCsProject.Id);
+            var compilationUnitSyntax = SyntaxFactory.ParseCompilationUnit($"namespace {namespaceToRename} {{}}");
+
+            var convertedWithDocs = convertedCsProject.Solution
+                .AddDocument(docId, originalDocPath, compilationUnitSyntax, filePath: originalDocPath)
+                .GetProject(convertedCsProject.Id);
+
+            var compilation = await convertedWithDocs.GetCompilationAsync();
+            var symbol = compilation.GetSymbolsWithName(s => s.StartsWith(namespaceToRename), SymbolFilter.Namespace).First();
+            var renamedSolution = await Renamer.RenameSymbolAsync(convertedWithDocs.Solution, symbol, "RenamedNamespace",
+                convertedWithDocs.Solution.Workspace.Options);
+            return cSharpCompilationOptions;
+        }
+
+        private static CSharpCompilationOptions CreateCsProjectInfo(Project proj, out ProjectInfo projectInfo)
+        {
+            var cSharpCompilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
+            projectInfo = ProjectInfo.Create(proj.Id, proj.Version, proj.Name,
+                proj.AssemblyName,
+                cSharpCompilationOptions.Language, null, proj.OutputFilePath,
+                cSharpCompilationOptions, CSharpCompiler.ParseOptions, System.Array.Empty<DocumentInfo>(),
+                proj.ProjectReferences,
+                proj.MetadataReferences, proj.AnalyzerReferences);
+            return cSharpCompilationOptions;
+        }
+    }
+}

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using ICSharpCode.CodeConverter;
+using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServices;
@@ -213,7 +214,7 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
 
         private async Task<ConversionResult> ConvertDocumentUnhandledAsync<TLanguageConversion>(string documentPath, Span selected, CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
         {
-            await _outputWindow.WriteToOutputWindowAsync($"Converting {documentPath}...", true, true);
+            await _outputWindow.WriteToOutputWindowAsync($"Reproing issue...", true, true);
 
             //TODO Figure out when there are multiple document ids for a single file path
             var documentId = _visualStudioWorkspace.CurrentSolution.GetDocumentIdsWithFilePath(documentPath).SingleOrDefault();
@@ -222,6 +223,7 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
                 return await ConvertTextOnlyAsync<TLanguageConversion>(documentPath, selected, cancellationToken);
             }
             var document = _visualStudioWorkspace.CurrentSolution.GetDocument(documentId);
+            await ReproIssue.ReproAsync(document.Project);
             var selectedTextSpan = new TextSpan(selected.Start, selected.Length);
             return await ProjectConversion.ConvertSingleAsync<TLanguageConversion>(document, new SingleConversionOptions {SelectedTextSpan = selectedTextSpan}, CreateOutputWindowProgress(), cancellationToken);
         }


### PR DESCRIPTION
Not a real PR - just a place to keep the cut down repro for https://github.com/icsharpcode/CodeConverter/issues/586

Repro steps:
* Launch Visual Studio 16.7.0 preview 3.1 or later with this branch's extension installed (either install the CI build, or launch the VSIX project from source)
* Create a new visual basic .net framework console project.
* Right click on a .vb file in the solution explorer
* Click "Convert to C#"

It will reasonably directly invoke the code added on this branch, and throw a very odd exception attempting to rename a namespace.

```csharp
StreamJsonRpc.RemoteInvocationException : Unexpected false
   at async StreamJsonRpc.JsonRpc.InvokeCoreAsync[TResult](<Unknown Parameters>)
   at async Microsoft.CodeAnalysis.Remote.RemoteEndPoint.InvokeAsync[T](<Unknown Parameters>)
   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
---> (Remote Exception) {
  "type": "System.InvalidOperationException",
  "message": "Unexpected false",
  "stack": "   at Roslyn.Utilities.Contract.Fail(String message)
   at Roslyn.Utilities.Contract.ThrowIfFalse(Boolean condition)
   at Microsoft.CodeAnalysis.Remote.SolutionCreator.<UpdateProjectInfoAsync>d__10.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionCreator.<UpdateProjectAsync>d__9.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionCreator.<UpdateProjectsAsync>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionCreator.<UpdateProjectsAsync>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionCreator.<CreateSolutionAsync>d__5.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionService.<CreateSolution_NoLockAsync>d__14.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.SolutionService.<GetSolutionAsync>d__13.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.CodeAnalysisService.<>c__DisplayClass31_0.<<RenameSymbolAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Remote.ServiceBase.<RunServiceAsync>d__14`1.MoveNext()",
  "code": -2146233079,
  "inner": null
}
```

---

Similar cases where I couldn't repro the issue:
* Real VB project in MSBuildWorkspace
* Programmatically adding a project to a AdhocWorkspace
* Programmatically adding a project to VisualStudioWorkspace's solution
