### PR TITLE
fixes #752 swap expressions around equals if equal to joinedvariable …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Use Conversions.ToString when concatenating a DateTime with a string [#806](https://github.com/icsharpcode/CodeConverter/issues/806)
 * Ensure named arguments are correctly named when followed by an omitted argument [#808](https://github.com/icsharpcode/CodeConverter/issues/808)
 * Convert static variables into fields [#623](https://github.com/icsharpcode/CodeConverter/issues/623)
+* Ensure query syntax join conditions are swapped to the necessary C# order [#752](https://github.com/icsharpcode/CodeConverter/issues/752)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/QueryConverter.cs
+++ b/CodeConverter/CSharp/QueryConverter.cs
@@ -416,7 +416,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                             ? expression
                             : SwapExpressions(expression),
 
-                        var _ => throw new NotImplementedException($"Conversion for join query clause with condition of kind '{expression.Lhs.Kind()}' not implemented")
+                        _ => throw new NotImplementedException($"Conversion for join query clause with condition of kind '{expression.Lhs.Kind()}' not implemented")
                     };
                 })
                .ToList();

--- a/Tests/CSharp/ExpressionTests/LinqExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/LinqExpressionTests.cs
@@ -463,6 +463,7 @@ internal partial class Test
         var orders = new List<Order>();
         var customerList = from cust in customers
                            join ord in orders on new { key0 = cust.CustomerID, key1 = cust.CompanyName } equals new { key0 = ord.CustomerID, key1 = ord.Total }
+
                            select new { cust.CompanyName, ord.Total };
     }
 }");
@@ -511,7 +512,8 @@ internal partial class Test
         var customers = new List<Customer>();
         var orders = new List<Order>();
         var customerList = from cust in customers
-                           join ord in orders on new { key0 = cust.Customer, key1 = cust.CompanyName } equals new { key0 = ord.Customer, key1 = ord.Total }
+                           join ord in orders on new { key0 = cust, key1 = cust.CompanyName } equals new { key0 = ord.Customer, key1 = ord.Total }
+
                            select new { cust.CompanyName, ord.Total };
     }
 }");


### PR DESCRIPTION
### Problem

- fixes #752

### Solution
* Swap joincondition lhs and rhs expressions if lhs expression name matches the joinedvariable name. 

*  Important code: QueryConverter.CreateJoinAnonymousObjectKeys. There seems to be a bug in which the formatter (in OptionalOperations.Format) adds an extra newline between a join and a select clause even without my change. This is why LinqMultipleJoinConditionsReorderExpressionsAsync and LinqMultipleIdentifierOnlyJoinConditionsReorderExpressionsAsync fail. Have you got any idea how to fix this?

* Added 3 tests in LinqExpressionTests