### PR TITLE
Add vistor for ConversionOperatorDeclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### C# -> VB
 
+* Converting explicit and implicit operator failed [#659](https://github.com/icsharpcode/CodeConverter/issues/659)
 
 ## [8.2.0] - 2020-10-12
 

--- a/CodeConverter/VB/NodesVisitor.cs
+++ b/CodeConverter/VB/NodesVisitor.cs
@@ -757,7 +757,18 @@ namespace ICSharpCode.CodeConverter.VB
 
         public override VisualBasicSyntaxNode VisitConversionOperatorDeclaration(CSS.ConversionOperatorDeclarationSyntax node)
         {
-            return base.VisitConversionOperatorDeclaration(node);
+            ConvertAndSplitAttributes(node.AttributeLists, out var attributes, out var returnAttributes);
+            var body = _commonConversions.ConvertBody(node.Body, node.ExpressionBody, true);
+            var parameterList = (ParameterListSyntax)node.ParameterList?.Accept(TriviaConvertingVisitor);
+            var modifiers = node.GetModifiers();
+            modifiers= modifiers.Add(node.ImplicitOrExplicitKeyword);
+            var stmt = SyntaxFactory.OperatorStatement(
+                attributes, CommonConversions.ConvertModifiers(modifiers, GetMemberContext(node)),
+                SyntaxFactory.Token(SyntaxKind.CTypeKeyword),
+                parameterList,
+                SyntaxFactory.SimpleAsClause(returnAttributes, (TypeSyntax)node.Type.Accept(TriviaConvertingVisitor))
+            );
+            return SyntaxFactory.OperatorBlock(stmt, body);
         }
 
         public override VisualBasicSyntaxNode VisitParameterList(CSS.ParameterListSyntax node)

--- a/CodeConverter/VB/SyntaxKindExtensions.cs
+++ b/CodeConverter/VB/SyntaxKindExtensions.cs
@@ -181,6 +181,10 @@ namespace ICSharpCode.CodeConverter.VB
                     return SyntaxKind.PlusToken;
                 case Microsoft.CodeAnalysis.CSharp.SyntaxKind.MinusMinusToken:
                     return SyntaxKind.MinusToken;
+                case Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExplicitKeyword:
+                    return SyntaxKind.NarrowingKeyword;
+                case Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImplicitKeyword:
+                    return SyntaxKind.WideningKeyword;
             }
 
             throw new NotSupportedException(t + " is not supported!");

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -418,6 +418,33 @@ End Class", conversionOptions: EmptyNamespaceOptionStrictOff);
     End Operator
 End Class");
         }
+ 
+        [Fact]
+        public async Task TestNarrowingWideningConversionOperatorAsync()
+        {
+            await TestConversionCSharpToVisualBasicAsync(@"
+public partial class MyInt
+{
+    public static explicit operator MyInt(int i)
+    {
+        return new MyInt();
+    }
+
+    public static implicit operator int(MyInt myInt)
+    {
+        return 1;
+    }
+}", @"Public Partial Class MyInt
+    Public Shared Narrowing Operator CType(ByVal i As Integer) As MyInt
+        Return New MyInt()
+    End Operator
+
+    Public Shared Widening Operator CType(ByVal myInt As MyInt) As Integer
+        Return 1
+    End Operator
+End Class"
+                );
+        }
 
         [Fact]
         public async Task TestSealedMethodAsync()


### PR DESCRIPTION
Link to issue(s) this covers
Closes #659 

### Problem
Missing visitor for explicit/implicit conversion operators

### Solution
* mapped Explicit to narrowing conversion and implicit to widening conversion in new ConversionOperatorDeclaration visitor.
* test mirrors the VB -> C# conversion/tests
* [X] Added test case for narrowing/widening conversions (implicit/explicit)

