### PR TITLE
Updated ConvertToVariableDeclarator to handle generic declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * CInt wrongly converted to (int)[#658](https://github.com/icsharpcode/CodeConverter/pull/658)
 
 ### C# -> VB
-
+* Generics type parameter missed BC30737 and BC32042 [#682] (https://github.com/icsharpcode/CodeConverter/issues/682)
 
 ## [8.2.1] - 2020-10-28
 

--- a/CodeConverter/Util/CSharpUtil.cs
+++ b/CodeConverter/Util/CSharpUtil.cs
@@ -198,16 +198,7 @@ namespace ICSharpCode.CodeConverter.Util
             throw new NotSupportedException();
         }
 
-        public static Microsoft.CodeAnalysis.VisualBasic.Syntax.TypeSyntax ToVbSyntax(this ITypeSymbol type, SemanticModel model, TypeSyntax typeSyntax)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-            return VBasic.SyntaxFactory.ParseTypeName(type.ToMinimalDisplayString(model, typeSyntax.SpanStart))
-                .WithLeadingTrivia(typeSyntax.GetLeadingTrivia().ConvertTrivia())
-                .WithTrailingTrivia(typeSyntax.GetTrailingTrivia().ConvertTrivia());
-        }
-
-        public static IEnumerable<TOut> FollowProperty<TOut>(this TOut start, Func<TOut, TOut> getProperty) where TOut : class
+         public static IEnumerable<TOut> FollowProperty<TOut>(this TOut start, Func<TOut, TOut> getProperty) where TOut : class
         {
             return FollowProperty<TOut, TOut>(start, getProperty);
         }

--- a/CodeConverter/VB/CommonConversions.cs
+++ b/CodeConverter/VB/CommonConversions.cs
@@ -148,9 +148,7 @@ namespace ICSharpCode.CodeConverter.VB
             TypeSyntax typeSyntax;
             if (des.Type.IsVar) {
                 var typeSymbol = ModelExtensions.GetSymbolInfo(_semanticModel, des.Type).ExtractBestMatch<ITypeSymbol>();
-                var csTypeSyntax =
-                   CS.SyntaxFactory.ParseTypeName(typeSymbol.ToMinimalDisplayString(_semanticModel, des.Type.SpanStart));
-                typeSyntax = (TypeSyntax)csTypeSyntax.Accept(_nodesVisitor);
+                typeSyntax =(TypeSyntax) VbSyntaxGenerator.TypeExpression(typeSymbol);
             } else {
                 typeSyntax = (TypeSyntax)des.Type.Accept(_nodesVisitor);
             }
@@ -188,7 +186,7 @@ namespace ICSharpCode.CodeConverter.VB
             TypeSyntax typeSyntax;
             if (des.Type.IsVar) {
                 var typeSymbol = ModelExtensions.GetSymbolInfo(_semanticModel, des.Type).ExtractBestMatch<ITypeSymbol>();
-                typeSyntax = typeSymbol?.ToVbSyntax(_semanticModel, des.Type);
+                typeSyntax = (TypeSyntax)VbSyntaxGenerator.TypeExpression(typeSymbol);
             } else {
                 typeSyntax = (TypeSyntax)des.Type.Accept(_nodesVisitor);
             }

--- a/CodeConverter/VB/CommonConversions.cs
+++ b/CodeConverter/VB/CommonConversions.cs
@@ -142,12 +142,15 @@ namespace ICSharpCode.CodeConverter.VB
 
         private VariableDeclaratorSyntax ConvertToVariableDeclarator(CSS.DeclarationExpressionSyntax des)
         {
+            
             var id = ((IdentifierNameSyntax)des.Accept(_nodesVisitor)).Identifier;
             var ids = SyntaxFactory.SingletonSeparatedList(SyntaxFactory.ModifiedIdentifier(id));
             TypeSyntax typeSyntax;
             if (des.Type.IsVar) {
                 var typeSymbol = ModelExtensions.GetSymbolInfo(_semanticModel, des.Type).ExtractBestMatch<ITypeSymbol>();
-                typeSyntax = typeSymbol?.ToVbSyntax(_semanticModel, des.Type);
+                var csTypeSyntax =
+                   CS.SyntaxFactory.ParseTypeName(typeSymbol.ToMinimalDisplayString(_semanticModel, des.Type.SpanStart));
+                typeSyntax = (TypeSyntax)csTypeSyntax.Accept(_nodesVisitor);
             } else {
                 typeSyntax = (TypeSyntax)des.Type.Accept(_nodesVisitor);
             }

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -127,10 +127,12 @@ End Class");
     Public Bar As String
 End Class");
         }
+
         [Fact]
-        public async Task BadAssignInCaseOfSubAsync() {
+        public async Task BadAssignInCaseOfSubAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class TestClass {
+                @"public class TestClass {
     public void TestMethod(int b) {
         int a;
         DoAction(() => a = b);
@@ -225,12 +227,12 @@ class TestClass
 Friend Class TestClass
     Private Shared Function [Do]() As Boolean
         Dim d = New Dictionary(Of String, String)()
-        Dim output As string = Nothing
+        Dim output As String = Nothing
         Return d.TryGetValue("""", output)
     End Function
-End Class");
+End Class",hasLineCommentConversionIssue:true);
         }
-
+ 
         [Fact]
         public async Task ThrowExpressionAsync()
         {
@@ -260,17 +262,18 @@ End Class
 1 target compilation errors:
 BC30451: 'CSharpImpl.__Throw' is not declared. It may be inaccessible due to its protection level.");
         }
+
         [Fact]
         public async Task DoNotGenerateSeveralThrowExpression_ObsoleteAndExceptionShouldBeFullQualifiedAsync()
         {
             await TestConversionCSharpToVisualBasicAsync(
-@"class TestClass {
+                @"class TestClass {
     void TestMethod(string str) {
         bool result = (str == """") ? throw new System.Exception(""empty"") : false;
     }
 }
 class TestClass2 { }",
-@"Friend Class TestClass
+                @"Friend Class TestClass
     Private Sub TestMethod(ByVal str As String)
         Dim result As Boolean = If(Equals(str, """"), CSharpImpl.__Throw(Of Boolean)(New System.Exception(""empty"")), False)
     End Sub
@@ -287,7 +290,8 @@ Friend Class TestClass2
 End Class
 
 1 target compilation errors:
-BC30451: 'CSharpImpl.__Throw' is not declared. It may be inaccessible due to its protection level.", conversionOptions: EmptyNamespaceOptionStrictOff);
+BC30451: 'CSharpImpl.__Throw' is not declared. It may be inaccessible due to its protection level.",
+                conversionOptions: EmptyNamespaceOptionStrictOff);
         }
 
         [Fact]
@@ -326,11 +330,12 @@ End Class
 1 source compilation errors:
 CS0103: The name 'Console' does not exist in the current context");
         }
+
         [Fact]
         public async Task CoalescingExpression_AssignmentAsync()
         {
             await TestConversionCSharpToVisualBasicAsync(
-@"class TestClass {
+                @"class TestClass {
     string prop;
     string prop2;
     string Property {
@@ -437,10 +442,12 @@ BC30491: Expression does not produce a value.");
     End Sub
 End Class");
         }
+
         [Fact]
-        public async Task CompoundAssignmentTestAsync() {
+        public async Task CompoundAssignmentTestAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class TestClass {
+                @"public class TestClass {
     void TestMethod() {
         int x = 10;
         x *= 3;
@@ -979,10 +986,12 @@ BC30451: 'GetProductList' is not declared. It may be inaccessible due to its pro
 BC36593: Expression of type '?' is not queryable. Make sure you are not missing an assembly reference and/or namespace import for the LINQ provider.
 BC32023: Expression is of type '?', which is not a collection type.");
         }
+
         [Fact]
-        public async Task MultilineSubExpressionWithSingleStatementAsync() {
+        public async Task MultilineSubExpressionWithSingleStatementAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class TestClass : System.Collections.ObjectModel.ObservableCollection<string> {
+                @"public class TestClass : System.Collections.ObjectModel.ObservableCollection<string> {
     public TestClass() {
         PropertyChanged += (o, e) => {
             if (e.PropertyName == ""AnyProperty"") {
@@ -1006,10 +1015,12 @@ BC32023: Expression is of type '?', which is not a collection type.");
     End Sub
 End Class");
         }
+
         [Fact]
-        public async Task MultilineFunctionExpressionWithSingleStatementAsync() {
+        public async Task MultilineFunctionExpressionWithSingleStatementAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"using System;
+                @"using System;
 public class TestClass {
     Func<object, string> create = o => {
         if(o is TestClass)
@@ -1039,14 +1050,15 @@ End Class");
         }
 
         [Fact]
-        public async Task PrefixUnaryExpression_SingleLineFunctionAsync() {
+        public async Task PrefixUnaryExpression_SingleLineFunctionAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class TestClass {
+                @"public class TestClass {
     public TestClass() {
         System.Func<string, bool> func = o => !string.IsNullOrEmpty(""test"");
     }
 }",
-@"Public Class TestClass
+                @"Public Class TestClass
     Public Sub New()
         Dim func As Func(Of String, Boolean) = Function(o) Not String.IsNullOrEmpty(""test"")
     End Sub
@@ -1054,9 +1066,10 @@ End Class");
         }
 
         [Fact]
-        public async Task Issue486_MustCastForTernaryAsync() {
+        public async Task Issue486_MustCastForTernaryAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class WhyWeNeedToCastNothing
+                @"public class WhyWeNeedToCastNothing
 {
     public void Example(int? vbInitValue)
     {
@@ -1064,7 +1077,7 @@ End Class");
         var withNull = vbInitValue != null ? (int?)8 : null;
     }
 }",
-@"Public Class WhyWeNeedToCastNothing
+                @"Public Class WhyWeNeedToCastNothing
     Public Sub Example(ByVal vbInitValue As Integer?)
         Dim withDefault = If(vbInitValue IsNot Nothing, 7, DirectCast(Nothing, Integer?))
         Dim withNull = If(vbInitValue IsNot Nothing, CType(8, Integer?), Nothing)
@@ -1073,9 +1086,10 @@ End Class");
         }
 
         [Fact]
-        public async Task Issue486_MustCastForOverloadAsync() {
+        public async Task Issue486_MustCastForOverloadAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"using System;
+                @"using System;
 
 public partial class WhyWeNeedToCastNothing
 {
@@ -1097,7 +1111,7 @@ public partial class WhyWeNeedToCastNothing
         return vbInitValue == null ? ""null"" : vbInitValue;
     }
 }",
-@"Imports System
+                @"Imports System
 
 Public Partial Class WhyWeNeedToCastNothing
     Public Shared Sub CorrectOverloadChosen()
@@ -1116,10 +1130,12 @@ Public Partial Class WhyWeNeedToCastNothing
     End Function
 End Class");
         }
+
         [Fact]
-        public async Task ErroneousCastNothingAsync() {
+        public async Task ErroneousCastNothingAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"using System;
+                @"using System;
 using System.Linq;
 
 public class Class1 {
@@ -1127,7 +1143,7 @@ public class Class1 {
         DateTime? nullableDate = values.SingleOrDefault(x => x != null);
     }
 }",
-@"Imports System.Linq
+                @"Imports System.Linq
 
 Public Class Class1
     Public Sub Example(ByVal values As Date?())
@@ -1137,9 +1153,10 @@ End Class", hasLineCommentConversionIssue: true);
         }
 
         [Fact]
-        public async Task EqualsExpressionAsync() {
+        public async Task EqualsExpressionAsync()
+        {
             await TestConversionCSharpToVisualBasicAsync(
-@"public class TestClass {
+                @"public class TestClass {
     public TestClass() {
         int i = 0;
         int j = 0;
@@ -1168,7 +1185,7 @@ End Class", hasLineCommentConversionIssue: true);
     }
     public void DoSomething() { }
 }",
-@"Public Class TestClass
+                @"Public Class TestClass
     Public Sub New()
         Dim i As Integer = 0
         Dim j As Integer = 0
@@ -1196,6 +1213,63 @@ CS0019: Operator '==' cannot be applied to operands of type 'int' and 'string'
 CS0019: Operator '==' cannot be applied to operands of type 'int' and 'object'
 CS0019: Operator '==' cannot be applied to operands of type 'string' and 'int'
 CS0019: Operator '==' cannot be applied to operands of type 'object' and 'int'");
+        }
+
+        [Fact]
+        public async Task TaskCompletionExpressionAsync()
+        {
+            await TestConversionCSharpToVisualBasicAsync(
+                @"using System;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+public class TestClass {
+    private ConcurrentDictionary<Guid,
+        TaskCompletionSource<bool>> pendingOrders;
+    TaskCompletionSource<bool> orderComplete;
+    private void Sdk_OnOrderCompleted(object sender, OrderOutcome e)
+    {
+        this.pendingOrders.TryRemove(e.OrderId, out var tcs);
+        tcs.SetResult(e.Success);
+    }
+}
+
+public class OrderOutcome
+{
+    public Guid OrderId { get; set; }
+    public bool Success { get; set; }
+
+    public OrderOutcome(Guid orderId, bool success)
+    {
+        this.OrderId = orderId;
+        this.Success = success;
+    }
+}
+"
+                , @"Imports System
+Imports System.Threading.Tasks
+Imports System.Collections.Concurrent
+
+Public Class TestClass
+    Private pendingOrders As ConcurrentDictionary(Of Guid, TaskCompletionSource(Of Boolean))
+    Private orderComplete As TaskCompletionSource(Of Boolean)
+
+    Private Sub Sdk_OnOrderCompleted(ByVal sender As Object, ByVal e As OrderOutcome)
+        Dim tcs As TaskCompletionSource(Of Boolean) = Nothing
+        pendingOrders.TryRemove(e.OrderId, tcs)
+        tcs.SetResult(e.Success)
+    End Sub
+End Class
+
+Public Class OrderOutcome
+    Public Property OrderId As Guid
+    Public Property Success As Boolean
+
+    Public Sub New(ByVal orderId As Guid, ByVal success As Boolean)
+        Me.OrderId = orderId
+        Me.Success = success
+    End Sub
+End Class
+",hasLineCommentConversionIssue:true);
         }
     }
 }


### PR DESCRIPTION
Link to issue(s) this covers
This closes issue #682 .

### Problem
The system is generating a local variable for an out parameter. The type symbol was incorrectly parsed as a VB type which didn't properly recognize generics.

### Solution
* I replaced the call to `ToVBSyntax` with a call to the C# SyntaxFactory.ParseText instead of VB ParseText for the type symbol which then recognized the generic and the needed type arguments. I also added a call to the node visitor on the resulting CS type syntax.
* The ToVBSyntax had a NULL check (for type Symbol returned from `ExtractBestMatch<ITypeSymbol>`. Unsure if an explicit  NULL check and error throwing is needed
* Resharper formatted ExpressionsTest.cs resulting in several "minor" changes to the file. I can undo if needed.
* I did need to add the `hasLineCommentConversionIssue` to this test plus the existing `DeclarationExpressionAsync` test
* [X] At least one test covering the code changed

I reviewed the callers for the `ToVBSyntax` which is called from the `ConvertToVariableDeclarator` overload for property declarations. It didn't seem to be an issue because it should never be called. A property cannot be declared as `var` so the call is unneeded. I believe the case will always fall into the `else` clause that simply calls the node visitor for the type.

