### PR TITLE
Resolve Multi-file Solution and Project test failures after install .Net 5.0

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,8 +30,8 @@
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements">
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.4.0" />
-    <PackageReference Include="Microsoft.Build" Version="16.4.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.4.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />


### PR DESCRIPTION
Link to issue(s) this covers
This closes #674. 

### Problem
After installing .NET 5.0 the MultiFileSolutionAndProjectTests were failing. 

### Solution
* Updated package references for Microsoft.Build and Microsoft.Build.Tasks.Core for the test project to 16.8 (from 16.4)
* [X] Allows tests to pass again with .NET 5.0

