### PR TITLE
Add code for format clause escape character.

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -308,7 +308,8 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public override async Task<CSharpSyntaxNode> VisitInterpolationFormatClause(VBasic.Syntax.InterpolationFormatClauseSyntax node)
         {
-            SyntaxToken formatStringToken = SyntaxFactory.Token(SyntaxTriviaList.Empty, SyntaxKind.InterpolatedStringTextToken, node.FormatStringToken.Text, node.FormatStringToken.ValueText, SyntaxTriviaList.Empty);
+            var textForUser = LiteralConversions.EscapeEscapeChar(node.FormatStringToken.ValueText);
+            SyntaxToken formatStringToken = SyntaxFactory.Token(SyntaxTriviaList.Empty, SyntaxKind.InterpolatedStringTextToken, textForUser, node.FormatStringToken.ValueText, SyntaxTriviaList.Empty);
             return SyntaxFactory.InterpolationFormatClause(SyntaxFactory.Token(SyntaxKind.ColonToken), formatStringToken);
         }
 

--- a/CodeConverter/CSharp/LiteralConversions.cs
+++ b/CodeConverter/CSharp/LiteralConversions.cs
@@ -112,6 +112,10 @@ namespace ICSharpCode.CodeConverter.CSharp
             }
         }
 
+        internal static string EscapeEscapeChar(string valueTextForCompiler)
+        {
+                return valueTextForCompiler.Replace("\\", "\\\\");
+        }
         private static string Unquote(string quotedText)
         {
             quotedText = quotedText.Replace('”', '"');

--- a/CodeConverter/VB/NodesVisitor.cs
+++ b/CodeConverter/VB/NodesVisitor.cs
@@ -901,6 +901,11 @@ namespace ICSharpCode.CodeConverter.VB
             if (CS.CSharpExtensions.IsVerbatimStringLiteral(token)) return token.Text;
             return token.ValueText.Replace("\"", "\"\"");
         }
+        private static string ConvertUserFormatText(SyntaxToken token)
+        {
+            if (CS.CSharpExtensions.IsVerbatimStringLiteral(token)) return token.Text;
+            return token.ValueText.Replace("\\\\", "\\");
+        }
 
         public override VisualBasicSyntaxNode VisitInterpolation(CSS.InterpolationSyntax node)
         {
@@ -910,7 +915,7 @@ namespace ICSharpCode.CodeConverter.VB
         public override VisualBasicSyntaxNode VisitInterpolationFormatClause(CSS.InterpolationFormatClauseSyntax node)
         {
             SyntaxToken formatStringToken = SyntaxFactory.InterpolatedStringTextToken(SyntaxTriviaList.Empty,
-                node.FormatStringToken.Text, node.FormatStringToken.ValueText, SyntaxTriviaList.Empty);
+              ConvertUserFormatText(node.FormatStringToken), node.FormatStringToken.ValueText, SyntaxTriviaList.Empty);
             return SyntaxFactory.InterpolationFormatClause(SyntaxFactory.Token(SyntaxKind.ColonToken), formatStringToken);
         }
 

--- a/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
@@ -299,6 +299,34 @@ namespace InnerNamespace
         }
 
         [Fact]
+        public async Task StringInterpolationWithDateFormatAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"Imports System
+
+Namespace Global.InnerNamespace
+    Public Class Test
+           public function InterStringDateFormat(dt As DateTime) As String
+            Dim a As String = $""Soak: {dt: d\.h\:mm\:ss\.f}""
+            return a 
+            End function
+    End Class
+End Namespace",
+                @"using System;
+
+namespace InnerNamespace
+{
+    public partial class Test
+    {
+        public string InterStringDateFormat(DateTime dt)
+        {
+            string a = $""Soak: {dt: d\\.h\\:mm\\:ss\\.f}"";
+            return a;
+        }
+    }
+}");
+        }
+        [Fact]
         public async Task NoConversionRequiredWithinConcatenationAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -63,6 +63,26 @@ End Namespace
 1 source compilation errors:
 CS7000: Unexpected use of an aliased name");
         }
+        [Fact]
+        public async Task StringInterpolationWithDateFormatAsync()
+        {
+            await TestConversionCSharpToVisualBasicAsync(
+                @"using System;
+public class Test
+{
+    public string InterStringDateFormat(DateTime dt)
+    {
+        string a = $""Soak: {dt: d\\.h\\:mm\\:ss\\.f}"";
+        return a;
+    }
+}",  @"Public Class Test
+    Public Function InterStringDateFormat(ByVal dt As Date) As String
+        Dim a As String = $""Soak: {dt: d\.h\:mm\:ss\.f}""
+        Return a
+    End Function
+End Class"
+ ,hasLineCommentConversionIssue:true);
+        }
 
         [Fact]
         public async Task ConditionalExpressionAsync()


### PR DESCRIPTION
Link to issue(s) this covers
This closes issue #684 . 
### Problem
For format text on interpolated strings require an escape for the "\" character in C#, but not in VB. 

### Solution
* Added code to add an extra"\" converted to C# and to remove the unneeded "\" converting to VB.
* The test converting to VB is failing.  Would like pointer on getting it to pass. C# needs `using System;` but VB doesn't but the test says "comments for line 0 not converted." Without `using System;` the conversion is unsuccessful.
* [X] Covering unit tests: VB -> C# and C# -> VB

