### PR TITLE
Allow 2022 installation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,7 @@ jobs:
  build:
     runs-on: windows-latest
     env:
-      BuildVersion: '8.2.5'
+      BuildVersion: '8.3.0'
       BuildPlatform: Any CPU
       BuildTarget: Release
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ### Vsix
+
+
+### VB -> C#
+
+
+### C# -> VB
+
+
+## [8.3.0] - 2021-07-02
+
+
+### Vsix
 * Support for VS2022
 
 ## [8.2.5] - 2021-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ### Vsix
-
-
-### VB -> C#
-
-
-### C# -> VB
-
+* Support for VS2022
 
 ## [8.2.5] - 2021-06-19
 

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -14,9 +14,9 @@
     </Description>
     <Product>Code Converter for C# to/from VB.NET</Product>
     <Copyright>Copyright (c) 2017-2020 AlphaSierraPapa for the CodeConverter team</Copyright>
-    <AssemblyVersion>8.2.5.0</AssemblyVersion>
-    <FileVersion>8.2.5.0</FileVersion>
-    <Version>8.2.5</Version>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
+    <Version>8.3.0</Version>
     <PackageId>ICSharpCode.CodeConverter</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -6,8 +6,8 @@
     <AssemblyName>ICSharpCode.CodeConverter.CodeConv.NetFramework</AssemblyName>
     <RootNamespace>ICSharpCode.CodeConverter.CodeConv.NetFramework</RootNamespace>
     <ToolCommandName>codeconv</ToolCommandName>
-    <AssemblyVersion>8.2.5.0</AssemblyVersion>
-    <FileVersion>8.2.5.0</FileVersion>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -9,9 +9,9 @@
     <AssemblyName>ICSharpCode.CodeConverter.CodeConv</AssemblyName>
     <RootNamespace>ICSharpCode.CodeConverter.CodeConv</RootNamespace>
     <ToolCommandName>codeconv</ToolCommandName>
-    <AssemblyVersion>8.2.5.0</AssemblyVersion>
-    <FileVersion>8.2.5.0</FileVersion>
-    <Version>8.2.5</Version>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
+    <Version>8.3.0</Version>
     <Description>Bidirectional code converter for VB and C#
 This package contains a command line tool.
 For a nugetted dll, web converter or visual studio extension, see https://github.com/icsharpcode/CodeConverter</Description>

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -4,8 +4,8 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>ICSharpCode.CodeConverter.Func</RootNamespace>
     <AssemblyName>ICSharpCode.CodeConverter.Func</AssemblyName>
-    <AssemblyVersion>8.2.5.0</AssemblyVersion>
-    <FileVersion>8.2.5.0</FileVersion>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <UserSecretsId>1d2f0b91-7e29-4920-8a93-e52863d06c2e</UserSecretsId>
   </PropertyGroup>

--- a/Vsix/OutputWindow.cs
+++ b/Vsix/OutputWindow.cs
@@ -50,7 +50,19 @@ namespace ICSharpCode.CodeConverter.VsExtension
             _outputPane = outputPaneAsync;
 
             _solutionEvents = VisualStudioInteraction.Dte.Events.SolutionEvents;
-            _solutionEvents.Opened += () => OnSolutionOpenedAsync().Forget();
+            SignUpToSolutionOpened();
+        }
+
+        private void SignUpToSolutionOpened()
+        {
+            try {
+                SignUpToSolutionOpenedPriorToVs2022();
+            } catch (MissingMethodException) {
+            }
+
+            // When attempting to call this function, it throws an MissingMethodException in VS2022 onwards.
+            // I don't know another way to get this behaviour that was available in VS2017, so we'll forego this until we can drop VS2017 support and use a more recent interface
+            void SignUpToSolutionOpenedPriorToVs2022() => _solutionEvents.Opened += () => OnSolutionOpenedAsync().Forget();
         }
 
         public async Task ClearAsync()

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -8,8 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace>ICSharpCode.CodeConverter.VsExtension</RootNamespace>
     <AssemblyName>ICSharpCode.CodeConverter.VsExtension</AssemblyName>
-    <AssemblyVersion>8.2.5.0</AssemblyVersion>
-    <FileVersion>8.2.5.0</FileVersion>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
     <ProjectGuid>{99498EF8-C9E0-433B-8D7B-EA8E9E66F0C7}</ProjectGuid>
     <ProjectTypeGuids>{82B43B9B-A64C-4715-B499-D71E9CA2BD60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.29" />
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.9.3039">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -13,9 +13,9 @@
         <Tags>code converter vb csharp visual basic csharp net translate</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[15.0,18.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,18.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,18.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="7e2a69d6-193b-4cdf-878d-3370d5931942" Version="8.2.5.0" Language="en-US" Publisher="IC#Code"/>
+        <Identity Id="7e2a69d6-193b-4cdf-878d-3370d5931942" Version="8.3.0.0" Language="en-US" Publisher="IC#Code"/>
         <DisplayName>Code Converter (VB - C#)</DisplayName>
         <Description xml:space="preserve">Convert VB.NET to C# and vice versa with this roslyn based converter</Description>
         <MoreInfo>https://github.com/icsharpcode/CodeConverter</MoreInfo>

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    <AssemblyVersion>8.2.4.0</AssemblyVersion>
-    <FileVersion>8.2.4.0</FileVersion>
-    <Version>8.2.4</Version>
+    <AssemblyVersion>8.3.0.0</AssemblyVersion>
+    <FileVersion>8.3.0.0</FileVersion>
+    <Version>8.3.0</Version>
     <LangVersion>8</LangVersion>
     <NoWarn>$(NoWarn);1998</NoWarn>
     <RootNamespace>ICSharpCode.CodeConverter.Web</RootNamespace>


### PR DESCRIPTION
The build tools update commit seemed to be required locally in VS2022 in order to avoid a complicated SDK error regarding the bitness of the task (which was presumably x86-only until 16.9 when the team realized they were going 64 bit soon).