### PR TITLE
VB -> C#: add async check for lamba expressions

### DIFF
--- a/CodeConverter/CSharp/LambdaConverter.cs
+++ b/CodeConverter/CSharp/LambdaConverter.cs
@@ -47,11 +47,20 @@ namespace ICSharpCode.CodeConverter.CSharp
             var body = (CSharpSyntaxNode)block ?? expressionBody;
 
             LambdaExpressionSyntax lambda;
-            if (param.Parameters.Count == 1 && param.Parameters.Single().Type == null) {
-                lambda = SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body);
+            if (_semanticModel.GetOperation(vbNode) is IAnonymousFunctionOperation anonFuncOp) {
+                if (param.Parameters.Count == 1 && param.Parameters.Single().Type == null) {
+                    lambda = anonFuncOp.Symbol.IsAsync ? SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body).WithAsyncKeyword(SyntaxFactory.Token(SyntaxKind.AsyncKeyword)) : SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body);
+                } else {
+                    lambda = anonFuncOp.Symbol.IsAsync ? SyntaxFactory.ParenthesizedLambdaExpression(param, body).WithAsyncKeyword(SyntaxFactory.Token(SyntaxKind.AsyncKeyword)) : SyntaxFactory.ParenthesizedLambdaExpression(param, body);
+                }
             } else {
-                lambda = SyntaxFactory.ParenthesizedLambdaExpression(param, body);
+                if (param.Parameters.Count == 1 && param.Parameters.Single().Type == null) {
+                    lambda = SyntaxFactory.SimpleLambdaExpression(param.Parameters[0], body);
+                } else {
+                    lambda = SyntaxFactory.ParenthesizedLambdaExpression(param, body);
+                }
             }
+
             return lambda;
         }
 


### PR DESCRIPTION
Link to issue(s) this covers
This closes #657 
### Problem
anonymous Async function without parameters was missing the async in converted code.

### Solution
* Added a check to see if anonymous function is Async like the other 2 lamba conversions
* I'm unsure if the else is needed (lines 56-61) there isn't a test that covers those lines, but since the other two routines check for anonymous I left it in. I think all lambas should be anonymous
* [X] At least one test covering the code changed
* [X] Added test case to improve code coverage of lambda conversions

