### PR TITLE
Output path updates for project Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ### VB -> C#
+* XML output path needs output path prepending [#641](https://github.com/icsharpcode/CodeConverter/issues/641)
 
 
 ### C# -> VB
+* XML output path needs output path prepending [#641](https://github.com/icsharpcode/CodeConverter/issues/641)
 
 
 ## [8.2.0] - 2020-10-12

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/CSharpConsoleApp.vbproj
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertCSharpConsoleAppOnly/ConsoleApp2/CSharpConsoleApp.vbproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG,TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>ConsoleApp2.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/CSharpConsoleApp.vbproj
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/ConsoleApp2/CSharpConsoleApp.vbproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG,TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>ConsoleApp2.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/ConsoleApp2/CSharpConsoleApp.csproj
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/ConsoleApp2/CSharpConsoleApp.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\ConsoleApp2.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
@@ -24,7 +24,7 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>VbLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -34,7 +34,7 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>VbLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
@@ -24,7 +24,7 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>VbLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -34,7 +34,7 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>VbLibrary.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WindowsAppVb.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WindowsAppVb.csproj
@@ -23,7 +23,7 @@
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
-    <DocumentationFile>WindowsAppVb.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\WindowsAppVb.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -33,7 +33,7 @@
     <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DocumentationFile>WindowsAppVb.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\WindowsAppVb.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Link to issue(s) this covers
### Problem
This closes #641 
The documentation file path is different between C# projects and VB projects. In C# it includes the output directory path. In VB the output path is separate.

### Solution
* Added tweakOutputPath to CStoVBConversion  and VBtoCSConversion class which is called from PostTransformProjectFile method.
* Updated MultiFileSolutionAndProjectTests to test and verify the Documentation File tag results.

