### PR TITLE
Build GH Action Build matching Azure DevOps Pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     
     env:
-      CC_BUILD_VERSION: '8.2.2.${{ env.Project_Path }}'
+      BuildVersion: '8.2.2.${{ env.Project_Path }}'
 
     steps:
     - uses: actions/checkout@v2
@@ -19,9 +19,9 @@ jobs:
       uses: roryprimrose/set-vs-sdk-project-version@v1
       with:
         projectFilter: '**/CodeConverter.csproj'
-        version: ${{ CC_BUILD_VERSION }}
-        assemblyVersion: ${{ CC_BUILD_VERSION }}
-        fileVersion: ${{ CC_BUILD_VERSION }}
+        version: ${{ env.BuildVersion }}
+        assemblyVersion: ${{ env.BuildVersion }}
+        fileVersion: ${{ env.BuildVersion }}
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -37,10 +37,10 @@ jobs:
     - name: Upload Windows artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: ICSharpCode.CodeConverter.${{ CC_BUILD_VERSION }}.nupkg
+        name: ICSharpCode.CodeConverter.${{ env.BuildVersion }}.nupkg
         path: CodeConverter\bin\Release\ICSharpCode.CodeConverter.*.nupkg
     - name: Upload VSIX
       uses: actions/upload-artifact@v2
       with:
-        name: ICSharpCode.CodeConverter.VsExtension.${{ CC_BUILD_VERSION }}.vsix
+        name: ICSharpCode.CodeConverter.VsExtension.${{ env.BuildVersion }}.vsix
         path: Vsix\bin\Release\ICSharpCode.CodeConverter.VsExtension.vsix

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,12 +5,14 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-env:
-  CC_BUILD_VERSION: '8.2.2.${{ env.Project_Path }}'
-  
+ 
 jobs:
-  build:
+ build:
     runs-on: windows-latest
+    
+    env:
+      CC_BUILD_VERSION: '8.2.2.${{ env.Project_Path }}'
+
     steps:
     - uses: actions/checkout@v2
     - name: Update project version

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       BuildVersion: '8.2.2'
       BuildPlatform: Any CPU
+      BuildTarget: Release
     steps:
     - uses: actions/checkout@v2
     - name: Update project version
@@ -30,22 +31,22 @@ jobs:
       with:
        vs-version: '[16.6,16.9)'
     - name: Restore the application
-      run: msbuild CodeConverter.sln /t:Restore /p:Configuration=Release /p:Platform=$env:BuildPlatform 
+      run: msbuild CodeConverter.sln /t:Restore /p:Configuration=$env:BuildTarget /p:Platform=$env:BuildPlatform 
     - name: Build
-      run: msbuild CodeConverter.sln /p:Configuration=Release /p:Platform=$env:BuildPlatform 
+      run: msbuild CodeConverter.sln /p:Configuration=$env:BuildTarget /p:Platform=$env:BuildPlatform 
     - name: Execute unit tests
       run: dotnet test $env:Tests1
       env:
-        Tests1: Tests\bin\Release\ICSharpCode.CodeConverter.Tests.dll
+        Tests1: Tests\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.Tests.dll
     - name: Pack
       run:  dotnet pack CodeConverter/CodeConverter.csproj
     - name: Upload NuGet package
       uses: actions/upload-artifact@v2
       with:
         name: ICSharpCode.CodeConverter.${{ env.BuildVersion }}.nupkg
-        path: CodeConverter\bin\Release\ICSharpCode.CodeConverter.*.nupkg
+        path: CodeConverter\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.*.nupkg
     - name: Upload VSIX
       uses: actions/upload-artifact@v2
       with:
         name: ICSharpCode.CodeConverter.VsExtension.${{ env.BuildVersion }}.vsix
-        path: Vsix\bin\Release\ICSharpCode.CodeConverter.VsExtension.vsix
+        path: Vsix\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.VsExtension.vsix

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -50,3 +50,8 @@ jobs:
       with:
         name: ICSharpCode.CodeConverter.VsExtension.${{ env.BuildVersion }}.vsix
         path: Vsix\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.VsExtension.vsix
+    - name: Upload code conv tool
+      uses: actions/upload-artifact@v2
+      with:
+        name: ICSharpCode.CodeConverter.CodeConv.${{ env.BuildVersion }}.nupkg
+        path: CommandLine\CodeConv\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.CodeConv.*.vsix

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,8 +33,10 @@ jobs:
       run: msbuild CodeConverter.sln /t:Restore /p:Configuration=Release /p:Platform=$env:BuildPlatform 
     - name: Build
       run: msbuild CodeConverter.sln /p:Configuration=Release /p:Platform=$env:BuildPlatform 
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
+    - name: Execute unit tests
+      run: dotnet test $env:Tests1
+      env:
+        Tests1: Tests\bin\Release\ICSharpCode.CodeConverter.Tests.dll
     - name: Pack
       run:  dotnet pack CodeConverter/CodeConverter.csproj
     - name: Upload NuGet package

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         Tests1: Tests\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.Tests.dll
     - name: Pack
-      run:  dotnet pack CodeConverter/CodeConverter.csproj
+      run:  dotnet pack CodeConverter/CodeConverter.csproj -c $env:BuildTarget
     - name: Upload NuGet package
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,19 +9,17 @@ on:
 jobs:
  build:
     runs-on: windows-latest
-    
     env:
-      BuildVersion: '8.2.2.${{ env.Project_Path }}'
-
+      BuildVersion: '8.2.2'
     steps:
     - uses: actions/checkout@v2
     - name: Update project version
       uses: roryprimrose/set-vs-sdk-project-version@v1
       with:
         projectFilter: '**/CodeConverter.csproj'
-        version: ${{ env.BuildVersion }}
-        assemblyVersion: ${{ env.BuildVersion }}
-        fileVersion: ${{ env.BuildVersion }}
+        version: ${{ env.BuildVersion }}.${{ github.run_number }}
+        assemblyVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
+        fileVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,4 +54,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ICSharpCode.CodeConverter.CodeConv.${{ env.BuildVersion }}.nupkg
-        path: CommandLine\CodeConv\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.CodeConv.*.vsix
+        path: CommandLine\CodeConv\bin\${{ env.BuildTarget }}\ICSharpCode.CodeConverter.CodeConv.*.nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: windows-latest
     env:
       BuildVersion: '8.2.2'
+      BuildPlatform: Any CPU
     steps:
     - uses: actions/checkout@v2
     - name: Update project version
@@ -24,10 +25,14 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+      with:
+       vs-version: '[16.6,16.9)'
+    - name: Restore the application
+      run: msbuild CodeConverter.sln /t:Restore /p:Configuration=Release /p:Platform=$env:BuildPlatform 
     - name: Build
-      run: dotnet build --no-restore -c Release
+      run: msbuild CodeConverter.sln /p:Configuration=Release /p:Platform=$env:BuildPlatform 
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Pack

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,7 +32,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal
     - name: Pack
       run:  dotnet pack CodeConverter/CodeConverter.csproj
-    - name: Upload Windows artifacts
+    - name: Upload NuGet package
       uses: actions/upload-artifact@v2
       with:
         name: ICSharpCode.CodeConverter.${{ env.BuildVersion }}.nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,44 @@
+name: Build CodeConverter
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+env:
+  CC_BUILD_VERSION: '8.2.2.${{ env.Project_Path }}'
+  
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Update project version
+      uses: roryprimrose/set-vs-sdk-project-version@v1
+      with:
+        projectFilter: '**/CodeConverter.csproj'
+        version: ${{ CC_BUILD_VERSION }}
+        assemblyVersion: ${{ CC_BUILD_VERSION }}
+        fileVersion: ${{ CC_BUILD_VERSION }}
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -c Release
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+    - name: Pack
+      run:  dotnet pack CodeConverter/CodeConverter.csproj
+    - name: Upload Windows artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ICSharpCode.CodeConverter.${{ CC_BUILD_VERSION }}.nupkg
+        path: CodeConverter\bin\Release\ICSharpCode.CodeConverter.*.nupkg
+    - name: Upload VSIX
+      uses: actions/upload-artifact@v2
+      with:
+        name: ICSharpCode.CodeConverter.VsExtension.${{ CC_BUILD_VERSION }}.vsix
+        path: Vsix\bin\Release\ICSharpCode.CodeConverter.VsExtension.vsix


### PR DESCRIPTION
I have not matched https://github.com/icsharpcode/CodeConverter/blob/master/azure-pipelines.yml#L57 (necessary???)

First run artifacts:

https://github.com/icsharpcode/CodeConverter/actions/runs/586676519#artifacts

Note that GH re-zips automatically for download (no way around this behavior) and that artifacts can be downloaded only when you are logged in to GH.

Build passing badge can be built for master/succeeded once merged. TODO after merge: delete azure-pipelines.yml & pipeline on Azure DevOps.

Please squash-merge.