### PR TITLE
update string = nothing expression to use IsNullOrEmpty

### DIFF
--- a/CodeConverter/CSharp/VisualBasicEqualityComparison.cs
+++ b/CodeConverter/CSharp/VisualBasicEqualityComparison.cs
@@ -65,9 +65,9 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             bool requiresVbEqualityCheck = typeInfos.Any(t => t.Type?.SpecialType == SpecialType.System_Object);
 
-            if (typeInfos.All(t => t.Type != null) && typeInfos.All(
-                t => t.Type.SpecialType == SpecialType.System_String ||
-                     t.Type.IsArrayOf(SpecialType.System_Char))) {
+            if (typeInfos.All(
+                t => t.Type?.SpecialType == SpecialType.System_String ||
+                     t.Type.IsArrayOf(SpecialType.System_Char) || t.Type == null ) ) {
                 return RequiredType.StringOnly;
             };
 

--- a/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
@@ -136,7 +136,7 @@ public partial class Class1
             throw new Exception();
         }
 
-        if (s1 == null)
+        if (string.IsNullOrEmpty(s1))
         {
             // 
         }
@@ -197,7 +197,7 @@ public partial class Class1
             throw new Exception();
         }
 
-        if (s1 == null)
+        if (string.IsNullOrEmpty(s1))
         {
             // 
         }


### PR DESCRIPTION
Link to issue(s) this covers
This closes #689 .
### Problem
For proper runtime behavior string variable = nothing should use string.IsNullOrEmpty 

### Solution
* Simple update to the Linq expression to use string compare
* [X] At least one test covering the code changed

