### PR TITLE
handle U32/U64 hex literals without suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### C# -> VB
 
+* Hex values in UInt32 and Uint64 ranges not converted properly. [#695](https://github.com/icsharpcode/CodeConverter/pull/695)
 
 ## [8.2.1] - 2020-10-28
 

--- a/CodeConverter/VB/CommonConversions.cs
+++ b/CodeConverter/VB/CommonConversions.cs
@@ -594,7 +594,7 @@ namespace ICSharpCode.CodeConverter.VB
             if (value is bool)
                 return (ExpressionSyntax)((bool)value ? generator.TrueLiteralExpression() : generator.FalseLiteralExpression());
 
-            valueText = valueText != null ? ConvertNumericLiteralValueText(valueText) : value.ToString();
+            valueText = valueText != null ? ConvertNumericLiteralValueText(valueText,value) : value.ToString();
 
             if (value is byte)
                 return SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(valueText, (byte)value));
@@ -627,7 +627,7 @@ namespace ICSharpCode.CodeConverter.VB
         /// <summary>
         ///  https://docs.microsoft.com/en-us/dotnet/visual-basic/programming-guide/language-features/data-types/type-characters
         /// </summary>
-        private static string ConvertNumericLiteralValueText(string valueText)
+        private static string ConvertNumericLiteralValueText(string valueText,object value)
         {
             var replacements = new Dictionary<string, string> {
                 {"U", "UI"},
@@ -649,6 +649,16 @@ namespace ICSharpCode.CodeConverter.VB
             if (valueText.Length <= 2) return valueText;
 
             if (valueText.StartsWith("0x")) {
+                if (value switch {
+                    ulong _ => "UL",
+                    uint _ => "UI",
+                    _ => default
+                } is { } suffix) {
+                    if (!valueText.EndsWith(suffix)) {
+                        valueText += suffix;
+                    }
+                }
+
                 return "&H" + valueText.Substring(2).Replace("R", "D"); // Undo any accidental replacements that assumed this was a decimal;
             }
 

--- a/Tests/VB/SpecialConversionTests.cs
+++ b/Tests/VB/SpecialConversionTests.cs
@@ -475,6 +475,32 @@ End Class");
         }
 
         [Fact]
+        public async Task Issue695HexAndBinaryLiteralsAsync()
+        {
+            await TestConversionCSharpToVisualBasicAsync(
+                @"class Test
+{
+    public decimal Int32Start   = 0x0;
+    public decimal Int32End     = 0x7FFFFFFF;
+    public decimal UInt32Start  = 0x80000000;
+    public decimal UInt32End    = 0xFFFFFFFF;
+    public decimal Int64Start   = 0x100000000;
+    public decimal Int64End     = 0x7FFFFFFFFFFFFFFF;
+    public decimal UInt64Start  = 0x8000000000000000;
+    public decimal UInt64End    = 0xFFFFFFFFFFFFFFFF;
+}", @"Friend Class Test
+    Public Int32Start As Decimal = &H0
+    Public Int32End As Decimal = &H7FFFFFFF
+    Public UInt32Start As Decimal = &H80000000UI
+    Public UInt32End As Decimal = &HFFFFFFFFUI
+    Public Int64Start As Decimal = &H100000000
+    Public Int64End As Decimal = &H7FFFFFFFFFFFFFFF
+    Public UInt64Start As Decimal = &H8000000000000000UL
+    Public UInt64End As Decimal = &HFFFFFFFFFFFFFFFFUL
+End Class");
+        }
+
+        [Fact]
         public async Task CaseConflict_LocalWithLocalAsync() {
             await TestConversionCSharpToVisualBasicAsync(
 @"void Test() {


### PR DESCRIPTION
Link to issue(s) this covers
closes issue #695 
### Problem
Hex literals for unsigned integers or large integers require a suffix in VB. Was missing in conversion.

### Solution
* Add check for literal type and add suffix if needed
* [X] At least one test covering the code changed

