### PR TITLE
Fix NRE when a VB static variable has no initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### VB -> C#
 
+* No longer throws NRE for VB Static variable without initializer. [See comment on #623](https://github.com/icsharpcode/CodeConverter/issues/623#issuecomment-1009917188)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -111,7 +111,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 if (isVBStatic) {
                     foreach (var decl in localDeclarationStatementSyntaxs) {
                         var variable = decl.Declaration.Variables.Single();
-                        var initializeValue = variable.Initializer.Value;
+                        var initializeValue = variable.Initializer?.Value;
                         string methodName;
                         VBSyntax.MethodBaseSyntax methodOrSubNewStatement;
                         if (_methodNode is VBSyntax.MethodBlockSyntax methodBlock) {

--- a/CodeConverter/CSharp/PerScopeState.cs
+++ b/CodeConverter/CSharp/PerScopeState.cs
@@ -126,8 +126,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                 NameGenerator.GetUniqueVariableNameInScope(semanticModel, generatedNames, typeNode, f.FieldName)
             );
             foreach (var field in fieldInfo) {
-                var decl = CommonConversions.CreateVariableDeclarationAndAssignment(newNames[field.OriginalVariableName],
-                    field.Initializer, field.Type);
+                var decl = (field.Initializer != null) 
+                    ? CommonConversions.CreateVariableDeclarationAndAssignment(newNames[field.OriginalVariableName], field.Initializer, field.Type)
+                    : SyntaxFactory.VariableDeclaration(field.Type, SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(newNames[field.OriginalVariableName])));
                 var modifiers = new List<SyntaxToken> { CS.SyntaxFactory.Token(SyntaxKind.PrivateKeyword) };
                 if (field.IsStatic || namedTypeSymbol.IsModuleType()) {
                     modifiers.Add(CS.SyntaxFactory.Token(SyntaxKind.StaticKeyword));

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -2507,6 +2507,32 @@ internal partial class StaticLocalConvertedToField
         }
 
         [Fact]
+        public async Task TestStaticLocalWithoutDefaultInitializerConvertedToFieldAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+@"Class StaticLocalConvertedToField
+    Function OtherName() as Integer
+        Static sPrevPosition As Integer
+        sPrevPosition = 23
+        Console.WriteLine(sPrevPosition)
+        Return sPrevPosition
+    End Function
+End Class", @"using System;
+
+internal partial class StaticLocalConvertedToField
+{
+    private int _OtherName_sPrevPosition;
+
+    public int OtherName()
+    {
+        _OtherName_sPrevPosition = 23;
+        Console.WriteLine(_OtherName_sPrevPosition);
+        return _OtherName_sPrevPosition;
+    }
+}");
+        }
+
+        [Fact]
         public async Task TestModuleStaticLocalConvertedToStaticFieldAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
[See comment on #623](https://github.com/icsharpcode/CodeConverter/issues/623#issuecomment-1009917188)

### Problem
When there is no initializer, and also no default initializer is generated because the value is always assigned before the first read, an NRE is thrown because the field generation assumes there always is an initializer.

### Solution
* The field is now generated without an initializer in that case.
* Alternatively, the field could be entirely omitted and the VB Static keyword ignored, because the value is always overwritten anyways, but this way it is closer to the original VB code.
* [x] At least one test covering the code changed

