### PR TITLE
Fix access modifiers for explicit interface implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 ### VB -> C#
-
+* Fix access modifiers for explicit interface implementations. [#819](https://github.com/icsharpcode/CodeConverter/issues/819)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -655,7 +655,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var csIdentifier = CommonConversions.ConvertIdentifier(node.Identifier);
             var additionalDeclarations = new List<MemberDeclarationSyntax>();
 
-            var explicitInterfaceSpecifier = IsPrivateInterfaceImplementation(propSymbol) || IsRenamedInterfaceMember(propSymbol, directlyConvertedCsIdentifier, csIdentifier)
+            var explicitInterfaceSpecifier = IsNonPublicInterfaceImplementation(propSymbol) || IsRenamedInterfaceMember(propSymbol, directlyConvertedCsIdentifier, csIdentifier)
                 ? SyntaxFactory.ExplicitInterfaceSpecifier(CommonConversions.GetFullyQualifiedNameSyntax(propSymbol.ExplicitInterfaceImplementations.First().ContainingType))
                 : null;
 
@@ -744,10 +744,13 @@ namespace ICSharpCode.CodeConverter.CSharp
 
             AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceMemberIdentifiers, interfaceDeclParams);
 
-            var renamedInterfaceImplDeclParams = new PropertyDeclarationParameters(attributes, originalModifiers,
-                rawType, accessorList, directlyConvertedCsIdentifier);
+            if (isExplicitInterfaceImplementation) 
+            {
+                var renamedInterfaceImplDeclParams = new PropertyDeclarationParameters(attributes, originalModifiers,
+                    rawType, accessorList, directlyConvertedCsIdentifier);
 
-            AddInterfaceMemberDeclaration(interfaceMemberIdentifiers, propSymbol, additionalDeclarations, renamedInterfaceImplDeclParams);
+                AddInterfaceMemberDeclaration(additionalDeclarations, renamedInterfaceImplDeclParams);
+            }
 
             if (accessedThroughMyClass) {
 
@@ -948,7 +951,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var declaredPropSymbol = containingPropertyStmt != null ? _semanticModel.GetDeclaredSymbol(containingPropertyStmt) : null;
 
             string potentialMethodId;
-            var explicitInterfaceSpecifier = declaredPropSymbol is { } propSymbol && IsPrivateInterfaceImplementation(propSymbol)
+            var explicitInterfaceSpecifier = declaredPropSymbol is { } propSymbol && IsNonPublicInterfaceImplementation(propSymbol)
                 ? SyntaxFactory.ExplicitInterfaceSpecifier(SyntaxFactory.IdentifierName(propSymbol.ExplicitInterfaceImplementations.First().ContainingType.Name))
                 : null;
 
@@ -1148,137 +1151,135 @@ namespace ICSharpCode.CodeConverter.CSharp
             var attributes = await CommonConversions.ConvertAttributesAsync(node.AttributeLists);
             bool hasBody = node.Parent is VBSyntax.MethodBlockBaseSyntax;
 
-            if ("Finalize".Equals(node.Identifier.ValueText, StringComparison.OrdinalIgnoreCase)
-                && node.Modifiers.Any(m => VBasic.VisualBasicExtensions.Kind(m) == VBasic.SyntaxKind.OverridesKeyword)) {
-                var decl = SyntaxFactory.DestructorDeclaration(CommonConversions.ConvertIdentifier(node.GetAncestor<VBSyntax.TypeBlockSyntax>().BlockStatement.Identifier)
-                ).WithAttributeLists(attributes);
-                if (hasBody) return decl;
-                return decl.WithSemicolonToken(SemicolonToken);
-            } else {
-                var tokenContext = GetMemberContext(node);
-                var declaredSymbol = (IMethodSymbol)ModelExtensions.GetDeclaredSymbol(_semanticModel, node);
-                var extraCsModifierKinds = declaredSymbol?.IsExtern == true ? new[] { Microsoft.CodeAnalysis.CSharp.SyntaxKind.ExternKeyword } : Array.Empty<Microsoft.CodeAnalysis.CSharp.SyntaxKind>();
-                var convertedModifiers = CommonConversions.ConvertModifiers(node, node.Modifiers, tokenContext, extraCsModifierKinds: extraCsModifierKinds);
+            if ("Finalize".Equals(node.Identifier.ValueText, StringComparison.OrdinalIgnoreCase) && 
+                node.Modifiers.Any(m => VBasic.VisualBasicExtensions.Kind(m) == VBasic.SyntaxKind.OverridesKeyword)) 
+            {
+                var declaration = SyntaxFactory.
+                    DestructorDeclaration(CommonConversions.ConvertIdentifier(node.GetAncestor<VBSyntax.TypeBlockSyntax>().BlockStatement.Identifier)).
+                    WithAttributeLists(attributes);
+                return hasBody ? declaration : declaration.WithSemicolonToken(SemicolonToken);
+            } 
+            
+            var tokenContext = GetMemberContext(node);
+            var declaredSymbol = (IMethodSymbol)ModelExtensions.GetDeclaredSymbol(_semanticModel, node);
+            var extraCsModifierKinds = declaredSymbol?.IsExtern == true ? new[] { CSSyntaxKind.ExternKeyword } : Array.Empty<CSSyntaxKind>();
+            var convertedModifiers = CommonConversions.ConvertModifiers(node, node.Modifiers, tokenContext, extraCsModifierKinds: extraCsModifierKinds);
 
-                bool accessedThroughMyClass = IsAccessedThroughMyClass(node, node.Identifier, declaredSymbol);
+            bool accessedThroughMyClass = IsAccessedThroughMyClass(node, node.Identifier, declaredSymbol);
 
-                var isPartialDefinition = declaredSymbol.IsPartialMethodDefinition();
-
-                if (declaredSymbol.IsPartialMethodImplementation() || isPartialDefinition) {
-                    var privateModifier = convertedModifiers.SingleOrDefault(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PrivateKeyword));
-                    if (privateModifier != default) {
-                        convertedModifiers = convertedModifiers.Remove(privateModifier);
-                    }
-                    if (!HasPartialKeyword(node.Modifiers)) {
-                        convertedModifiers = convertedModifiers.Add(SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PartialKeyword));
-                    }
+            if (declaredSymbol.IsPartialMethodImplementation() || declaredSymbol.IsPartialMethodDefinition()) 
+            {
+                var privateModifier = convertedModifiers.SingleOrDefault(m => m.IsKind(CSSyntaxKind.PrivateKeyword));
+                if (privateModifier != default) {
+                    convertedModifiers = convertedModifiers.Remove(privateModifier);
                 }
-                var (typeParameters, constraints) = await SplitTypeParametersAsync(node.TypeParameterList);
+                if (!HasPartialKeyword(node.Modifiers)) {
+                    convertedModifiers = convertedModifiers.Add(SyntaxFactory.Token(CSSyntaxKind.PartialKeyword));
+                }
+            }
+            var (typeParameters, constraints) = await SplitTypeParametersAsync(node.TypeParameterList);
 
-                var returnType = (declaredSymbol != null ? CommonConversions.GetTypeSyntax(declaredSymbol.ReturnType) :
-                    await (node.AsClause?.Type).AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.VoidKeyword)));
+            var returnType = (declaredSymbol != null ? CommonConversions.GetTypeSyntax(declaredSymbol.ReturnType) :
+                await (node.AsClause?.Type).AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(CSSyntaxKind.VoidKeyword)));
 
-                var directlyConvertedCsIdentifier = CommonConversions.CsEscapedIdentifier(node.Identifier.Value as string);
-                var csIdentifier = CommonConversions.ConvertIdentifier(node.Identifier);
-                var parameterList = await node.ParameterList.AcceptAsync<ParameterListSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.ParameterList();
-                var additionalDeclarations = new List<MemberDeclarationSyntax>();
+            var directlyConvertedCsIdentifier = CommonConversions.CsEscapedIdentifier(node.Identifier.Value as string);
+            var csIdentifier = CommonConversions.ConvertIdentifier(node.Identifier);
+            var parameterList = await node.ParameterList.AcceptAsync<ParameterListSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.ParameterList();
+            var additionalDeclarations = new List<MemberDeclarationSyntax>();
 
-                var explicitInterfaceSpecifier = IsPrivateInterfaceImplementation(declaredSymbol) || IsRenamedInterfaceMember(declaredSymbol, directlyConvertedCsIdentifier, csIdentifier)
-                    ? SyntaxFactory.ExplicitInterfaceSpecifier(CommonConversions.GetFullyQualifiedNameSyntax(declaredSymbol.ExplicitInterfaceImplementations.First().ContainingType))
-                    : null;
+            var explicitInterfaceSpecifier = IsNonPublicInterfaceImplementation(declaredSymbol) || IsRenamedInterfaceMember(declaredSymbol, directlyConvertedCsIdentifier, csIdentifier)
+                ? SyntaxFactory.ExplicitInterfaceSpecifier(CommonConversions.GetFullyQualifiedNameSyntax(declaredSymbol.ExplicitInterfaceImplementations.First().ContainingType))
+                : null;
 
-                var additionalInterfaceImplements = explicitInterfaceSpecifier != null
-                    ? declaredSymbol.ExplicitInterfaceImplementations.Skip(1)
-                    : ImmutableArray<IMethodSymbol>.Empty;
+            var additionalInterfaceImplements = explicitInterfaceSpecifier != null
+                ? declaredSymbol.ExplicitInterfaceImplementations.Skip(1)
+                : ImmutableArray<IMethodSymbol>.Empty;
 
-                var originalConvertedModifiers = convertedModifiers;
-                var originalParameterList = parameterList;
+            var originalConvertedModifiers = convertedModifiers;
+            var originalParameterList = parameterList;
 
-                var filteredModifiers = convertedModifiers.RemoveOnly(m => m.IsCsMemberVisibility());
-                var requiredParameterList = MakeOptionalParametersRequired(parameterList);
+            var filteredModifiers = convertedModifiers.RemoveOnly(m => m.IsCsMemberVisibility());
+            var requiredParameterList = MakeOptionalParametersRequired(parameterList);
 
-                var interfaceMemberIdentifiers = new List<SyntaxToken> { csIdentifier };
+            var interfaceMemberIdentifiers = new List<SyntaxToken> { csIdentifier };
 
-                var clause = GetDelegatingClause(explicitInterfaceSpecifier, csIdentifier,
-                    requiredParameterList, false);
+            var clause = GetDelegatingClause(explicitInterfaceSpecifier, csIdentifier,
+                requiredParameterList, false);
 
-                var interfaceDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers, returnType, typeParameters, requiredParameterList, constraints, clause);
+            var interfaceDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers, returnType, typeParameters, requiredParameterList, constraints, clause);
 
-                AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceMemberIdentifiers, interfaceDeclParams);
+            AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceMemberIdentifiers, interfaceDeclParams);
 
+            if (explicitInterfaceSpecifier != null) 
+            {
                 var renamedInterfaceImplDeclParams = new MethodDeclarationParameters(attributes, originalConvertedModifiers,
                     returnType, typeParameters, originalParameterList, constraints, clause, directlyConvertedCsIdentifier);
 
-                AddInterfaceMemberDeclaration(interfaceMemberIdentifiers, declaredSymbol, additionalDeclarations, renamedInterfaceImplDeclParams);
+                AddInterfaceMemberDeclaration(additionalDeclarations, renamedInterfaceImplDeclParams);
+            }
 
-                // If the method is virtual, and there is a MyClass.SomeMethod() call,
-                // we need to emit a non-virtual method for it to call
-                if (accessedThroughMyClass) {
-                    var identifierName = "MyClass" + directlyConvertedCsIdentifier.ValueText;
-                    var arrowClause = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(identifierName), CreateDelegatingArgList(parameterList)));
-                    var declModifiers = convertedModifiers;
+            // If the method is virtual, and there is a MyClass.SomeMethod() call,
+            // we need to emit a non-virtual method for it to call
+            if (accessedThroughMyClass) {
+                var identifierName = "MyClass" + directlyConvertedCsIdentifier.ValueText;
+                var arrowClause = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(identifierName), CreateDelegatingArgList(parameterList)));
+                var declModifiers = convertedModifiers;
 
-                    // If an extra delegate method is emitted already because of interface method renaming,
-                    // don't emit the virtual and accessor modifiers on the explicit implementation. 
-                    if (interfaceMemberIdentifiers.Any(identifier => IsRenamedInterfaceMember(declaredSymbol,
-                        renamedInterfaceImplDeclParams.Identifier, identifier))) {
-                        declModifiers = declModifiers.RemoveOnly(m => m.IsCsMemberVisibility())
-                           .RemoveOnly(m => m.IsKind(CSSyntaxKind.VirtualKeyword));
-                    }
-
-                    var originalNameDecl = SyntaxFactory.MethodDeclaration(
-                        attributes,
-                        declModifiers,
-                        returnType,
-                        explicitInterfaceSpecifier,
-                        csIdentifier,
-                        typeParameters,
-                        parameterList,
-                        constraints,
-                        null,
-                        arrowClause,
-                        SyntaxFactory.Token(CSSyntaxKind.SemicolonToken)
-                    );
-
-                    additionalDeclarations.Add(originalNameDecl);
-                    convertedModifiers = convertedModifiers.Remove(convertedModifiers.Single(m => m.IsKind(CSSyntaxKind.VirtualKeyword)));
-                    csIdentifier = SyntaxFactory.Identifier(identifierName);
-                    explicitInterfaceSpecifier = null;
-                } else if (explicitInterfaceSpecifier != null) {
-                    convertedModifiers = filteredModifiers;
-                    parameterList = requiredParameterList;
+                // If an extra delegate method is emitted already because of interface method renaming,
+                // don't emit the virtual and accessor modifiers on the explicit implementation. 
+                if (explicitInterfaceSpecifier != null) 
+                {
+                    declModifiers = declModifiers
+                        .RemoveOnly(m => m.IsCsMemberVisibility())
+                        .RemoveOnly(m => m.IsKind(CSSyntaxKind.VirtualKeyword));
                 }
 
-                if (additionalDeclarations.Any()) {
-                    var declNode = (VBSyntax.StatementSyntax)node.Parent;
-                    _additionalDeclarations.Add(declNode, additionalDeclarations.ToArray());
-                }
-
-                var decl = SyntaxFactory.MethodDeclaration(
+                var originalNameDecl = SyntaxFactory.MethodDeclaration(
                     attributes,
-                    convertedModifiers,
+                    declModifiers,
                     returnType,
                     explicitInterfaceSpecifier,
                     csIdentifier,
                     typeParameters,
                     parameterList,
                     constraints,
-                    null,//Body added by surrounding method block if appropriate
-                    null
+                    null,
+                    arrowClause,
+                    SyntaxFactory.Token(CSSyntaxKind.SemicolonToken)
                 );
-                return hasBody && declaredSymbol.CanHaveMethodBody() ? decl : decl.WithSemicolonToken(SemicolonToken);
+
+                additionalDeclarations.Add(originalNameDecl);
+                convertedModifiers = convertedModifiers.Remove(convertedModifiers.Single(m => m.IsKind(CSSyntaxKind.VirtualKeyword)));
+                csIdentifier = SyntaxFactory.Identifier(identifierName);
+                explicitInterfaceSpecifier = null;
+            } else if (explicitInterfaceSpecifier != null) {
+                convertedModifiers = filteredModifiers;
+                parameterList = requiredParameterList;
             }
+
+            if (additionalDeclarations.Any()) {
+                var declNode = (VBSyntax.StatementSyntax)node.Parent;
+                _additionalDeclarations.Add(declNode, additionalDeclarations.ToArray());
+            }
+
+            var decl = SyntaxFactory.MethodDeclaration(
+                attributes,
+                convertedModifiers,
+                returnType,
+                explicitInterfaceSpecifier,
+                csIdentifier,
+                typeParameters,
+                parameterList,
+                constraints,
+                null,//Body added by surrounding method block if appropriate
+                null
+            );
+
+            return hasBody && declaredSymbol.CanHaveMethodBody() ? decl : decl.WithSemicolonToken(SemicolonToken);
         }
 
-        private static void AddInterfaceMemberDeclaration(IEnumerable<SyntaxToken> interfaceMemberIdentifiers, ISymbol symbol,
-            ICollection<MemberDeclarationSyntax> additionalDeclarations, DeclarationParameters interfaceImplDeclParams)
+        private static void AddInterfaceMemberDeclaration(ICollection<MemberDeclarationSyntax> additionalDeclarations, DeclarationParameters interfaceImplDeclParams)
         {
-            // If we had to rename the method to match the interface, emit a method for external references with the old name to point to
-            if (!interfaceMemberIdentifiers.Any(identifier => IsRenamedInterfaceMember(symbol,
-                interfaceImplDeclParams.Identifier, identifier))) {
-                return;
-            }
-
             var semicolonToken = SyntaxFactory.Token(Microsoft.CodeAnalysis.CSharp.SyntaxKind.SemicolonToken);
 
             Func<MemberDeclarationSyntax>
@@ -1428,12 +1429,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             return simpleMemberAccess;
         }
 
-        private static bool IsPrivateInterfaceImplementation(ISymbol declaredSymbol)
+        private static bool IsNonPublicInterfaceImplementation(ISymbol declaredSymbol)
         {
             return declaredSymbol switch {
-                IMethodSymbol methodSymbol => methodSymbol.DeclaredAccessibility == Accessibility.Private &&
+                IMethodSymbol methodSymbol => methodSymbol.DeclaredAccessibility != Accessibility.Public &&
                                               methodSymbol.ExplicitInterfaceImplementations.Any(),
-                IPropertySymbol propertySymbol => propertySymbol.DeclaredAccessibility == Accessibility.Private &&
+                IPropertySymbol propertySymbol => propertySymbol.DeclaredAccessibility != Accessibility.Public &&
                                                   propertySymbol.ExplicitInterfaceImplementations.Any(),
                 _ => throw new ArgumentOutOfRangeException(nameof(declaredSymbol))
             };

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -666,7 +666,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 : ImmutableArray<IPropertySymbol>.Empty;
 
             var originalModifiers = modifiers;
-            var filteredModifiers = modifiers.RemoveOnly(m => m.IsCsMemberVisibility());
+            var filteredModifiers = modifiers.RemoveOnly(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword));
             var interfaceMemberIdentifiers = new List<SyntaxToken> { csIdentifier };
 
             var shouldConvertToMethods = ShouldConvertAsParameterizedProperty(node);
@@ -756,7 +756,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 var realModifiers = modifiers.RemoveOnly(m => m.IsKind(CSSyntaxKind.PrivateKeyword));
                 string csIndentifierName = AddRealPropertyDelegatingToMyClassVersion(node, csIdentifier, attributes, realModifiers, rawType);
-                modifiers = modifiers.Remove(modifiers.Single(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.VirtualKeyword)));
+                modifiers = modifiers.Remove(modifiers.Single(m => m.IsKind(CSSyntaxKind.VirtualKeyword)));
                 csIdentifier = SyntaxFactory.Identifier(csIndentifierName);
             } else if (explicitInterfaceSpecifier != null) {
                 modifiers = filteredModifiers;
@@ -1198,7 +1198,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             var originalConvertedModifiers = convertedModifiers;
             var originalParameterList = parameterList;
 
-            var filteredModifiers = convertedModifiers.RemoveOnly(m => m.IsCsMemberVisibility());
+            var filteredModifiers = convertedModifiers.RemoveOnly(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword));
             var requiredParameterList = MakeOptionalParametersRequired(parameterList);
 
             var interfaceMemberIdentifiers = new List<SyntaxToken> { csIdentifier };

--- a/CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -146,8 +146,12 @@ namespace ICSharpCode.CodeConverter.Util
 
         public static SyntaxTokenList RemoveOnly(this SyntaxTokenList list, Func<SyntaxToken, bool> where)
         {
-            var toRemove = list.OnlyOrDefault(where);
-            if (toRemove != default) list = list.Remove(toRemove);
+            for (int i = 0; i < list.Count; ++i) {
+                if (!where(list[i])) continue;
+
+                list = list.RemoveAt(i--);
+            }
+
             return list;
         }
     }

--- a/Tests/CSharp/ExpressionTests/ByRefTests.cs
+++ b/Tests/CSharp/ExpressionTests/ByRefTests.cs
@@ -331,6 +331,8 @@ public partial class Foo : IFoo
     {
         return 5;
     }
+
+    private int ExplicitFunc([Optional, DefaultParameterValue("""")] ref string str) => ((IFoo)this).ExplicitFunc(ref str);
 }");
         }
 

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -2061,6 +2061,8 @@ public partial class Foo : IFoo
         return 5;
     }
 
+    private int ExplicitFunc(ref string str, int i) => ((IFoo)this).ExplicitFunc(ref str, i);
+
     int IFoo.get_ExplicitProp(string str)
     {
         return 5;
@@ -2104,6 +2106,11 @@ public partial class Foo : IFoo, IBar
 {
     int IFoo.ExplicitProp { get; set; }
     int IBar.ExplicitProp
+    {
+        get => ((IFoo)this).ExplicitProp;
+        set => ((IFoo)this).ExplicitProp = value;
+    }
+    private int ExplicitProp
     {
         get => ((IFoo)this).ExplicitProp;
         set => ((IFoo)this).ExplicitProp = value;
@@ -2161,8 +2168,118 @@ public partial class Foo : IFoo, IBar
     int IBar.ExplicitProp
     {
         get => ((IFoo)this).ExplicitProp;
+        set => ((IFoo)this).ExplicitProp = value;
+    }
+    private int ExplicitProp
+    {
+        get => ((IFoo)this).ExplicitProp;
         set => ((IFoo)this).ExplicitProp = value; // Comment moves because this line gets split
     }
+}");
+        }
+
+        [Fact]
+        public async Task NonPublicPropertyImplementsInterfacesAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"Public Interface IFoo
+    Property FriendProp As Integer
+    Sub ProtectedSub()
+    Function PrivateFunc() As Integer
+    Sub ProtectedInternalSub()
+End Interface
+
+Public Interface IBar
+    Property FriendProp As Integer
+    Sub ProtectedSub()
+    Function PrivateFunc() As Integer
+    Sub ProtectedInternalSub()
+End Interface
+
+Public Class Foo
+    Implements IFoo, IBar
+    
+    Friend Property FriendProp As Integer Implements IFoo.FriendProp, IBar.FriendProp ' Comment moves because this line gets split
+        Get
+          Return 5
+        End Get
+        Set
+        End Set
+    End Property
+
+    Protected Sub ProtectedSub() Implements IFoo.ProtectedSub, IBar.ProtectedSub
+    End Sub
+
+    Private Function PrivateFunc() As Integer Implements IFoo.PrivateFunc, IBar.PrivateFunc
+    End Function
+
+    Protected Friend Overridable Sub ProtectedInternalSub() Implements IFoo.ProtectedInternalSub, IBar.ProtectedInternalSub
+    End Sub
+End Class", @"
+public partial interface IFoo
+{
+    int FriendProp { get; set; }
+
+    void ProtectedSub();
+    int PrivateFunc();
+    void ProtectedInternalSub();
+}
+
+public partial interface IBar
+{
+    int FriendProp { get; set; }
+
+    void ProtectedSub();
+    int PrivateFunc();
+    void ProtectedInternalSub();
+}
+
+public partial class Foo : IFoo, IBar
+{
+    int IFoo.FriendProp
+    {
+        get
+        {
+            return 5;
+        }
+
+        set
+        {
+        }
+    }
+
+    int IBar.FriendProp
+    {
+        get => ((IFoo)this).FriendProp;
+        set => ((IFoo)this).FriendProp = value;
+    }
+    internal int FriendProp
+    {
+        get => ((IFoo)this).FriendProp;
+        set => ((IFoo)this).FriendProp = value; // Comment moves because this line gets split
+    }
+
+    void IFoo.ProtectedSub()
+    {
+    }
+
+    void IBar.ProtectedSub() => ((IFoo)this).ProtectedSub();
+    protected void ProtectedSub() => ((IFoo)this).ProtectedSub();
+
+    int IFoo.PrivateFunc()
+    {
+        return default;
+    }
+
+    int IBar.PrivateFunc() => ((IFoo)this).PrivateFunc();
+    private int PrivateFunc() => ((IFoo)this).PrivateFunc();
+
+    void IFoo.ProtectedInternalSub()
+    {
+    }
+
+    void IBar.ProtectedInternalSub() => ((IFoo)this).ProtectedInternalSub();
+    protected internal virtual void ProtectedInternalSub() => ((IFoo)this).ProtectedInternalSub();
 }");
         }
 
@@ -2308,6 +2425,7 @@ public partial class Foo : IFoo, IBar
     }
 
     int IBar.ExplicitFunc(ref string str, int i) => ((IFoo)this).ExplicitFunc(ref str, i);
+    private int ExplicitFunc(ref string str, int i) => ((IFoo)this).ExplicitFunc(ref str, i);
 
     int IFoo.get_ExplicitProp(string str)
     {
@@ -2360,6 +2478,8 @@ public partial class Foo : IFoo
     {
         return 5;
     }
+
+    private int ExplicitFunc(string str = """", int i2 = 1) => ((IFoo)this).ExplicitFunc(str, i2);
 
     int IFoo.get_ExplicitProp(string str)
     {

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -2076,6 +2076,68 @@ public partial class Foo : IFoo
         }
 
         [Fact]
+        public async Task PropertyInterfaceImplementationKeepsVirtualModifierAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"Public Interface IFoo
+    Property PropParams(str As String) As Integer
+    Property Prop() As Integer
+End Interface
+
+Public Class Foo
+    Implements IFoo
+
+    Public Overridable Property PropParams(str As String) As Integer Implements IFoo.PropParams
+        Get
+            Return 5
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+
+    Public Overridable Property Prop As Integer Implements IFoo.Prop
+        Get
+            Return 5
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int get_PropParams(string str);
+    void set_PropParams(string str, int value);
+
+    int Prop { get; set; }
+}
+
+public partial class Foo : IFoo
+{
+    public virtual int get_PropParams(string str)
+    {
+        return 5;
+    }
+
+    public virtual void set_PropParams(string str, int value)
+    {
+    }
+
+    public virtual int Prop
+    {
+        get
+        {
+            return 5;
+        }
+
+        set
+        {
+        }
+    }
+}
+");
+        }
+
+        [Fact]
         public async Task PrivateAutoPropertyImplementsMultipleInterfacesAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(
@@ -2282,7 +2344,7 @@ public partial class Foo : IFoo, IBar
     protected internal virtual void ProtectedInternalSub() => ((IFoo)this).ProtectedInternalSub();
 }");
         }
-
+        
         [Fact]
         public async Task ReadonlyRenamedPropertyImplementsMultipleInterfacesAsync()
         {

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -2179,7 +2179,7 @@ public partial class Foo : IFoo, IBar
         }
 
         [Fact]
-        public async Task NonPublicPropertyImplementsInterfacesAsync()
+        public async Task NonPublicImplementsInterfacesAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(
                 @"Public Interface IFoo
@@ -2199,7 +2199,7 @@ End Interface
 Public Class Foo
     Implements IFoo, IBar
     
-    Friend Property FriendProp As Integer Implements IFoo.FriendProp, IBar.FriendProp ' Comment moves because this line gets split
+    Friend Overridable Property FriendProp As Integer Implements IFoo.FriendProp, IBar.FriendProp ' Comment moves because this line gets split
         Get
           Return 5
         End Get
@@ -2253,7 +2253,7 @@ public partial class Foo : IFoo, IBar
         get => ((IFoo)this).FriendProp;
         set => ((IFoo)this).FriendProp = value;
     }
-    internal int FriendProp
+    internal virtual int FriendProp
     {
         get => ((IFoo)this).FriendProp;
         set => ((IFoo)this).FriendProp = value; // Comment moves because this line gets split


### PR DESCRIPTION
Fixes #819. Ignore whitespaces when reviewing - I had to remove one big indentation.

1. I noticed that there is a problem with ```RemoveOnly``` method. The name suggests that it will remove all modifiers that are matching the predicate but in reality, it was removing modifiers only if exactly one match was found in the list.
It wasn't working correctly for methods with ```protected internal``` because two modifiers were matched so nothing was removed.
You can see this behavior in the converted code for ```IFoo.ExplicitProperty``` in #819.

2. Method ```IsPrivateInterfaceImplementation``` was renamed to ```IsNonPublicInterfaceImplementation``` and the condition was changed so any non-public interface implementation returns true.

3. Allowed generating delegating members not only for "interface implementation was renamed" case but also for non-public interface implementations.

4. Similar problems were with ```virtual``` keyword being added to explicit implementation.
5. I didn't fix parametrized properties (i.e. invalid modifiers are still being added to explicit implementation)
6. Abstract interface implementations for non-public members still won't compile. There is no way to implement a delegating call for an abstract method/property. This should be fixed by fixing #813 