### PR TITLE
Fixes an issue where Visual Basic optional parameter fails conversion to C#

### DIFF
--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -1407,7 +1407,14 @@ namespace ICSharpCode.CodeConverter.CSharp
             var attrListsToRemove = parameter.AttributeLists.SingleOrDefault(aList => aList.Attributes
                .All(a =>
                 {
-                    var attrIdentifier = ((IdentifierNameSyntax)a.Name).Identifier.Text;
+                    string attrIdentifier = string.Empty;
+
+                    if (a.Name is IdentifierNameSyntax identifierNameSyntax) {
+                        attrIdentifier = identifierNameSyntax.Identifier.Text;
+                    } else if (a.Name is AliasQualifiedNameSyntax aliasQualifiedNameSyntax) {
+                        attrIdentifier = aliasQualifiedNameSyntax.Alias.Identifier.Text;
+                    }
+
                     return optionalAttributes.Contains(attrIdentifier);
                 }));
 

--- a/Tests/CSharp/ExpressionTests/ParameterTests.cs
+++ b/Tests/CSharp/ExpressionTests/ParameterTests.cs
@@ -10,13 +10,13 @@ namespace ICSharpCode.CodeConverter.Tests.CSharp.ExpressionTests
         public async Task OptionalParameter_DoesNotThrowInvalidCastException()
         {
             await TestConversionVisualBasicToCSharpAsync(@"
-Public Class MyAttribute
+Public Class MyTestAttribute
     Inherits Attribute
 End Class
 
 Public Class MyController
     Public Function GetNothing(
-        <MyAttribute()> Optional indexer As Integer? = 0
+        <MyTest()> Optional indexer As Integer? = 0
     ) As String
         Return Nothing
     End Function
@@ -24,13 +24,13 @@ End Class
 ",
 @"using System;
 
-public partial class MyAttribute : Attribute
+public partial class MyTestAttribute : Attribute
 {
 }
 
 public partial class MyController
 {
-    public string GetNothing([My()] int? indexer = 0)
+    public string GetNothing([MyTest()] int? indexer = 0)
     {
         return null;
     }

--- a/Tests/CSharp/ExpressionTests/ParameterTests.cs
+++ b/Tests/CSharp/ExpressionTests/ParameterTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+using Xunit;
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp.ExpressionTests
+{
+    public class ParameterTests : ConverterTestBase
+    {
+        [Fact]
+        public async Task OptionalParameter_DoesNotThrowInvalidCastException()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"
+Public Class MyAttribute
+    Inherits Attribute
+End Class
+
+Public Class MyController
+    Public Function GetNothing(
+        <MyAttribute()> Optional indexer As Integer? = 0
+    ) As String
+        Return Nothing
+    End Function
+End Class
+",
+@"using System;
+
+public partial class MyAttribute : Attribute
+{
+}
+
+public partial class MyController
+{
+    public string GetNothing([My()] int? indexer = 0)
+    {
+        return null;
+    }
+}");
+        }
+    }
+}


### PR DESCRIPTION
### Problem
Fixes an invalid cast exception when converting optional parameters from VB to C#

### Solution
* [x] At least one test covering the code changed

