### PR TITLE
Upgrade to dotnet 5

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,10 +22,14 @@ jobs:
         version: ${{ env.BuildVersion }}.${{ github.run_number }}
         assemblyVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
         fileVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
-    - name: Setup .NET for main build
+    - name: Setup .NET 3.1 for command line
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+    - name: Setup .NET 5 for main build
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,8 +32,6 @@ jobs:
        vs-version: '[16.6,)'
     - name: Publish all
       run: dotnet publish CodeConverter.sln /p:Configuration=$env:BuildTarget /p:Platform=$env:BuildPlatform
-    - name: Build vsix using legacy msbuild
-      run: msbuild Vsix/Vsix.csproj -restore /p:Configuration=$env:BuildTarget
     - name: Execute unit tests
       run: dotnet test $env:Tests1
       env:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,10 +22,6 @@ jobs:
         version: ${{ env.BuildVersion }}.${{ github.run_number }}
         assemblyVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
         fileVersion: ${{ env.BuildVersion }}.${{ github.run_number }}
-    - name: Setup .NET 3.1 for command line
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
     - name: Setup .NET 5 for main build
       uses: actions/setup-dotnet@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-
 ### Vsix
 
 

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>ICSharpCode.CodeConverter.Func</RootNamespace>
     <AssemblyName>ICSharpCode.CodeConverter.Func</AssemblyName>

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Currently, the VB -> C# conversion quality is higher than the C# -> VB conversio
   * Or check out the [ConverterController](https://github.com/icsharpcode/CodeConverter/blob/master/Web/ConverterController.cs) for a more web-focused API.
 
 ## Building/running from source
-1. Ensure you have [.NET Core SDK 3.1+](https://dotnet.microsoft.com/download/dotnet-core/3.1)
-2. Open the solution in Visual Studio 2017+
+1. Ensure you have [.NET SDK 5](https://dotnet.microsoft.com/download/)
+2. Open the solution in the most recent version of Visual Studio you have (VS2019+)
 3. To run the website, set CodeConverter.Web as the startup project
 4. To run the Visual Studio extension, set Vsix as the startup project
    * A new instance of Visual Studio will open with the extension installed

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -17,6 +17,8 @@
     <StartArguments>/rootsuffix $(VSSDKTargetPlatformRegRootSuffix)</StartArguments>
     <SignAssembly>false</SignAssembly>
     <DeployExtension Condition="'$(BuildingInsideVisualStudio)' != 'true'">False</DeployExtension>
+    <CopyVsixExtensionLocation>$(LocalAppData)\Microsoft\VisualStudio\15.0_8bd9890a\Extensions\frc3cnfo.23z</CopyVsixExtensionLocation>
+    <CopyVsixExtensionFiles Condition="Exists($(CopyVsixExtensionLocation))">True</CopyVsixExtensionFiles>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -1,17 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace>ICSharpCode.CodeConverter.VsExtension</RootNamespace>
     <AssemblyName>ICSharpCode.CodeConverter.VsExtension</AssemblyName>
-    <ProjectGuid>{99498EF8-C9E0-433B-8D7B-EA8E9E66F0C7}</ProjectGuid>
-    <ProjectTypeGuids>{82B43B9B-A64C-4715-B499-D71E9CA2BD60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -24,29 +18,6 @@
     <SignAssembly>false</SignAssembly>
     <DeployExtension Condition="'$(BuildingInsideVisualStudio)' != 'true'">False</DeployExtension>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
-    <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CopyVsixExtensionLocation>$(LocalAppData)\Microsoft\VisualStudio\15.0_8bd9890a\Extensions\frc3cnfo.23z</CopyVsixExtensionLocation>
-    <CopyVsixExtensionFiles Condition="Exists($(CopyVsixExtensionLocation))">True</CopyVsixExtensionFiles>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <!-- Build against VS 15.7 -->
@@ -106,72 +77,28 @@
     <None Include="source.extension.vsixmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.Design" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\CodeConverter\Shared\DefaultReferences.cs">
       <Link>DefaultReferences.cs</Link>
     </Compile>
     <Compile Include="..\CommandLine\CodeConv.Shared\Util\AppDomainExtensions.cs">
       <Link>AppDomainExtensions.cs</Link>
     </Compile>
-    <Compile Include="AssemblyInfo.cs" />
-    <Compile Include="OleMenuCommandWithBlockingStatus.cs" />
-    <Compile Include="CodeConversion.cs" />
-    <Compile Include="ConvertCSToVBCommand.cs" />
-    <Compile Include="ConverterOptionsPage.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="ConvertVBToCSCommand.cs" />
-    <Compile Include="OutputWindow.cs" />
-    <Compile Include="Cancellation.cs" />
-    <Compile Include="CodeConverterPackage.cs" />
-    <Compile Include="PasteAsCS.cs" />
-    <Compile Include="PasteAsVB.cs" />
-    <Compile Include="ServiceProviderExtensions.cs" />
-    <Compile Include="SolutionProjectExtensions.cs" />
-    <Compile Include="TaskExtensions.cs" />
-    <Compile Include="VisualStudioInteraction.cs" />
-    <Compile Include="VsDocument.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="VSPackage.resx">
-      <MergeWithCTO>true</MergeWithCTO>
-      <ManifestResourceName>VSPackage</ManifestResourceName>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="WindowsFormsIntegration" />
+    <ProjectReference Include="..\CodeConverter\CodeConverter.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CodeConverter\CodeConverter.csproj">
-      <Project>{7ea075c6-6406-445c-ab77-6c47aff88d58}</Project>
-      <Name>CodeConverter</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>ICSharpCode.CodeConverter.Web</RootNamespace>
     <AssemblyName>ICSharpCode.CodeConverter.Web</AssemblyName>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.0",
+    "version": "5.0.0",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The idea is to get on to a single set of build tools to:
* Simplify the project requirements
* Smooth out the VS experience
* Prepare for dot net 6

I'm using this as inspiration:
* https://stackoverflow.com/a/58947835/1128762
* https://github.com/VsVim/VsVim/blob/master/Src/VsVim2022/VsVim2022.csproj

No luck so far - it doesn't deploy the vsix on build. I'm going to wait a bit and hope Microsoft officially supports this properly