### PR TITLE
Use new XElement(...) instead of XElement.Parse(...)  for conversions of XML expressions from VB to C#

### DIFF
--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -25,7 +25,7 @@ internal partial class TestClass
     private void TestMethod()
     {
         string hello = ""Hello"";
-        XElement x = XElement.Parse($@""<h1>{hello}</h1>"");
+        XElement x = new XElement(""h1"", hello);
     }
 }");
         }
@@ -47,7 +47,7 @@ internal partial class TestClass
     {
         int var1 = 1;
         int var2 = 2;
-        XElement x = XElement.Parse($@""<h1>{var1}{var2}<span>{var2}{var1}</span> </h1>"");
+        XElement x = new XElement(""h1"", var1, var2, new XElement(""span"", var2, var1));
     }
 }");
         }
@@ -110,15 +110,14 @@ internal partial class TestClass
 {
     private void TestMethod()
     {
-        XDocument catalog = XElement.Parse($@""<Catalog> <Book id=""""bk101""""> <Author>{""Garghentini, Davide""}</Author> <Title>{""XML Developer's Guide""}</Title> <Price>{""44.95""}</Price> <Description>{""\r\n          An in-depth look at creating applications\r\n          with ""}<technology>{""XML""}</technology>{"". For\r\n          ""}<audience>{""beginners""}</audience>{"" or\r\n          ""}<audience>{""advanced""}</audience>{"" developers.\r\n        ""}</Description> </Book> <Book id=""""bk331""""> <Author>{""Spencer, Phil""}</Author> <Title>{""Developing Applications with Visual Basic .NET""}</Title> <Price>{""45.95""}</Price> <Description>{""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with ""}<technology>{""Visual\r\n          Basic .NET""}</technology>{"".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top ""}<audience>{""developers""}</audience>{"".\r\n        ""}</Description> </Book> </Catalog>"");
-        XElement htmlOutput = XElement.Parse($@""<html> <body>{from book in catalog.Elements(""Catalog"").Elements(""Book"")
-                                                              select XElement.Parse($@""<div> <h1>{book.Elements(""Title"").Value}</h1> <h3>{""By "" + book.Elements(""Author"").Value}</h3> <h3>{""Price = "" + book.Elements(""Price"").Value}</h3> <h2>{""Description""}</h2>{TransformDescription(book.Elements(""Description"").ElementAtOrDefault(0))}{""<hr/>""}</div>"")}</body> </html>"");
+        XDocument catalog = new XDocument(new XElement(""Catalog"", new XElement(""Book"", new XAttribute(""id"", ""bk101""), new XElement(""Author"", ""Garghentini, Davide""), new XElement(""Title"", ""XML Developer's Guide""), new XElement(""Price"", ""44.95""), new XElement(""Description"", ""\r\n          An in-depth look at creating applications\r\n          with "", new XElement(""technology"", ""XML""), "". For\r\n          "", new XElement(""audience"", ""beginners""), "" or\r\n          "", new XElement(""audience"", ""advanced""), "" developers.\r\n        "")), new XElement(""Book"", new XAttribute(""id"", ""bk331""), new XElement(""Author"", ""Spencer, Phil""), new XElement(""Title"", ""Developing Applications with Visual Basic .NET""), new XElement(""Price"", ""45.95""), new XElement(""Description"", ""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with "", new XElement(""technology"", ""Visual\r\n          Basic .NET""), "".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top "", new XElement(""audience"", ""developers""), "".\r\n        ""))));
+        XElement htmlOutput = new XElement(""html"", new XElement(""body"", from book in catalog.Elements(""Catalog"").Elements(""Book"")
+                                                                        select new XElement(""div"", new XElement(""h1"", book.Elements(""Title"").Value), new XElement(""h3"", ""By "" + book.Elements(""Author"").Value), new XElement(""h3"", ""Price = "" + book.Elements(""Price"").Value), new XElement(""h2"", ""Description""), TransformDescription(book.Elements(""Description"").ElementAtOrDefault(0)), new XElement(""hr""))));
     }
 }
 1 source compilation errors:
 BC36610: Name 'TransformDescription' is either not declared or not in the current scope.
-3 target compilation errors:
-CS0029: Cannot implicitly convert type 'System.Xml.Linq.XElement' to 'System.Xml.Linq.XDocument'
+2 target compilation errors:
 CS1061: 'IEnumerable<XElement>' does not contain a definition for 'Value' and no accessible extension method 'Value' accepting a first argument of type 'IEnumerable<XElement>' could be found (are you missing a using directive or an assembly reference?)
 CS0103: The name 'TransformDescription' does not exist in the current context",
 hasLineCommentConversionIssue: true);
@@ -140,8 +139,73 @@ internal partial class TestClass
 {
     private void TestMethod()
     {
-        XElement b = XElement.Parse($@""<someXmlTag> </someXmlTag>"");
-        XElement c = XElement.Parse($@""<someXmlTag> <bla anAttribute=""""itsValue"""">{""tata""}</bla> <someContent>{""tata""}</someContent> </someXmlTag>"");
+        XElement b = new XElement(""someXmlTag"");
+        XElement c = new XElement(""someXmlTag"", new XElement(""bla"", new XAttribute(""anAttribute"", ""itsValue""), ""tata""), new XElement(""someContent"", ""tata""));
+    }
+}");
+        }
+
+
+
+        [Fact]
+        public async Task AssignmentStatementWithXmlElementAndEmbeddedExpressionAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Const value1 = ""something""
+        Dim xElement = <Elem1 Attr1=<%= value1 %> Attr2=<%= 100 %>></Elem1>
+    End Sub
+End Class", @"using System.Xml.Linq;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        const string value1 = ""something"";
+        XElement xElement = new XElement(""Elem1"", new XAttribute(""Attr1"", value1), new XAttribute(""Attr2"", 100));
+    }
+}");
+        }
+
+
+
+        [Fact]
+        public async Task SelfClosingXmlTagAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()       
+        Dim xElement = <Elem1 Attr1=""something"" />
+    End Sub
+End Class", @"using System.Xml.Linq;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        XElement xElement = new XElement(""Elem1"", new XAttribute(""Attr1"", ""something""));
+    }
+}");
+        }
+
+
+
+        [Fact]
+        public async Task ConditionalMemberAccessAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()       
+        Dim xDocument = <Test></Test>
+        Dim elements1 = xDocument.<Something>.SingleOrDefault()?.<SomethingElse>
+    End Sub
+End Class", @"using System.Linq;
+using System.Xml.Linq;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        XElement xDocument = new XElement(""Test"");
+        var elements1 = xDocument.Elements(""Something"").SingleOrDefault()?.Elements(""SomethingElse"");
     }
 }");
         }


### PR DESCRIPTION
Fixes #253

### Problem

* The current implementation does not handle embedded expressions well

Also, there are some other minor problems surrounding XML:

* XDocument is assigned using XElement instead (leading to compile error)
* Self-Closing tags are converted incorrectly
* Conditional access (?.) on XML expression throws ArgumentNullException during conversion

### Solution

* Use a per-member visiting approach to construct an actual expression instead of calling XElement.Parse() at runtime (I think that is much closer to what VB actually does)
* Use XDocument constructor in VisitXmlDocument
* Implement VisitXmlEmptyElement to correctly convert self-closing tags
* Use MemberBindingExpression in VisitXmlMemberAccessExpression when node.Base is null (such is the case for conditional access)

The new approach may leave some of the more obscure XML constructs uncovered (falling back to DefaultVisit and thowing a not implemented error) but I think any code that uses those would not convert under the current code either.

* [x] At least one test covering the code changed

