### PR TITLE
VB -> C#: Add brackets for null coalesce operator when needed

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -611,11 +611,16 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public override async Task<CSharpSyntaxNode> VisitBinaryConditionalExpression(VBasic.Syntax.BinaryConditionalExpressionSyntax node)
         {
-            return SyntaxFactory.BinaryExpression(
+            var expr = SyntaxFactory.BinaryExpression(
                 SyntaxKind.CoalesceExpression,
                 await node.FirstExpression.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor),
                 await node.SecondExpression.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor)
             );
+
+            if (node.Parent.IsKind(VBasic.SyntaxKind.Interpolation) || VbSyntaxNodeExtensions.PrecedenceCouldChange(node))
+                return SyntaxFactory.ParenthesizedExpression(expr);
+
+            return expr;
         }
 
         public override async Task<CSharpSyntaxNode> VisitTernaryConditionalExpression(VBasic.Syntax.TernaryConditionalExpressionSyntax node)

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -1658,17 +1658,21 @@ public partial class Compound
         public async Task NullCoalescingOperatorUsesParenthesisWhenNeededAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(@"Public Class VisualBasicClass
-    Public Sub TestMethod(ByVal a As String)
-        Dim x As String = If(a, ""a"")
-        Dim y As String = If(a, ""a"").ToUpper()
+    Public Sub TestMethod(ByVal x As String)
+        Dim a As String = If(x, ""x"")
+        Dim b As String = If(x, ""x"").ToUpper()
+        Dim c As String = $""{If(x, ""x"")}""
+        Dim d As String = $""{If(x, ""x"").ToUpper()}""
     End Sub
 End Class", @"
 public partial class VisualBasicClass
 {
-    public void TestMethod(string a)
+    public void TestMethod(string x)
     {
-        string x = a ?? ""a"";
-        string y = (a ?? ""a"").ToUpper();
+        string a = x ?? ""x"";
+        string b = (x ?? ""x"").ToUpper();
+        string c = $""{x ?? ""x""}"";
+        string d = $""{(x ?? ""x"").ToUpper()}"";
     }
 }");
         }

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -116,7 +116,7 @@ Public Class EnumToString
         Dim si_Txt As Short = CShort(2 ^ Tes.TEST2)
     End Sub
 End Class",
-@"using System;
+                @"using System;
 
 public partial class EnumToString
 {
@@ -145,7 +145,7 @@ public partial class EnumToString
         Foo(0)
     End Sub
 End Class",
-@"using Microsoft.VisualBasic; // Install-Package Microsoft.VisualBasic
+                @"using Microsoft.VisualBasic; // Install-Package Microsoft.VisualBasic
 
 public partial class Class1
 {
@@ -174,7 +174,7 @@ public partial class Class1
         Dim t1 As Integer = EnumVariable
     End Sub
 End Class",
-@"
+                @"
 public partial class MyTest
 {
     public enum TestEnum : int
@@ -205,7 +205,7 @@ End Enum
 Public Class MyTest
     Public MyEnum As FilePermissions = FilePermissions.None + FilePermissions.Create
 End Class",
-@"using System;
+                @"using System;
 
 [Flags()]
 public enum FilePermissions : int
@@ -244,7 +244,7 @@ public partial class MyTest
 
     End Sub
 End Class",
-@"
+                @"
 public partial class Class1
 {
     public enum E
@@ -292,7 +292,7 @@ public partial class Class1
 
     End Sub
 End Module",
-@"using System;
+                @"using System;
 
 internal static partial class Module1
 {
@@ -1650,6 +1650,25 @@ public partial class Compound
     {
         var col = Color.FromArgb((int)(someInt * 255.0f), (int)(someInt * 255.0f), (int)(someInt * 255.0f));
         var arry = new float[(int)(7d / someInt + 1)];
+    }
+}");
+        }
+
+        [Fact]
+        public async Task NullCoalescingOperatorUsesParenthesisWhenNeededAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Public Class VisualBasicClass
+    Public Sub TestMethod(ByVal a As String)
+        Dim x As String = If(a, ""a"")
+        Dim y As String = If(a, ""a"").ToUpper()
+    End Sub
+End Class", @"
+public partial class VisualBasicClass
+{
+    public void TestMethod(string a)
+    {
+        string x = a ?? ""a"";
+        string y = (a ?? ""a"").ToUpper();
     }
 }");
         }


### PR DESCRIPTION
Fixes #626 

### Problem
In some cases the null coalesce operator is missing parenthesis, resulting in incorrect output.

### Solution
* The same mechanism is used as already exists for the ternary operator
* Covered by test `NullCoalescingOperatorUsesParenthesisWhenNeededAsync`

