### PR TITLE
CS -> VB: improve generation of Call statement

### DIFF
--- a/CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
@@ -74,7 +74,9 @@ namespace ICSharpCode.CodeConverter.VB
                         (CastExpressionSyntax e) => e.Expression,
                         (MemberAccessExpressionSyntax e) => e.Expression
                     ));
-                if(allDirectExpressions.Last() is ObjectCreationExpressionSyntax)
+                InvocationExpressionSyntax invocationExpression = expression as InvocationExpressionSyntax;
+                var lastExpression = allDirectExpressions.LastOrDefault();
+                if (invocationExpression != null && lastExpression != null && !(lastExpression is IdentifierNameSyntax || lastExpression is InstanceExpressionSyntax))
                     exprNode = SyntaxFactory.CallStatement(expression);
                 else
                     exprNode = SyntaxFactory.ExpressionStatement(expression);

--- a/CodeConverter/VB/NodesVisitor.cs
+++ b/CodeConverter/VB/NodesVisitor.cs
@@ -1111,12 +1111,7 @@ namespace ICSharpCode.CodeConverter.VB
 
             var vbEventExpression = (ExpressionSyntax)node.Expression.Accept(TriviaConvertingVisitor);
             var argumentListSyntax = (ArgumentListSyntax)node.ArgumentList.Accept(TriviaConvertingVisitor);
-            var invocationExpressionSyntax = SyntaxFactory.InvocationExpression(vbEventExpression, argumentListSyntax);
-            var objectCreationExpression = node.Expression.DescendantNodesAndSelf().OfType<CSS.MemberAccessExpressionSyntax>().FirstOrDefault()?.Expression as CSS.ObjectCreationExpressionSyntax;
-            if (node.Parent is CSS.ExpressionStatementSyntax && objectCreationExpression != null) {
-                return SyntaxFactory.CallStatement(invocationExpressionSyntax);
-            }
-            return invocationExpressionSyntax;
+            return SyntaxFactory.InvocationExpression(vbEventExpression, argumentListSyntax);
         }
 
         private bool TryCreateRaiseEventStatement(CSS.ExpressionSyntax invokedCsExpression,

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -1414,7 +1414,7 @@ End Class");
         }
 
         [Fact]
-        public async Task ObjectCreationExpressionInInvocationExpressionAsync() {
+        public async Task Call_ObjectCreationExpressionInInvocationExpressionAsync() {
             await TestConversionCSharpToVisualBasicAsync(
 @"class TestClass {
     int field;
@@ -1443,7 +1443,7 @@ End Class");
 End Class");
         }
         [Fact]
-        public async Task ObjectCreationExpression_FluidCallsAsync() {
+        public async Task Call_ObjectCreationExpression_FluidCallsAsync() {
             await TestConversionCSharpToVisualBasicAsync(
 @"using System.Threading.Tasks;
 
@@ -1465,6 +1465,26 @@ Public Class TestClass
                                                                                                                                                                     End Sub)
     End Sub
 End Class");
+        }
+        [Fact]
+        public async Task Call_Lambda_CSharpDoesntHaveThisFunctionalityAsync() {
+            await TestConversionCSharpToVisualBasicAsync(
+@"using System;
+public class TestClass {
+    public void TestMethod() {
+        (() => Console.WriteLine(""Hello""))(); //compilation error in C#
+    }
+}",
+@"Imports System
+
+Public Class TestClass
+    Public Sub TestMethod()
+        Call (Sub() Console.WriteLine(""Hello""))() 'compilation error in C#
+    End Sub
+End Class
+
+1 source compilation errors:
+CS0149: Method name expected");
         }
     }
 }

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -1466,6 +1466,7 @@ Public Class TestClass
     End Sub
 End Class");
         }
+
         [Fact]
         public async Task Call_Lambda_CSharpDoesntHaveThisFunctionalityAsync() {
             await TestConversionCSharpToVisualBasicAsync(

--- a/Tests/VB/StatementTests.cs
+++ b/Tests/VB/StatementTests.cs
@@ -1442,5 +1442,29 @@ End Class");
     End Sub
 End Class");
         }
+        [Fact]
+        public async Task ObjectCreationExpression_FluidCallsAsync() {
+            await TestConversionCSharpToVisualBasicAsync(
+@"using System.Threading.Tasks;
+
+public class TestClass {
+    static void TestMethod() {
+        (new TaskFactory() as TaskFactory)
+            .StartNew(new System.Action(() => { }))
+            .ContinueWith(t => {}, TaskContinuationOptions.ExecuteSynchronously)
+            .ContinueWith(t => {});
+    }
+}",
+@"Imports System.Threading.Tasks
+
+Public Class TestClass
+    Private Shared Sub TestMethod()
+        Call TryCast(New TaskFactory(), TaskFactory).StartNew(New Action(Sub()
+                                                                         End Sub)).ContinueWith(Sub(t)
+                                                                                                End Sub, TaskContinuationOptions.ExecuteSynchronously).ContinueWith(Sub(t)
+                                                                                                                                                                    End Sub)
+    End Sub
+End Class");
+        }
     }
 }


### PR DESCRIPTION
### Problem
there is no CallStatementSyntax for ObjectCreationExpression when several expressions are used. For example
new TaskFactory() as TaskFactory)
            .StartNew(() => { })
            .ContinueWith(t => {});

### Solution

