### PR TITLE
VB -> C#: Converter takes the property name from interface instead of the concrete class.

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -324,7 +324,6 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                     baseSymbol = possibleSymbol;
                 }
-
             } 
             else 
             {

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -308,16 +308,25 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             //This also covers the case when the name is different (in VB you can have method X implements IFoo.Y), but doesn't resolve any resulting name clashes
             var assemblyIdentities = assembliesBeingConverted.Select(t => t.Identity);
+            ISymbol baseSymbol = default;
             var containingType = idSymbol.ContainingType;
-            ISymbol baseSymbol;
 
-            if (idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property))
+            if (idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property)) 
             {
                 var possibleSymbols = idSymbol.FollowProperty(s => s.BaseMember());
-                var possibleSymbol = possibleSymbols.LastOrDefault(s => !assemblyIdentities.Contains(s.ContainingAssembly.Identity) && s.ContainingType.Equals(containingType));
-                baseSymbol = possibleSymbol ?? possibleSymbols.Last();
-            }
-            else
+                foreach (var possibleSymbol in possibleSymbols)
+                {
+                    if (!assemblyIdentities.Contains(possibleSymbol.ContainingAssembly.Identity) && possibleSymbol.ContainingType.Equals(containingType)) 
+                    {
+                        baseSymbol = possibleSymbol;
+                        break;
+                    }
+
+                    baseSymbol = possibleSymbol;
+                }
+
+            } 
+            else 
             {
                 baseSymbol = idSymbol;
             }

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
-using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
@@ -273,7 +271,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             if (id.SyntaxTree == _semanticModel.SyntaxTree) {
                 var idSymbol = _semanticModel.GetSymbolInfo(id.Parent).Symbol ?? _semanticModel.GetDeclaredSymbol(id.Parent);
                 if (idSymbol != null && !String.IsNullOrWhiteSpace(idSymbol.Name)) {
-                    text = WithDeclarationName(id, idSymbol, text);
+                    text = WithDeclarationName(id, idSymbol, text, _typeContext.AssembliesBeingConverted);
                     var normalizedText = text.WithHalfWidthLatinCharacters();
                     if (idSymbol.IsConstructor() && isAttribute) {
                         text = idSymbol.ContainingType.Name;
@@ -306,10 +304,24 @@ namespace ICSharpCode.CodeConverter.CSharp
         /// <seealso cref="DeclarationNodeVisitor.WithDeclarationNameCasingAsync(VBSyntax.NamespaceBlockSyntax, ISymbol)"/>
         /// <seealso cref="CommonConversions.WithDeclarationNameCasing(TypeSyntax, ITypeSymbol)"/>
         /// </summary>
-        private static string WithDeclarationName(SyntaxToken id, ISymbol idSymbol, string text)
+        private static string WithDeclarationName(SyntaxToken id, ISymbol idSymbol, string text, IEnumerable<IAssemblySymbol> assembliesBeingConverted)
         {
             //This also covers the case when the name is different (in VB you can have method X implements IFoo.Y), but doesn't resolve any resulting name clashes
-            var baseSymbol = idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property) ? idSymbol.FollowProperty(s => s.BaseMember()).Last() : idSymbol;
+            var assemblyIdentities = assembliesBeingConverted.Select(t => t.Identity);
+            var containingType = idSymbol.ContainingType;
+            ISymbol baseSymbol;
+
+            if (idSymbol.IsKind(SymbolKind.Method) || idSymbol.IsKind(SymbolKind.Property))
+            {
+                var possibleSymbols = idSymbol.FollowProperty(s => s.BaseMember());
+                var possibleSymbol = possibleSymbols.LastOrDefault(s => !assemblyIdentities.Contains(s.ContainingAssembly.Identity) && s.ContainingType.Equals(containingType));
+                baseSymbol = possibleSymbol ?? possibleSymbols.Last();
+            }
+            else
+            {
+                baseSymbol = idSymbol;
+            }
+
             bool isDeclaration = baseSymbol.Locations.Any(l => l.SourceSpan == id.Span);
             bool isPartial = baseSymbol.IsPartialClassDefinition() || baseSymbol.IsPartialMethodDefinition() ||
                              baseSymbol.IsPartialMethodImplementation();

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -31,12 +31,11 @@ namespace ICSharpCode.CodeConverter.CSharp
         private static readonly Type DllImportType = typeof(DllImportAttribute);
         private static readonly Type CharSetType = typeof(CharSet);
         private static readonly SyntaxToken SemicolonToken = SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SemicolonToken);
-        private readonly CSharpCompilation _csCompilation;
         private readonly SyntaxGenerator _csSyntaxGenerator;
         private readonly Compilation _vbCompilation;
         private readonly SemanticModel _semanticModel;
         private readonly Dictionary<VBSyntax.StatementSyntax, MemberDeclarationSyntax[]> _additionalDeclarations = new Dictionary<VBSyntax.StatementSyntax, MemberDeclarationSyntax[]>();
-        private readonly TypeContext _typeContext = new TypeContext();
+        private readonly TypeContext _typeContext;
         private uint _failedMemberConversionMarkerCount;
         private readonly HashSet<string> _extraUsingDirectives = new HashSet<string>();
         private readonly VisualBasicEqualityComparison _visualBasicEqualityComparison;
@@ -51,12 +50,13 @@ namespace ICSharpCode.CodeConverter.CSharp
         internal HoistedNodeState AdditionalLocals => _typeContext.HoistedState;
 
         public DeclarationNodeVisitor(Document document, Compilation compilation, SemanticModel semanticModel,
-            CSharpCompilation csCompilation, SyntaxGenerator csSyntaxGenerator)
+            CSharpCompilation csCompilation, SyntaxGenerator csSyntaxGenerator,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted)
         {
             _vbCompilation = compilation;
             _semanticModel = semanticModel;
-            _csCompilation = csCompilation;
             _csSyntaxGenerator = csSyntaxGenerator;
+            _typeContext = new TypeContext {AssembliesBeingConverted = assembliesBeingConverted};
             _visualBasicEqualityComparison = new VisualBasicEqualityComparison(_semanticModel, _extraUsingDirectives);
             TriviaConvertingDeclarationVisitor = new CommentConvertingVisitorWrapper(this, _semanticModel.SyntaxTree);
             var expressionEvaluator = new ExpressionEvaluator(semanticModel, _visualBasicEqualityComparison);

--- a/CodeConverter/CSharp/ITypeContext.cs
+++ b/CodeConverter/CSharp/ITypeContext.cs
@@ -1,10 +1,14 @@
-﻿namespace ICSharpCode.CodeConverter.CSharp
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace ICSharpCode.CodeConverter.CSharp
 {
     internal interface ITypeContext
     {
         AdditionalInitializers Initializers { get; }
         MethodsWithHandles MethodsWithHandles { get; }
         HoistedNodeState HoistedState { get; }
+        IEnumerable<IAssemblySymbol> AssembliesBeingConverted { get; }
         bool Any();
     }
 }

--- a/CodeConverter/CSharp/TypeContext.cs
+++ b/CodeConverter/CSharp/TypeContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
@@ -10,6 +11,7 @@ namespace ICSharpCode.CodeConverter.CSharp
         public MethodsWithHandles MethodsWithHandles => _contextStack.Peek().Methods;
 
         public HoistedNodeState HoistedState { get; internal set; } = new HoistedNodeState();
+        public IEnumerable<IAssemblySymbol> AssembliesBeingConverted { get; internal set; }
 
         public void Push(MethodsWithHandles methodWithHandles, AdditionalInitializers additionalInitializers)
         {

--- a/CodeConverter/CSharp/VBToCSConversion.cs
+++ b/CodeConverter/CSharp/VBToCSConversion.cs
@@ -25,17 +25,17 @@ namespace ICSharpCode.CodeConverter.CSharp
         private const string UnresolvedNamespaceDiagnosticId = "CS0246";
         private const string FabricatedAssemblyName = ISymbolExtensions.ForcePartialTypesAssemblyName;
         private VBToCSProjectContentsConverter _vbToCsProjectContentsConverter;
-        private IProgress<ConversionProgress> _progress;
         private CancellationToken _cancellationToken;
 
         public ConversionOptions ConversionOptions { get; set; }
 
-        public async Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project, IProgress<ConversionProgress> progress, CancellationToken cancellationToken)
+        public async Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted, IProgress<ConversionProgress> progress,
+            CancellationToken cancellationToken)
         {
-            _progress = progress;
             _cancellationToken = cancellationToken;
             bool useProjectLevelWinformsAdjustments = project.AssemblyName != FabricatedAssemblyName;
-            _vbToCsProjectContentsConverter = new VBToCSProjectContentsConverter(ConversionOptions, useProjectLevelWinformsAdjustments, progress, cancellationToken);
+            _vbToCsProjectContentsConverter = new VBToCSProjectContentsConverter(ConversionOptions, useProjectLevelWinformsAdjustments, assembliesBeingConverted, progress, cancellationToken);
             await _vbToCsProjectContentsConverter.InitializeSourceAsync(project);
             return _vbToCsProjectContentsConverter;
         }

--- a/CodeConverter/CSharp/VBToCSProjectContentsConverter.cs
+++ b/CodeConverter/CSharp/VBToCSProjectContentsConverter.cs
@@ -22,6 +22,7 @@ namespace ICSharpCode.CodeConverter.CSharp
     {
         private readonly ConversionOptions _conversionOptions;
         private readonly bool _useProjectLevelWinformsAdjustments;
+        private readonly IEnumerable<IAssemblySymbol> _assembliesBeingConverted;
         private CSharpCompilation _csharpViewOfVbSymbols;
         private Dictionary<string, string> _designerToResxRelativePath;
         private Project _convertedCsProject;
@@ -30,10 +31,13 @@ namespace ICSharpCode.CodeConverter.CSharp
         private readonly IProgress<ConversionProgress> _progress;
         private readonly CancellationToken _cancellationToken;
 
-        public VBToCSProjectContentsConverter(ConversionOptions conversionOptions, bool useProjectLevelWinformsAdjustments, IProgress<ConversionProgress> progress, CancellationToken cancellationToken)
+        public VBToCSProjectContentsConverter(ConversionOptions conversionOptions,
+            bool useProjectLevelWinformsAdjustments, IEnumerable<IAssemblySymbol> assembliesBeingConverted,
+            IProgress<ConversionProgress> progress, CancellationToken cancellationToken)
         {
             _conversionOptions = conversionOptions;
-            this._useProjectLevelWinformsAdjustments = useProjectLevelWinformsAdjustments;
+            _useProjectLevelWinformsAdjustments = useProjectLevelWinformsAdjustments;
+            _assembliesBeingConverted = assembliesBeingConverted;
             _progress = progress;
             _cancellationToken = cancellationToken;
             OptionalOperations = new OptionalOperations(conversionOptions.AbandonOptionalTasksAfter, progress, cancellationToken);
@@ -68,7 +72,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
         public async Task<SyntaxNode> SingleFirstPassAsync(Document document)
         {
-            return await VisualBasicConverter.ConvertCompilationTreeAsync(document, _csharpViewOfVbSymbols, _csharpReferenceProject, OptionalOperations, _cancellationToken);
+            return await VisualBasicConverter.ConvertCompilationTreeAsync(document, _csharpViewOfVbSymbols, _csharpReferenceProject, _assembliesBeingConverted, OptionalOperations, _cancellationToken);
         }
 
         public async Task<(Project project, List<WipFileConversion<DocumentId>> firstPassDocIds)> GetConvertedProjectAsync(WipFileConversion<SyntaxNode>[] firstPassResults)

--- a/CodeConverter/CSharp/VisualBasicConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicConverter.cs
@@ -1,14 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editing;
-using Microsoft.CodeAnalysis.Formatting;
 using VBSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using CSS = Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Threading;
-using ICSharpCode.CodeConverter.VB;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
@@ -16,6 +15,7 @@ namespace ICSharpCode.CodeConverter.CSharp
     {
         public static async Task<SyntaxNode> ConvertCompilationTreeAsync(Document document,
             CSharpCompilation csharpViewOfVbSymbols, Project csharpReferenceProject,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted,
             OptionalOperations optionalOperations, CancellationToken cancellationToken)
         {
             document = await document.WithExpandedRootAsync(cancellationToken);
@@ -29,7 +29,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var csSyntaxGenerator = SyntaxGenerator.GetGenerator(csharpReferenceProject);
             var semanticModel = compilation.GetSemanticModel(tree, true);
             var visualBasicSyntaxVisitor = new
-                DeclarationNodeVisitor(document, compilation, semanticModel, csharpViewOfVbSymbols, csSyntaxGenerator);
+                DeclarationNodeVisitor(document, compilation, semanticModel, csharpViewOfVbSymbols, csSyntaxGenerator, assembliesBeingConverted);
             var converted = await root.AcceptAsync<CSS.CompilationUnitSyntax>(visualBasicSyntaxVisitor.TriviaConvertingDeclarationVisitor);
 
             return optionalOperations.MapSourceTriviaToTargetHandled(root, converted, document);

--- a/CodeConverter/ILanguageConversion.cs
+++ b/CodeConverter/ILanguageConversion.cs
@@ -24,7 +24,9 @@ namespace ICSharpCode.CodeConverter
         string TargetLanguage { get; }
         ConversionOptions ConversionOptions { get; set; }
 
-        Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project, IProgress<ConversionProgress> progress, CancellationToken cancellationToken);
+        Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted, IProgress<ConversionProgress> progress,
+            CancellationToken cancellationToken);
         string PostTransformProjectFile(string xml);
 
         Task<Document> CreateProjectDocumentFromTreeAsync(SyntaxTree tree, IEnumerable<MetadataReference> references);

--- a/CodeConverter/Shared/ProjectConversion.cs
+++ b/CodeConverter/Shared/ProjectConversion.cs
@@ -62,7 +62,9 @@ namespace ICSharpCode.CodeConverter.Shared
                 document = await WithAnnotatedSelectionAsync(document, conversionOptions.SelectedTextSpan);
             }
 
-            var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(document.Project, progress, cancellationToken);
+            var assemblyBeingConverted = (await document.Project.GetCompilationAsync(cancellationToken)).Assembly;
+            var assembliesBeingConverted = new[] {assemblyBeingConverted};
+            var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(document.Project, assembliesBeingConverted, progress, cancellationToken);
 
             document = projectContentsConverter.SourceProject.GetDocument(document.Id);
 
@@ -79,15 +81,15 @@ namespace ICSharpCode.CodeConverter.Shared
         }
 
         public static async IAsyncEnumerable<ConversionResult> ConvertProject(Project project,
-            ILanguageConversion languageConversion, IProgress<ConversionProgress> progress, [EnumeratorCancellation] CancellationToken cancellationToken,
+            ILanguageConversion languageConversion, IProgress<ConversionProgress> progress,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted,
+            [EnumeratorCancellation] CancellationToken cancellationToken,
             params (string Find, string Replace, bool FirstOnly)[] replacements)
         {
             progress ??= new Progress<ConversionProgress>();
             using var roslynEntryPoint = await RoslynEntryPointAsync(progress);
-
-            var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(project, progress, cancellationToken);
+            var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(project, assembliesBeingConverted, progress, cancellationToken);
             var sourceFilePaths = project.Documents.Concat(projectContentsConverter.SourceProject.AdditionalDocuments).Select(d => d.FilePath).ToImmutableHashSet();
-            project = projectContentsConverter.SourceProject;
             var convertProjectContents = ConvertProjectContents(projectContentsConverter, languageConversion, progress, cancellationToken);
 
             var results = WithProjectFile(projectContentsConverter, languageConversion, sourceFilePaths, convertProjectContents, replacements);

--- a/CodeConverter/Shared/SolutionConverter.cs
+++ b/CodeConverter/Shared/SolutionConverter.cs
@@ -66,7 +66,7 @@ namespace ICSharpCode.CodeConverter.Shared
         private async Task<IAsyncEnumerable<ConversionResult>> ConvertProjects()
         {
             var assemblies = _projectsToConvert.Select(t => t.GetCompilationAsync(_cancellationToken));
-            var assembliesBeingConverted = (await Task.WhenAll(assemblies)).Select(t => t.Assembly);
+            var assembliesBeingConverted = (await Task.WhenAll(assemblies)).Select(t => t.Assembly).ToList();
             return _projectsToConvert.ToAsyncEnumerable().SelectMany(project => ConvertProject(project, assembliesBeingConverted));
         }
 

--- a/CodeConverter/Shared/SolutionConverter.cs
+++ b/CodeConverter/Shared/SolutionConverter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 
@@ -53,24 +54,27 @@ namespace ICSharpCode.CodeConverter.Shared
             _cancellationToken = cancellationToken;
         }
 
-        public IAsyncEnumerable<ConversionResult> Convert()
+        public async Task<IAsyncEnumerable<ConversionResult>> Convert()
         {
             var projectsToUpdateReferencesOnly = _projectsToConvert.First().Solution.Projects.Except(_projectsToConvert);
             var solutionResult = string.IsNullOrWhiteSpace(_sourceSolutionContents) ? Enumerable.Empty<ConversionResult>() : ConvertSolutionFile().Yield();
-            return ConvertProjects()
+            var convertedProjects = await ConvertProjects();
+            return convertedProjects
                 .Concat(UpdateProjectReferences(projectsToUpdateReferencesOnly).Concat(solutionResult).ToAsyncEnumerable());
         }
 
-        private IAsyncEnumerable<ConversionResult> ConvertProjects()
+        private async Task<IAsyncEnumerable<ConversionResult>> ConvertProjects()
         {
-            return _projectsToConvert.ToAsyncEnumerable().SelectMany(project => ConvertProject(project));
+            var assemblies = _projectsToConvert.Select(t => t.GetCompilationAsync(_cancellationToken));
+            var assembliesBeingConverted = (await Task.WhenAll(assemblies)).Select(t => t.Assembly);
+            return _projectsToConvert.ToAsyncEnumerable().SelectMany(project => ConvertProject(project, assembliesBeingConverted));
         }
 
-        private IAsyncEnumerable<ConversionResult> ConvertProject(Project project)
+        private IAsyncEnumerable<ConversionResult> ConvertProject(Project project, IEnumerable<IAssemblySymbol> assembliesBeingConverted)
         {
             var replacements = _projectReferenceReplacements.ToArray();
             _progress.Report(new ConversionProgress($"Converting {project.Name}..."));
-            return ProjectConversion.ConvertProject(project, _languageConversion, _progress, _cancellationToken, replacements);
+            return ProjectConversion.ConvertProject(project, _languageConversion, _progress, assembliesBeingConverted, _cancellationToken, replacements);
         }
 
         private IEnumerable<ConversionResult> UpdateProjectReferences(IEnumerable<Project> projectsToUpdateReferencesOnly)

--- a/CodeConverter/VB/CSToVBConversion.cs
+++ b/CodeConverter/VB/CSToVBConversion.cs
@@ -26,7 +26,9 @@ namespace ICSharpCode.CodeConverter.VB
         private IProgress<ConversionProgress> _progress;
         private CancellationToken _cancellationToken;
 
-        public async Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project, IProgress<ConversionProgress> progress, CancellationToken cancellationToken)
+        public async Task<IProjectContentsConverter> CreateProjectContentsConverterAsync(Project project,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted, IProgress<ConversionProgress> progress,
+            CancellationToken cancellationToken)
         {
             _progress = progress;
             _cancellationToken = cancellationToken;

--- a/CommandLine/CodeConv.Shared/MSBuildWorkspaceConverter.cs
+++ b/CommandLine/CodeConv.Shared/MSBuildWorkspaceConverter.cs
@@ -63,8 +63,8 @@ namespace ICSharpCode.CodeConverter.CommandLine
                 : LanguageNames.CSharp;
 
             var projectsToConvert = solution.Projects.Where(p => p.Language == languageNameToConvert && shouldConvertProject(p)).ToArray();
-            var results = SolutionConverter.CreateFor(languageConversion, projectsToConvert, progress, token).Convert();
-            await foreach (var r in results) yield return r;
+            var results = await SolutionConverter.CreateFor(languageConversion, projectsToConvert, progress, token).Convert();
+            await foreach (var r in results.WithCancellation(token)) yield return r;
         }
 
         private async Task<Solution> GetSolutionAsync(string projectOrSolutionFile, IProgress<string> progress)

--- a/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
+++ b/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
@@ -19,14 +19,14 @@ namespace ICSharpCode.CodeConverter.Tests.CSharp
             _multiFileTestFixture = multiFileTestFixture;
         }
 
-        [Fact(Skip = "Doesn't work on Github actions agent")]
+        [Fact]
         public async Task ConvertWholeSolutionAsync()
         {
 
             await _multiFileTestFixture.ConvertProjectsWhereAsync(p => true, Language.CS);
         }
 
-        [Fact(Skip = "Doesn't work on Github actions agent")]
+        [Fact]
         public async Task ConvertVbLibraryOnlyAsync()
         {
             await _multiFileTestFixture.ConvertProjectsWhereAsync(p => p.Name == "VbLibrary", Language.CS);

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/Module1.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/Module1.vb
@@ -15,7 +15,10 @@ Module Module1
         Dim interfaceInstance As AnInterface = New AnInterfaceImplementation
         Dim classInstance As New AnInterfaceImplementation
         Console.WriteLine(interfaceInstance.AnInterfaceProperty)
-        Console.WriteLine(classInstance.APropertyWithDifferentNameThanPropertyFromInterface)
+        Console.WriteLine(classInstance.APropertyWithDifferentName)
+
+        interfaceInstance.AnInterfaceMethod()
+        classInstance.AMethodWithDifferentName()
     End Sub
 
 End Module

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/Module1.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/Module1.vb
@@ -1,4 +1,5 @@
 ﻿Imports System
+Imports VbNetStandardLib
 
 Module Module1
     Private dict As New Dictionary(Of Integer, Integer)
@@ -10,6 +11,11 @@ Module Module1
 
     Sub Main()
         Console.Write(AClass.NestedEnum.First)
+
+        Dim interfaceInstance As AnInterface = New AnInterfaceImplementation
+        Dim classInstance As New AnInterfaceImplementation
+        Console.WriteLine(interfaceInstance.AnInterfaceProperty)
+        Console.WriteLine(classInstance.APropertyWithDifferentNameThanPropertyFromInterface)
     End Sub
 
 End Module

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/VbLibrary.vbproj
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbLibrary/VbLibrary.vbproj
@@ -110,5 +110,11 @@
     </None>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\VbNetStandardLib\VbNetStandardLib.vbproj">
+      <Project>{fbfbe639-a532-408a-960d-288e05feeb0e}</Project>
+      <Name>VbNetStandardLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterface.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterface.vb
@@ -1,3 +1,4 @@
 ﻿Public Interface AnInterface
     ReadOnly Property AnInterfaceProperty As String
+    Sub AnInterfaceMethod()
 End Interface

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterface.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterface.vb
@@ -1,0 +1,3 @@
+﻿Public Interface AnInterface
+    ReadOnly Property AnInterfaceProperty As String
+End Interface

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterfaceImplementation.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterfaceImplementation.vb
@@ -1,0 +1,9 @@
+﻿Public Class AnInterfaceImplementation
+    Implements AnInterface
+
+    Public ReadOnly Property APropertyWithDifferentNameThanPropertyFromInterface As String Implements AnInterface.AnInterfaceProperty
+        Get
+            Return "Const"
+        End Get
+    End Property
+End Class

--- a/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterfaceImplementation.vb
+++ b/Tests/TestData/MultiFileCharacterization/SourceFiles/VbNetStandardLib/AnInterfaceImplementation.vb
@@ -1,9 +1,12 @@
 ﻿Public Class AnInterfaceImplementation
     Implements AnInterface
 
-    Public ReadOnly Property APropertyWithDifferentNameThanPropertyFromInterface As String Implements AnInterface.AnInterfaceProperty
+    Public ReadOnly Property APropertyWithDifferentName As String Implements AnInterface.AnInterfaceProperty
         Get
             Return "Const"
         End Get
     End Property
+
+    Public Sub AMethodWithDifferentName() Implements AnInterface.AnInterfaceMethod
+    End Sub
 End Class

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualBasic.CompilerServices;
+using VbNetStandardLib;
 
 namespace VbLibrary
 {
@@ -18,6 +19,10 @@ namespace VbLibrary
         public static void Main()
         {
             Console.Write((int)AClass.NestedEnum.First);
+            AnInterface interfaceInstance = new AnInterfaceImplementation();
+            var classInstance = new AnInterfaceImplementation();
+            Console.WriteLine(interfaceInstance.AnInterfaceProperty);
+            Console.WriteLine(classInstance.APropertyWithDifferentNameThanPropertyFromInterface);
         }
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
@@ -22,7 +22,9 @@ namespace VbLibrary
             AnInterface interfaceInstance = new AnInterfaceImplementation();
             var classInstance = new AnInterfaceImplementation();
             Console.WriteLine(interfaceInstance.AnInterfaceProperty);
-            Console.WriteLine(classInstance.APropertyWithDifferentNameThanPropertyFromInterface);
+            Console.WriteLine(classInstance.APropertyWithDifferentName);
+            interfaceInstance.AnInterfaceMethod();
+            classInstance.AMethodWithDifferentName();
         }
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
@@ -116,5 +116,11 @@
     </None>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\VbNetStandardLib\VbNetStandardLib.vbproj">
+      <Project>{fbfbe639-a532-408a-960d-288e05feeb0e}</Project>
+      <Name>VbNetStandardLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
@@ -23,6 +23,8 @@ namespace VbLibrary
             var classInstance = new AnInterfaceImplementation();
             Console.WriteLine(interfaceInstance.AnInterfaceProperty);
             Console.WriteLine(classInstance.AnInterfaceProperty);
+            interfaceInstance.AnInterfaceMethod();
+            classInstance.AnInterfaceMethod();
         }
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualBasic.CompilerServices;
+using VbNetStandardLib;
 
 namespace VbLibrary
 {
@@ -18,6 +19,10 @@ namespace VbLibrary
         public static void Main()
         {
             Console.Write((int)AClass.NestedEnum.First);
+            AnInterface interfaceInstance = new AnInterfaceImplementation();
+            var classInstance = new AnInterfaceImplementation();
+            Console.WriteLine(interfaceInstance.AnInterfaceProperty);
+            Console.WriteLine(classInstance.AnInterfaceProperty);
         }
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
@@ -116,5 +116,11 @@
     </None>
     <None Include="App.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\VbNetStandardLib\VbNetStandardLib.csproj">
+      <Project>{49DF6752-696A-0F7B-1455-E2F06769DFAE}</Project>
+      <Name>VbNetStandardLib</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterface.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterface.cs
@@ -1,0 +1,8 @@
+
+namespace VbNetStandardLib
+{
+    public interface AnInterface
+    {
+        string AnInterfaceProperty { get; }
+    }
+}

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterface.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterface.cs
@@ -4,5 +4,7 @@ namespace VbNetStandardLib
     public interface AnInterface
     {
         string AnInterfaceProperty { get; }
+
+        void AnInterfaceMethod();
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
@@ -1,0 +1,14 @@
+
+namespace VbNetStandardLib
+{
+    public class AnInterfaceImplementation : AnInterface
+    {
+        public string AnInterfaceProperty
+        {
+            get
+            {
+                return "Const";
+            }
+        }
+    }
+}

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
@@ -10,5 +10,11 @@ namespace VbNetStandardLib
                 return "Const";
             }
         }
+
+        public void AnInterfaceMethod()
+        {
+        }
+
+        public void AMethodWithDifferentName() => AnInterfaceMethod();
     }
 }

--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -185,8 +185,10 @@ End Sub";
             return baseConversion.CanBeContainedByMethod(node);
         }
 
-        async Task<IProjectContentsConverter> ILanguageConversion.CreateProjectContentsConverterAsync(Project project, IProgress<ConversionProgress> progress, CancellationToken cancellationToken) {
-            return await baseConversion.CreateProjectContentsConverterAsync(project, progress, cancellationToken);
+        async Task<IProjectContentsConverter> ILanguageConversion.CreateProjectContentsConverterAsync(Project project,
+            IEnumerable<IAssemblySymbol> assembliesBeingConverted, IProgress<ConversionProgress> progress,
+            CancellationToken cancellationToken) {
+            return await baseConversion.CreateProjectContentsConverterAsync(project, assembliesBeingConverted, progress, cancellationToken);
         }
 
         async Task<Document> ILanguageConversion.CreateProjectDocumentFromTreeAsync(SyntaxTree tree, IEnumerable<MetadataReference> references)

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,8 +30,8 @@
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements">
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="3.4.0" />
-    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.8.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.10.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -272,7 +272,7 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             var conversionOptions = new ConversionOptions(){AbandonOptionalTasksAfter = await GetAbandonOptionalTasksAfterAsync()};
             var solutionConverter = SolutionConverter.CreateFor<TLanguageConversion>(projects, progress: CreateOutputWindowProgress(), cancellationToken: cancellationToken, conversionOptions: conversionOptions);
 
-            var results = solutionConverter.Convert();
+            var results = await solutionConverter.Convert();
             await foreach(var result in results) yield return result;
         }
 


### PR DESCRIPTION
Link to issue(s) this covers
https://github.com/icsharpcode/CodeConverter/issues/731

### Problem
When the interface and the implementation are in the assembly that is not being converted the converter takes the property/method name from the interface instead of the concrete class. 
As the result, the code doesn't compile.

### Solution
Check if the type is not in the assembly being converted and then take the property name from the appriopate symbol (interface or implementation).
It probably doesn't cover the case when we convert a single document.

* [x] At least one test covering the code changed

