### PR TITLE
Fix explicit interface implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### VB -> C#
 * Fix access modifiers for explicit interface implementations. [#819](https://github.com/icsharpcode/CodeConverter/issues/819)
-
+* Fix code generation for explicit interface implementations. [#813](https://github.com/icsharpcode/CodeConverter/issues/813)
 ### C# -> VB
 
 

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -325,8 +325,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                             baseSymbol.IsPartialMethodImplementation();
 
             if (isInterfaceImplRef) {
-                if (isCasingDiffOnly && baseClassSymbol.DeclaredAccessibility == Accessibility.Public)
+                if (isCasingDiffOnly && baseClassSymbol.DeclaredAccessibility == Accessibility.Public) {
                     return baseSymbol.Name;
+                }
 
                 return baseClassSymbol.Name;
             }

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -316,22 +316,22 @@ namespace ICSharpCode.CodeConverter.CSharp
             //proxy property
             var baseClassSymbol = GetBaseSymbol(idSymbol, s => s.ContainingType.IsClassType());
             var baseSymbol = GetBaseSymbol(baseClassSymbol, s => true);
-
-            var isCasingDiffOnly = StringComparer.Ordinal.Equals(text, baseClassSymbol.Name) !=
-                                   StringComparer.OrdinalIgnoreCase.Equals(text, baseClassSymbol.Name);
-            var isInterfaceImplRef =
-                baseSymbol.ContainingType.IsInterfaceType() && !(id.Parent is VBSyntax.StatementSyntax);
+            var isInterfaceImplRef = baseSymbol.ContainingType.IsInterfaceType();
             var isDeclaration = isInterfaceImplRef || baseSymbol.Locations.Any(l => l.SourceSpan == id.Span);
+            var isCasingDiffOnly = StringComparer.OrdinalIgnoreCase.Equals(text, baseSymbol.Name) &&
+                                   !StringComparer.Ordinal.Equals(text, baseSymbol.Name);
 
             var isPartial = baseSymbol.IsPartialClassDefinition() || baseSymbol.IsPartialMethodDefinition() ||
                             baseSymbol.IsPartialMethodImplementation();
 
             if (isInterfaceImplRef && isCasingDiffOnly) {
+                return baseSymbol.Name;
+            }
+            if (isInterfaceImplRef) {
                 return baseClassSymbol.Name;
             }
-
-            if ((isPartial || !isDeclaration)) {
-                text = baseSymbol.Name;
+            if (isPartial || !isDeclaration) {
+                return baseSymbol.Name;
             }
 
             return text;

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -324,12 +324,13 @@ namespace ICSharpCode.CodeConverter.CSharp
             var isPartial = baseSymbol.IsPartialClassDefinition() || baseSymbol.IsPartialMethodDefinition() ||
                             baseSymbol.IsPartialMethodImplementation();
 
-            if (isInterfaceImplRef && isCasingDiffOnly) {
-                return baseSymbol.Name;
-            }
             if (isInterfaceImplRef) {
+                if (isCasingDiffOnly && baseClassSymbol.DeclaredAccessibility == Accessibility.Public)
+                    return baseSymbol.Name;
+
                 return baseClassSymbol.Name;
             }
+
             if (isPartial || !isDeclaration) {
                 return baseSymbol.Name;
             }

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -803,12 +803,18 @@ namespace ICSharpCode.CodeConverter.CSharp
             var clause = GetDelegatingClause(method.Identifier, method.ParameterList, false);
 
             additionalInterfaceImplements.Do(interfaceImplement => {
-                var identifier = SyntaxFactory.Identifier(accessorKind == VBasic.SyntaxKind.GetAccessorBlock ? 
+                var isGetterMethodForParametrizedProperty = accessorKind == VBasic.SyntaxKind.GetAccessorBlock;
+
+                if (interfaceImplement.IsReadOnly && !isGetterMethodForParametrizedProperty)
+                    return;
+                if (interfaceImplement.IsWriteOnly && isGetterMethodForParametrizedProperty)
+                    return;
+
+                var identifier = SyntaxFactory.Identifier(isGetterMethodForParametrizedProperty ? 
                     GetMethodId(interfaceImplement.Name) : 
                     SetMethodId(interfaceImplement.Name));
                 var interfaceMethodDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers,
-                    method.ReturnType, method.TypeParameterList,
-                    MakeOptionalParametersRequired(method.ParameterList), method.ConstraintClauses, clause, identifier);
+                    method.ReturnType, method.TypeParameterList, MakeOptionalParametersRequired(method.ParameterList), method.ConstraintClauses, clause, identifier);
 
                 AddInterfaceMemberDeclarations(interfaceImplement, additionalDeclarations, interfaceMethodDeclParams);
             });

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -19,7 +18,6 @@ using CSSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 using SyntaxToken = Microsoft.CodeAnalysis.SyntaxToken;
 using Microsoft.CodeAnalysis.VisualBasic;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
-using Microsoft.CodeAnalysis.FindSymbols;
 
 namespace ICSharpCode.CodeConverter.CSharp
 {
@@ -652,23 +650,14 @@ namespace ICSharpCode.CodeConverter.CSharp
             bool hasImplementation = !node.Modifiers.Any(m => m.IsKind(VBasic.SyntaxKind.MustOverrideKeyword)) && node.GetAncestor<VBSyntax.InterfaceBlockSyntax>() == null;
 
             var directlyConvertedCsIdentifier = CommonConversions.CsEscapedIdentifier(node.Identifier.Value as string);
-            var csIdentifier = CommonConversions.ConvertIdentifier(node.Identifier);
             var additionalDeclarations = new List<MemberDeclarationSyntax>();
 
-            var explicitInterfaceSpecifier = IsNonPublicInterfaceImplementation(propSymbol) || IsRenamedInterfaceMember(propSymbol, directlyConvertedCsIdentifier, csIdentifier)
-                ? SyntaxFactory.ExplicitInterfaceSpecifier(CommonConversions.GetFullyQualifiedNameSyntax(propSymbol.ExplicitInterfaceImplementations.First().ContainingType))
-                : null;
+            var hasExplicitInterfaceImplementation = IsNonPublicInterfaceImplementation(propSymbol) || IsRenamedInterfaceMember(propSymbol, directlyConvertedCsIdentifier, propSymbol.ExplicitInterfaceImplementations);
+            var additionalInterfaceImplements = propSymbol.ExplicitInterfaceImplementations;
+            directlyConvertedCsIdentifier = hasExplicitInterfaceImplementation ? directlyConvertedCsIdentifier : CommonConversions.ConvertIdentifier(node.Identifier);
 
-            var hasExplicitInterfaceImplementation = explicitInterfaceSpecifier != null;
-
-            var additionalInterfaceImplements = explicitInterfaceSpecifier != null
-                ? propSymbol.ExplicitInterfaceImplementations.Skip(1)
-                : ImmutableArray<IPropertySymbol>.Empty;
-
-            var originalModifiers = modifiers;
-            var filteredModifiers = modifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword));
+            var filteredModifiers = modifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword) || m.IsKind(CSSyntaxKind.AbstractKeyword));
             var shouldConvertToMethods = ShouldConvertAsParameterizedProperty(node);
-
             var (initializer, vbType) = await GetVbReturnTypeAsync(node);
 
             var rawType = await vbType.AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor)
@@ -685,9 +674,11 @@ namespace ICSharpCode.CodeConverter.CSharp
                         await a.AcceptAsync<MethodDeclarationSyntax>(TriviaConvertingDeclarationVisitor, a == propertyBlock.Accessors.First() ? SourceTriviaMapKind.All : SourceTriviaMapKind.None));
                     var accessorMethods = methodDeclarationSyntaxs.Select(WithMergedModifiers).ToArray();
 
-                    accessorMethods.Do(method => AddRemainingInterfaceDeclarations(method, explicitInterfaceSpecifier, attributes,
-                        filteredModifiers, additionalInterfaceImplements, additionalDeclarations));
-
+                    if (hasExplicitInterfaceImplementation) {
+                        accessorMethods.Do(method => AddRemainingInterfaceDeclarations(method, attributes,
+                            filteredModifiers, additionalInterfaceImplements, additionalDeclarations));
+                    }
+                    
                     _additionalDeclarations.Add(propertyBlock, accessorMethods.Skip(1).Concat(additionalDeclarations).ToArray());
 
                     return accessorMethods[0];
@@ -706,7 +697,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 if (propSymbol.SetMethod != null) {
                     var setMethod = await CreateMethodDeclarationSyntaxAsync(node.ParameterList, SetMethodId(node), true);
-                    setMethod = AddValueSetParameter(propSymbol, setMethod, rawType, explicitInterfaceSpecifier);
+                    setMethod = AddValueSetParameter(propSymbol, setMethod, rawType, hasExplicitInterfaceImplementation);
                     methodDeclarationSyntaxs.Add(setMethod);
                 }
 
@@ -735,27 +726,29 @@ namespace ICSharpCode.CodeConverter.CSharp
                 );
             }
 
-            var accessorList = GetDelegatingAccessorList(explicitInterfaceSpecifier, csIdentifier, accessors);
-            var interfaceDeclParams = new PropertyDeclarationParameters(attributes, filteredModifiers, rawType, accessorList);
+            if (hasExplicitInterfaceImplementation) {
 
-            AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceDeclParams);
+                var delegatingAccessorList = GetDelegatingAccessorList(directlyConvertedCsIdentifier, accessors);
+                foreach (var additionalInterface in additionalInterfaceImplements) {
+                    var explicitInterfaceAccessors = new SyntaxList<AccessorDeclarationSyntax>();
+                    if (additionalInterface.IsReadOnly)
+                        explicitInterfaceAccessors = explicitInterfaceAccessors.Add(delegatingAccessorList.Single(t => t.IsKind(CSSyntaxKind.GetAccessorDeclaration)));
+                    else if (additionalInterface.IsWriteOnly)
+                        explicitInterfaceAccessors = explicitInterfaceAccessors.Add(delegatingAccessorList.Single(t => t.IsKind(CSSyntaxKind.SetAccessorDeclaration)));
+                    else
+                        explicitInterfaceAccessors = delegatingAccessorList;
 
-            if (hasExplicitInterfaceImplementation) 
-            {
-                var renamedInterfaceImplDeclParams = new PropertyDeclarationParameters(attributes, originalModifiers,
-                    rawType, accessorList, directlyConvertedCsIdentifier);
-
-                AddInterfaceMemberDeclaration(additionalDeclarations, renamedInterfaceImplDeclParams);
+                    var interfaceDeclParams = new PropertyDeclarationParameters(attributes, filteredModifiers, rawType, SyntaxFactory.AccessorList(explicitInterfaceAccessors));
+                    AddInterfaceMemberDeclarations(additionalInterface, additionalDeclarations, interfaceDeclParams);
+                }
             }
 
             if (accessedThroughMyClass) {
 
                 var realModifiers = modifiers.RemoveWhere(m => m.IsKind(CSSyntaxKind.PrivateKeyword));
-                string csIdentifierName = AddRealPropertyDelegatingToMyClassVersion(node, csIdentifier, attributes, realModifiers, rawType);
+                string csIdentifierName = AddRealPropertyDelegatingToMyClassVersion(additionalDeclarations, directlyConvertedCsIdentifier, attributes, realModifiers, rawType, isReadonly, isWriteOnly);
                 modifiers = modifiers.Remove(modifiers.Single(m => m.IsKind(CSSyntaxKind.VirtualKeyword)));
-                csIdentifier = SyntaxFactory.Identifier(csIdentifierName);
-            } else if (explicitInterfaceSpecifier != null) {
-                modifiers = filteredModifiers;
+                directlyConvertedCsIdentifier = SyntaxFactory.Identifier(csIdentifierName);
             }
 
             if (additionalDeclarations.Any()) {
@@ -768,8 +761,9 @@ namespace ICSharpCode.CodeConverter.CSharp
                 attributes,
                 modifiers,
                 rawType,
-                explicitInterfaceSpecifier,
-                csIdentifier, accessors,
+                explicitInterfaceSpecifier: null,
+                directlyConvertedCsIdentifier, 
+                accessors,
                 null,
                 initializer,
                 semicolonToken);
@@ -780,7 +774,6 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var hasVisibility = originalModifiers.Any(m => m.IsCsMemberVisibility());
                 var modifiersToAdd = hasVisibility ? modifiers.Where(m => !m.IsCsMemberVisibility()) : modifiers;
                 var newModifiers = SyntaxFactory.TokenList(originalModifiers.Concat(modifiersToAdd));
-                if (explicitInterfaceSpecifier != null) newModifiers = SyntaxFactory.TokenList(newModifiers.Where(m => !m.IsCsMemberVisibility()));
                 return member.WithModifiers(newModifiers);
             }
 
@@ -790,26 +783,24 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var methodModifiers = SyntaxFactory.TokenList(modifiers.Where(m => !m.IsCsVisibility(false, false)));
                 MethodDeclarationSyntax methodDeclarationSyntax = SyntaxFactory.MethodDeclaration(attributes, methodModifiers,
                     voidReturn ? SyntaxFactory.PredefinedType(SyntaxFactory.Token(CSSyntaxKind.VoidKeyword)) : rawType,
-                    explicitInterfaceSpecifier,
+                    null,
                     SyntaxFactory.Identifier(methodId), null,
-                    (ParameterListSyntax)parameterListSyntax, SyntaxFactory.List<TypeParameterConstraintClauseSyntax>(), null, null)
+                    parameterListSyntax, SyntaxFactory.List<TypeParameterConstraintClauseSyntax>(), null, null)
                     .WithSemicolonToken(SyntaxFactory.Token(CSSyntaxKind.SemicolonToken));
                 return methodDeclarationSyntax;
             }
         }
 
-        private void AddRemainingInterfaceDeclarations(MethodDeclarationSyntax method,
-            ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxList<AttributeListSyntax> attributes,
+        private void AddRemainingInterfaceDeclarations(MethodDeclarationSyntax method, SyntaxList<AttributeListSyntax> attributes,
             SyntaxTokenList filteredModifiers, IEnumerable<IPropertySymbol> additionalInterfaceImplements,
             ICollection<MemberDeclarationSyntax> additionalDeclarations)
         {
             var identifier = method.Identifier;
-            var clause = GetDelegatingClause(explicitInterfaceSpecifier, identifier,
-                method.ParameterList, false);
+            var clause = GetDelegatingClause(identifier, method.ParameterList, false);
 
             var interfaceMethodDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers,
                 method.ReturnType, method.TypeParameterList,
-                method.ParameterList, method.ConstraintClauses, clause,
+                MakeOptionalParametersRequired(method.ParameterList), method.ConstraintClauses, clause,
                 identifier);
 
             AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceMethodDeclParams);
@@ -839,14 +830,10 @@ namespace ICSharpCode.CodeConverter.CSharp
             return (initializer, vbType);
         }
 
-        private static AccessorListSyntax GetDelegatingAccessorList(
-            ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier,
-            SyntaxToken csIdentifier, AccessorListSyntax accessors)
+        private static SyntaxList<AccessorDeclarationSyntax> GetDelegatingAccessorList(SyntaxToken csIdentifier, AccessorListSyntax accessors)
         {
-            if(explicitInterfaceSpecifier == null) return null;
-
-            var getArrowClause = GetDelegatingClause(explicitInterfaceSpecifier, csIdentifier, null, false);
-            var setArrowClause = GetDelegatingClause(explicitInterfaceSpecifier, csIdentifier, null, true);
+            var getArrowClause = GetDelegatingClause(csIdentifier, null, false);
+            var setArrowClause = GetDelegatingClause(csIdentifier, null, true);
 
             var getSetDict = new Dictionary<CSSyntaxKind, ArrowExpressionClauseSyntax> {
                 {CSSyntaxKind.GetAccessorDeclaration, getArrowClause},
@@ -863,22 +850,31 @@ namespace ICSharpCode.CodeConverter.CSharp
                 return delegatingAccessor;
             });
 
-            var delegatingAccessorList = new SyntaxList<AccessorDeclarationSyntax>(delegatingAccessors);
-            return SyntaxFactory.AccessorList(delegatingAccessorList);
+            return new SyntaxList<AccessorDeclarationSyntax>(delegatingAccessors);
         }
 
-        private string AddRealPropertyDelegatingToMyClassVersion(VBSyntax.PropertyStatementSyntax node, SyntaxToken csIdentifier,
-            SyntaxList<AttributeListSyntax> attributes, SyntaxTokenList modifiers, TypeSyntax rawType)
+        private string AddRealPropertyDelegatingToMyClassVersion(List<MemberDeclarationSyntax> additionalDeclarations, SyntaxToken csIdentifier,
+            SyntaxList<AttributeListSyntax> attributes, SyntaxTokenList modifiers, TypeSyntax rawType, bool readOnly, bool writeOnly)
         {
-            var csIndentifierName = "MyClass" + csIdentifier.ValueText;
-            ExpressionSyntax thisDotIdentifier = SyntaxFactory.ParseExpression($"this.{csIndentifierName}");
-            var getReturn = SyntaxFactory.Block(SyntaxFactory.ReturnStatement(thisDotIdentifier));
-            var getAccessor = SyntaxFactory.AccessorDeclaration(CSSyntaxKind.GetAccessorDeclaration, getReturn);
-            var setValue = SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(
-                SyntaxFactory.AssignmentExpression(CSSyntaxKind.SimpleAssignmentExpression, thisDotIdentifier,
-                    SyntaxFactory.IdentifierName(CommonConversions.CsEscapedIdentifier("value")))));
-            var setAccessor = SyntaxFactory.AccessorDeclaration(CSSyntaxKind.SetAccessorDeclaration, setValue);
-            var realAccessors = SyntaxFactory.AccessorList(SyntaxFactory.List(new[] {getAccessor, setAccessor}));
+            var csIdentifierName = "MyClass" + csIdentifier.ValueText;
+            ExpressionSyntax thisDotIdentifier = GetSimpleMemberAccess(SyntaxFactory.Identifier(csIdentifierName));
+
+            var accessors = SyntaxFactory.List(Array.Empty<AccessorDeclarationSyntax>());
+            if (readOnly || !writeOnly) {
+                var getReturn = SyntaxFactory.Block(SyntaxFactory.ReturnStatement(thisDotIdentifier));
+                var getAccessor = SyntaxFactory.AccessorDeclaration(CSSyntaxKind.GetAccessorDeclaration, getReturn);
+                accessors = accessors.Add(getAccessor);
+            }
+
+            if (writeOnly || !readOnly) {
+                var setValue = SyntaxFactory.Block(SyntaxFactory.ExpressionStatement(
+                    SyntaxFactory.AssignmentExpression(CSSyntaxKind.SimpleAssignmentExpression, thisDotIdentifier,
+                        SyntaxFactory.IdentifierName(CommonConversions.CsEscapedIdentifier("value")))));
+                var setAccessor = SyntaxFactory.AccessorDeclaration(CSSyntaxKind.SetAccessorDeclaration, setValue);
+                accessors = accessors.Add(setAccessor);
+            }
+
+            var realAccessors = SyntaxFactory.AccessorList(accessors);
             var realDecl = SyntaxFactory.PropertyDeclaration(
                 attributes,
                 modifiers,
@@ -889,8 +885,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 null,
                 SyntaxFactory.Token(CSSyntaxKind.None));
 
-            _additionalDeclarations.Add(node, new MemberDeclarationSyntax[] { realDecl });
-            return csIndentifierName;
+            additionalDeclarations.Add(realDecl);
+            return csIdentifierName;
         }
 
         private static AccessorListSyntax ConvertSimpleAccessors(bool isWriteOnly, bool isReadonly,
@@ -942,10 +938,6 @@ namespace ICSharpCode.CodeConverter.CSharp
             var declaredPropSymbol = containingPropertyStmt != null ? _semanticModel.GetDeclaredSymbol(containingPropertyStmt) : null;
 
             string potentialMethodId;
-            var explicitInterfaceSpecifier = declaredPropSymbol is { } propSymbol && IsNonPublicInterfaceImplementation(propSymbol)
-                ? SyntaxFactory.ExplicitInterfaceSpecifier(SyntaxFactory.IdentifierName(propSymbol.ExplicitInterfaceImplementations.First().ContainingType.Name))
-                : null;
-
             var sourceMap = ancestoryPropertyBlock?.Accessors.FirstOrDefault() == node ? SourceTriviaMapKind.All : SourceTriviaMapKind.None;
             var returnType = containingPropertyStmt?.AsClause is VBSyntax.SimpleAsClauseSyntax asClause ?
                 await asClause.Type.AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor, sourceMap) :
@@ -967,7 +959,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                     if (ShouldConvertAsParameterizedProperty(containingPropertyStmt)) {
                         var setMethod = await CreateMethodDeclarationSyntax(containingPropertyStmt?.ParameterList, true);
-                        return AddValueSetParameter(declaredPropSymbol, setMethod, returnType, explicitInterfaceSpecifier);
+                        return AddValueSetParameter(declaredPropSymbol, setMethod, returnType, false);
                     }
                     break;
                 case VBasic.SyntaxKind.AddHandlerAccessorBlock:
@@ -990,19 +982,12 @@ namespace ICSharpCode.CodeConverter.CSharp
             async Task<MethodDeclarationSyntax> CreateMethodDeclarationSyntax(VBSyntax.ParameterListSyntax containingPropParameterList, bool voidReturn)
             {
                 var parameterListSyntax = await containingPropParameterList.AcceptAsync<ParameterListSyntax>(_triviaConvertingExpressionVisitor, sourceMap);
-                SyntaxTokenList methodModifiers;
+                //var methodModifiers = modifiers.RemoveWhere(x => x.IsKind(CSSyntaxKind.PrivateKeyword));
+                //parameterListSyntax = MakeOptionalParametersRequired(parameterListSyntax);
 
-                if (explicitInterfaceSpecifier != null) {
-                    methodModifiers = modifiers.RemoveWhere(x => x.IsKind(CSSyntaxKind.PrivateKeyword));
-                    parameterListSyntax = MakeOptionalParametersRequired(parameterListSyntax);
-
-                } else {
-                    methodModifiers = modifiers;
-                }
-
-                MethodDeclarationSyntax methodDeclarationSyntax = SyntaxFactory.MethodDeclaration(attributes, methodModifiers,
+                MethodDeclarationSyntax methodDeclarationSyntax = SyntaxFactory.MethodDeclaration(attributes, modifiers,
                     voidReturn ? SyntaxFactory.PredefinedType(SyntaxFactory.Token(CSSyntaxKind.VoidKeyword)) : returnType,
-                    explicitInterfaceSpecifier,
+                    explicitInterfaceSpecifier: null,
                     SyntaxFactory.Identifier(potentialMethodId), null,
                     parameterListSyntax, SyntaxFactory.List<TypeParameterConstraintClauseSyntax>(), body, null);
                 return methodDeclarationSyntax;
@@ -1010,11 +995,10 @@ namespace ICSharpCode.CodeConverter.CSharp
         }
 
         private static MethodDeclarationSyntax AddValueSetParameter(IPropertySymbol declaredPropSymbol,
-            MethodDeclarationSyntax setMethod, TypeSyntax returnType,
-            ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifierSyntax)
+            MethodDeclarationSyntax setMethod, TypeSyntax returnType, bool hasExplicitInterfaceImplementation)
         {
             var valueParam = SyntaxFactory.Parameter(CommonConversions.CsEscapedIdentifier("value")).WithType(returnType);
-            if ((declaredPropSymbol?.Parameters.Any(p => p.IsOptional) ?? false) && explicitInterfaceSpecifierSyntax == null) valueParam = valueParam.WithDefault(SyntaxFactory.EqualsValueClause(ValidSyntaxFactory.DefaultExpression));
+            if ((declaredPropSymbol?.Parameters.Any(p => p.IsOptional) ?? false) && !hasExplicitInterfaceImplementation) valueParam = valueParam.WithDefault(SyntaxFactory.EqualsValueClause(ValidSyntaxFactory.DefaultExpression));
             return setMethod.AddParameterListParameters(valueParam);
         }
 
@@ -1174,38 +1158,23 @@ namespace ICSharpCode.CodeConverter.CSharp
                 await (node.AsClause?.Type).AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(CSSyntaxKind.VoidKeyword)));
 
             var directlyConvertedCsIdentifier = CommonConversions.CsEscapedIdentifier(node.Identifier.Value as string);
-            var csIdentifier = CommonConversions.ConvertIdentifier(node.Identifier);
             var parameterList = await node.ParameterList.AcceptAsync<ParameterListSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.ParameterList();
             var additionalDeclarations = new List<MemberDeclarationSyntax>();
 
-            var explicitInterfaceSpecifier = IsNonPublicInterfaceImplementation(declaredSymbol) || IsRenamedInterfaceMember(declaredSymbol, directlyConvertedCsIdentifier, csIdentifier)
-                ? SyntaxFactory.ExplicitInterfaceSpecifier(CommonConversions.GetFullyQualifiedNameSyntax(declaredSymbol.ExplicitInterfaceImplementations.First().ContainingType))
-                : null;
+            var hasExplicitInterfaceImplementation = IsNonPublicInterfaceImplementation(declaredSymbol) || IsRenamedInterfaceMember(declaredSymbol, directlyConvertedCsIdentifier, declaredSymbol.ExplicitInterfaceImplementations);
+            directlyConvertedCsIdentifier = hasExplicitInterfaceImplementation ? directlyConvertedCsIdentifier : CommonConversions.ConvertIdentifier(node.Identifier);
 
-            var hasExplicitInterfaceSpecifier = explicitInterfaceSpecifier != null;
-            var additionalInterfaceImplements = hasExplicitInterfaceSpecifier
-                ? declaredSymbol.ExplicitInterfaceImplementations.Skip(1)
-                : ImmutableArray<IMethodSymbol>.Empty;
-
-            var originalConvertedModifiers = convertedModifiers;
-            var originalParameterList = parameterList;
-
-            var filteredModifiers = convertedModifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword));
+            var additionalInterfaceImplements = declaredSymbol.ExplicitInterfaceImplementations;
+            var filteredModifiers = convertedModifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword) || m.IsKind(CSSyntaxKind.AbstractKeyword));
             var requiredParameterList = MakeOptionalParametersRequired(parameterList);
 
-            var clause = GetDelegatingClause(explicitInterfaceSpecifier, csIdentifier,
-                requiredParameterList, false);
 
-            var interfaceDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers, returnType, typeParameters, requiredParameterList, constraints, clause);
+            if (hasExplicitInterfaceImplementation) {
 
-            AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceDeclParams);
+                var delegatingClause = GetDelegatingClause(directlyConvertedCsIdentifier, requiredParameterList, false);
 
-            if (hasExplicitInterfaceSpecifier) 
-            {
-                var renamedInterfaceImplDeclParams = new MethodDeclarationParameters(attributes, originalConvertedModifiers,
-                    returnType, typeParameters, originalParameterList, constraints, clause, directlyConvertedCsIdentifier);
-
-                AddInterfaceMemberDeclaration(additionalDeclarations, renamedInterfaceImplDeclParams);
+                var interfaceDeclParams = new MethodDeclarationParameters(attributes, filteredModifiers, returnType, typeParameters, requiredParameterList, constraints, delegatingClause);
+                AddInterfaceMemberDeclarations(additionalInterfaceImplements, additionalDeclarations, interfaceDeclParams);
             }
 
             // If the method is virtual, and there is a MyClass.SomeMethod() call,
@@ -1215,21 +1184,13 @@ namespace ICSharpCode.CodeConverter.CSharp
                 var arrowClause = SyntaxFactory.ArrowExpressionClause(SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(identifierName), CreateDelegatingArgList(parameterList)));
                 var declModifiers = convertedModifiers;
 
-                // If an extra delegate method is emitted already because of interface method renaming,
-                // don't emit the virtual and accessor modifiers on the explicit implementation. 
-                if (hasExplicitInterfaceSpecifier) 
-                {
-                    declModifiers = declModifiers
-                        .RemoveWhere(m => m.IsCsMemberVisibility())
-                        .RemoveWhere(m => m.IsKind(CSSyntaxKind.VirtualKeyword));
-                }
 
                 var originalNameDecl = SyntaxFactory.MethodDeclaration(
                     attributes,
                     declModifiers,
                     returnType,
-                    explicitInterfaceSpecifier,
-                    csIdentifier,
+                    null,
+                    directlyConvertedCsIdentifier,
                     typeParameters,
                     parameterList,
                     constraints,
@@ -1240,15 +1201,11 @@ namespace ICSharpCode.CodeConverter.CSharp
 
                 additionalDeclarations.Add(originalNameDecl);
                 convertedModifiers = convertedModifiers.Remove(convertedModifiers.Single(m => m.IsKind(CSSyntaxKind.VirtualKeyword)));
-                csIdentifier = SyntaxFactory.Identifier(identifierName);
-                explicitInterfaceSpecifier = null;
-            } else if (explicitInterfaceSpecifier != null) {
-                convertedModifiers = filteredModifiers;
-                parameterList = requiredParameterList;
+                directlyConvertedCsIdentifier = SyntaxFactory.Identifier(identifierName);
             }
 
             if (additionalDeclarations.Any()) {
-                var declNode = (VBSyntax.StatementSyntax)node.Parent;
+                var declNode = (VBSyntax.StatementSyntax)node.FirstAncestorOrSelf<VBSyntax.MethodBlockBaseSyntax>() ?? node;
                 _additionalDeclarations.Add(declNode, additionalDeclarations.ToArray());
             }
 
@@ -1256,8 +1213,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                 attributes,
                 convertedModifiers,
                 returnType,
-                explicitInterfaceSpecifier,
-                csIdentifier,
+                null,
+                directlyConvertedCsIdentifier,
                 typeParameters,
                 parameterList,
                 constraints,
@@ -1268,32 +1225,7 @@ namespace ICSharpCode.CodeConverter.CSharp
             return hasBody && declaredSymbol.CanHaveMethodBody() ? decl : decl.WithSemicolonToken(SemicolonToken);
         }
 
-        private static void AddInterfaceMemberDeclaration(ICollection<MemberDeclarationSyntax> additionalDeclarations, DeclarationParameters interfaceImplDeclParams)
-        {
-            var semicolonToken = SyntaxFactory.Token(CSSyntaxKind.SemicolonToken);
-
-            Func<MemberDeclarationSyntax>
-                declDelegate = interfaceImplDeclParams switch {
-                    MethodDeclarationParameters methodParams => ()
-                        => SyntaxFactory.MethodDeclaration(methodParams.Attributes, methodParams.Modifiers,
-                            methodParams.ReturnType, null, methodParams.Identifier
-                            , methodParams.TypeParameters, methodParams.ParameterList, methodParams.Constraints, null,
-                            methodParams.ArrowClause, semicolonToken).WithoutSourceMapping(),
-
-                    PropertyDeclarationParameters propertyParams => ()
-                        => SyntaxFactory.PropertyDeclaration(propertyParams.Attributes, propertyParams.Modifiers,
-                            propertyParams.ReturnType, null, propertyParams.Identifier, propertyParams.Accessors,
-                            null, null).NormalizeWhitespace(),
-
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-
-            var declaration = declDelegate.Invoke();
-
-            additionalDeclarations.Add(declaration);
-        }
-
-        private void AddInterfaceMemberDeclarations(IEnumerable<ISymbol> additionalInterfaceImplements,
+        private void AddInterfaceMemberDeclarations(ISymbol interfaceImplement,
             ICollection<MemberDeclarationSyntax> additionalDeclarations,
             DeclarationParameters declParams)
         {
@@ -1314,11 +1246,17 @@ namespace ICSharpCode.CodeConverter.CSharp
                     _ => throw new ArgumentOutOfRangeException()
                 };
 
-            additionalInterfaceImplements.Do(interfaceImplement => AddMemberDeclaration(additionalDeclarations,
-                interfaceImplement, declParams.Identifier, declDelegate));
+            AddMemberDeclaration(additionalDeclarations, interfaceImplement, declParams.Identifier, declDelegate);
         }
 
-        private void AddMemberDeclaration(ICollection<MemberDeclarationSyntax> additionalDeclarations, 
+        private void AddInterfaceMemberDeclarations(IEnumerable<ISymbol> additionalInterfaceImplements,
+            ICollection<MemberDeclarationSyntax> additionalDeclarations,
+            DeclarationParameters declParams)
+        {
+            additionalInterfaceImplements.Do(interfaceImplement => AddInterfaceMemberDeclarations(interfaceImplement, additionalDeclarations, declParams));
+        }
+
+        private void AddMemberDeclaration(ICollection<MemberDeclarationSyntax> additionalDeclarations,
             ISymbol interfaceImplement, SyntaxToken identifier, Func<ExplicitInterfaceSpecifierSyntax, SyntaxToken, MemberDeclarationSyntax> declDelegate)
         {
             var explicitInterfaceName = CommonConversions.GetFullyQualifiedNameSyntax(interfaceImplement.ContainingType);
@@ -1366,18 +1304,15 @@ namespace ICSharpCode.CodeConverter.CSharp
             return parameter.WithDefault(null).WithAttributeLists(newAttrLists);
         }
 
-        private static ArrowExpressionClauseSyntax GetDelegatingClause(
-            ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken csIdentifier,
+        private static ArrowExpressionClauseSyntax GetDelegatingClause(SyntaxToken csIdentifier,
             ParameterListSyntax parameterList, bool isSetAccessor)
         {
-            if (explicitInterfaceSpecifier == null) return null;
-
             if (parameterList != null && isSetAccessor)
                 throw new InvalidOperationException("Parameterized setters shouldn't have a delegating clause. " +
                                                     $"\r\nInvalid arguments: {nameof(isSetAccessor)} = {true}," +
                                                     $" {nameof(parameterList)} has {parameterList.Parameters.Count} parameters");
 
-            var simpleMemberAccess = GetSimpleMemberAccess(explicitInterfaceSpecifier, csIdentifier);
+            var simpleMemberAccess = GetSimpleMemberAccess(csIdentifier);
 
             var expression = parameterList != null
                 ? (ExpressionSyntax)SyntaxFactory.InvocationExpression(simpleMemberAccess, CreateDelegatingArgList(parameterList))
@@ -1392,19 +1327,10 @@ namespace ICSharpCode.CodeConverter.CSharp
             return arrowClause;
         }
 
-        private static MemberAccessExpressionSyntax GetSimpleMemberAccess(
-            ExplicitInterfaceSpecifierSyntax explicitInterfaceSpecifier, SyntaxToken csIdentifier)
+        private static MemberAccessExpressionSyntax GetSimpleMemberAccess(SyntaxToken csIdentifier)
         {
-            var cast = SyntaxFactory.CastExpression(SyntaxFactory.Token(CSSyntaxKind.OpenParenToken),
-                explicitInterfaceSpecifier.Name, SyntaxFactory.Token(CSSyntaxKind.CloseParenToken),
-                SyntaxFactory.ThisExpression());
-
-            var parenthesized = SyntaxFactory.ParenthesizedExpression(
-                SyntaxFactory.Token(CSSyntaxKind.OpenParenToken), cast,
-                SyntaxFactory.Token(CSSyntaxKind.CloseParenToken));
-
             var simpleMemberAccess = SyntaxFactory.MemberAccessExpression(
-                CSSyntaxKind.SimpleMemberAccessExpression, parenthesized,
+                CSSyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(),
                 SyntaxFactory.Token(CSSyntaxKind.DotToken), SyntaxFactory.IdentifierName(csIdentifier));
 
             return simpleMemberAccess;
@@ -1422,17 +1348,16 @@ namespace ICSharpCode.CodeConverter.CSharp
         }
 
         private static bool IsRenamedInterfaceMember(ISymbol declaredSymbol,
-            SyntaxToken directlyConvertedCsIdentifier, SyntaxToken csIdentifier)
+            SyntaxToken directlyConvertedCsIdentifier, IEnumerable<ISymbol> explicitInterfaceImplementations)
         {
-            return declaredSymbol switch {
-                IMethodSymbol methodSymbol => !StringComparer.Ordinal.Equals(directlyConvertedCsIdentifier.Value,
-                                                  csIdentifier.Value)
-                                              && methodSymbol.ExplicitInterfaceImplementations.Any(),
-                IPropertySymbol propertySymbol => !StringComparer.Ordinal.Equals(directlyConvertedCsIdentifier.Value,
-                                                      csIdentifier.Value)
-                                                  && propertySymbol.ExplicitInterfaceImplementations.Any(),
-                _ => throw new ArgumentOutOfRangeException(nameof(declaredSymbol))
-            };
+            bool IsRenamed(ISymbol csIdentifier) =>
+                declaredSymbol switch {
+                    IMethodSymbol methodSymbol => !StringComparer.OrdinalIgnoreCase.Equals(directlyConvertedCsIdentifier.Value, csIdentifier.Name) && methodSymbol.ExplicitInterfaceImplementations.Any(),
+                    IPropertySymbol propertySymbol => !StringComparer.OrdinalIgnoreCase.Equals(directlyConvertedCsIdentifier.Value, csIdentifier.Name) && propertySymbol.ExplicitInterfaceImplementations.Any(),
+                    _ => throw new ArgumentOutOfRangeException(nameof(declaredSymbol))
+                };
+
+            return explicitInterfaceImplementations.Any(IsRenamed);
         }
 
         private static ArgumentListSyntax CreateDelegatingArgList(ParameterListSyntax parameterList)

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -395,7 +395,8 @@ namespace ICSharpCode.CodeConverter.CSharp
                     left = CommonConversions.GetTypeSyntax(typeInfo.Type);
                 } else {
                     left = SyntaxFactory.ThisExpression();
-                    if (nodeSymbol.IsVirtual && !nodeSymbol.IsAbstract) {
+                    if (nodeSymbol.IsVirtual && !nodeSymbol.IsAbstract ||
+                        nodeSymbol.IsImplicitlyDeclared && nodeSymbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol { IsVirtual: true, IsAbstract: false } }) {
                         simpleNameSyntax =
                             SyntaxFactory.IdentifierName(
                                 $"MyClass{ConvertIdentifier(node.Name.Identifier).ValueText}");

--- a/Tests/CSharp/ExpressionTests/ByRefTests.cs
+++ b/Tests/CSharp/ExpressionTests/ByRefTests.cs
@@ -327,12 +327,12 @@ public partial interface IFoo
 
 public partial class Foo : IFoo
 {
-    int IFoo.ExplicitFunc(ref string str)
+    private int ExplicitFunc([Optional, DefaultParameterValue("""")] ref string str)
     {
         return 5;
     }
 
-    private int ExplicitFunc([Optional, DefaultParameterValue("""")] ref string str) => ((IFoo)this).ExplicitFunc(ref str);
+    int IFoo.ExplicitFunc(ref string str) => ExplicitFunc(ref str);
 }");
         }
 

--- a/Tests/CSharp/MemberTests/IndexerTests.cs
+++ b/Tests/CSharp/MemberTests/IndexerTests.cs
@@ -1,0 +1,227 @@
+﻿using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+using Xunit;
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp.MemberTests
+{
+    public class IndexerTests : ConverterTestBase
+    {
+                [Fact]
+        public async Task InterfaceImplementationOfIndexerAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Default Property Item(str As String) As Integer
+End Interface
+
+Public Class Foo
+    Implements IFoo
+
+    Default Overridable Public Property Item(str As String) As Integer Implements IFoo.Item
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int this[string str] { get; set; }
+}
+
+public partial class Foo : IFoo
+{
+    public virtual int this[string str]
+    {
+        get
+        {
+            return 1;
+        }
+
+        set
+        {
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public async Task InterfaceImplementationOfIndexerAsAbstractAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Default Property Item(str As String) As Integer
+End Interface
+
+Public MustInherit Class Foo
+    Implements IFoo
+
+    Default Public MustOverride Property Item(str As String) As Integer Implements IFoo.Item
+End Class
+
+Public Class FooChild
+    Inherits Foo
+
+    Default Public Overrides Property Item(str As String) As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int this[string str] { get; set; }
+}
+
+public abstract partial class Foo : IFoo
+{
+    public abstract int this[string str] { get; set; }
+}
+
+public partial class FooChild : Foo
+{
+    public override int this[string str]
+    {
+        get
+        {
+            return 1;
+        }
+
+        set
+        {
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public async Task RenamedImplementationOfIndexerWithAbstractAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Default Property Item(str As String) As Integer
+End Interface
+
+Public MustInherit Class Foo
+    Implements IFoo
+
+    Default Public MustOverride Property ItemRenamed(str As String) As Integer Implements IFoo.Item
+End Class
+
+Public Class FooChild
+    Inherits Foo
+
+    Default Public Overrides Property ItemRenamed(str As String) As Integer
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int this[string str] { get; set; }
+}
+
+public abstract partial class Foo : IFoo
+{
+    public abstract int this[string str] { get; set; }
+}
+
+public partial class FooChild : Foo
+{
+    public override int this[string str]
+    {
+        get
+        {
+            return 1;
+        }
+
+        set
+        {
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public async Task ReadOnlyImplementationOfIndexerAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Default ReadOnly Property Item(str As String) As Integer
+End Interface
+
+Public Class Foo
+    Implements IFoo
+
+    Default Public Overridable ReadOnly Property Item(str As String) As Integer Implements IFoo.Item
+    Get
+        Return 2
+    End Get
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int this[string str] { get; }
+}
+
+public partial class Foo : IFoo
+{
+    public virtual int this[string str]
+    {
+        get
+        {
+            return 2;
+        }
+    }
+}
+");
+        }
+
+        [Fact]
+        public async Task WriteOnlyImplementationOfIndexerAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Default WriteOnly Property Item(str As String) As Integer
+End Interface
+
+Public Class Foo
+    Implements IFoo
+
+    Default Public Overridable WriteOnly Property Item(str As String) As Integer Implements IFoo.Item
+    Set
+    End Set
+    End Property
+End Class", @"
+public partial interface IFoo
+{
+    int this[string str] { set; }
+}
+
+public partial class Foo : IFoo
+{
+    public virtual int this[string str]
+    {
+        set
+        {
+        }
+    }
+}
+");
+        }
+    }
+}

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -461,6 +461,278 @@ internal abstract partial class TestClass
         }
 
         [Fact]
+        public async Task TestAbstractReadOnlyAndWriteOnlyPropertyAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"MustInherit Class TestClass
+        Public MustOverride ReadOnly Property ReadOnlyProp As String
+        Public MustOverride WriteOnly Property WriteOnlyProp As String
+End Class
+
+Class ChildClass
+    Inherits TestClass
+
+    Public Overrides ReadOnly Property ReadOnlyProp As String
+    Public Overrides WriteOnly Property WriteOnlyProp As String
+        Set
+        End Set
+    End Property
+End Class
+", @"
+internal abstract partial class TestClass
+{
+    public abstract string ReadOnlyProp { get; }
+    public abstract string WriteOnlyProp { set; }
+}
+
+internal partial class ChildClass : TestClass
+{
+    public override string ReadOnlyProp { get; }
+
+    public override string WriteOnlyProp
+    {
+        set
+        {
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestReadOnlyAndWriteOnlyParametrizedPropertyAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"Interface IClass
+    ReadOnly Property ReadOnlyProp(i as Integer) As String
+    WriteOnly Property WriteOnlyProp(i as Integer) As String
+End Interface
+
+Class ChildClass
+    Implements IClass
+
+    Public Overridable ReadOnly Property ReadOnlyProp(i As Integer) As String Implements IClass.ReadOnlyProp
+        Get
+            Throw New NotImplementedException
+        End Get
+    End Property
+
+    Public Overridable WriteOnly Property WriteOnlyProp(i As Integer) As String Implements IClass.WriteOnlyProp
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+End Class
+", @"using System;
+
+internal partial interface IClass
+{
+    string get_ReadOnlyProp(int i);
+    void set_WriteOnlyProp(int i, string value);
+}
+
+internal partial class ChildClass : IClass
+{
+    public virtual string get_ReadOnlyProp(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual void set_WriteOnlyProp(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
+        [Fact]
+        public async Task TestExplicitImplementationOfParametrizedPropertyAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"Interface IClass
+    ReadOnly Property ReadOnlyPropToRename(i as Integer) As String
+    WriteOnly Property WriteOnlyPropToRename(i as Integer) As String
+    Property PropToRename(i as Integer) As String
+
+    ReadOnly Property ReadOnlyPropNonPublic(i as Integer) As String
+    WriteOnly Property WriteOnlyPropNonPublic(i as Integer) As String
+    Property PropNonPublic(i as Integer) As String
+
+    ReadOnly Property ReadOnlyPropToRenameNonPublic(i as Integer) As String
+    WriteOnly Property WriteOnlyPropToRenameNonPublic(i as Integer) As String
+    Property PropToRenameNonPublic(i as Integer) As String
+
+End Interface
+
+Class ChildClass
+    Implements IClass
+
+    Public ReadOnly Property ReadOnlyPropRenamed(i As Integer) As String Implements IClass.ReadOnlyPropToRename
+        Get
+            Throw New NotImplementedException
+        End Get
+    End Property
+
+    Public Overridable WriteOnly Property WriteOnlyPropRenamed(i As Integer) As String Implements IClass.WriteOnlyPropToRename
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Public Overridable Property PropRenamed(i As Integer) As String Implements IClass.PropToRename
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Private ReadOnly Property ReadOnlyPropNonPublic(i As Integer) As String Implements IClass.ReadOnlyPropNonPublic
+        Get
+            Throw New NotImplementedException
+        End Get
+    End Property
+
+    Protected Friend Overridable WriteOnly Property WriteOnlyPropNonPublic(i As Integer) As String Implements IClass.WriteOnlyPropNonPublic
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Friend Overridable Property PropNonPublic(i As Integer) As String Implements IClass.PropNonPublic
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Protected Friend Overridable ReadOnly Property ReadOnlyPropRenamedNonPublic(i As Integer) As String Implements IClass.ReadOnlyPropToRenameNonPublic
+        Get
+            Throw New NotImplementedException
+        End Get
+    End Property
+
+    Private WriteOnly Property WriteOnlyPropRenamedNonPublic(i As Integer) As String Implements IClass.WriteOnlyPropToRenameNonPublic
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+
+    Friend Overridable Property PropToRenameNonPublic(i As Integer) As String Implements IClass.PropToRenameNonPublic
+        Get
+            Throw New NotImplementedException
+        End Get
+        Set
+            Throw New NotImplementedException
+        End Set
+    End Property
+End Class
+", @"using System;
+
+internal partial interface IClass
+{
+    string get_ReadOnlyPropToRename(int i);
+    void set_WriteOnlyPropToRename(int i, string value);
+    string get_PropToRename(int i);
+    void set_PropToRename(int i, string value);
+    string get_ReadOnlyPropNonPublic(int i);
+    void set_WriteOnlyPropNonPublic(int i, string value);
+    string get_PropNonPublic(int i);
+    void set_PropNonPublic(int i, string value);
+    string get_ReadOnlyPropToRenameNonPublic(int i);
+    void set_WriteOnlyPropToRenameNonPublic(int i, string value);
+    string get_PropToRenameNonPublic(int i);
+    void set_PropToRenameNonPublic(int i, string value);
+}
+
+internal partial class ChildClass : IClass
+{
+    public string get_ReadOnlyPropRenamed(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_ReadOnlyPropToRename(int i) => get_ReadOnlyPropRenamed(i);
+
+    public virtual void set_WriteOnlyPropRenamed(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    void IClass.set_WriteOnlyPropToRename(int i, string value) => set_WriteOnlyPropRenamed(i, value);
+
+    public virtual string get_PropRenamed(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    public virtual void set_PropRenamed(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_PropToRename(int i) => get_PropRenamed(i);
+    void IClass.set_PropToRename(int i, string value) => set_PropRenamed(i, value);
+
+    private string get_ReadOnlyPropNonPublic(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_ReadOnlyPropNonPublic(int i) => get_ReadOnlyPropNonPublic(i);
+
+    protected internal virtual void set_WriteOnlyPropNonPublic(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    void IClass.set_WriteOnlyPropNonPublic(int i, string value) => set_WriteOnlyPropNonPublic(i, value);
+
+    internal virtual string get_PropNonPublic(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    internal virtual void set_PropNonPublic(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_PropNonPublic(int i) => get_PropNonPublic(i);
+    void IClass.set_PropNonPublic(int i, string value) => set_PropNonPublic(i, value);
+
+    protected internal virtual string get_ReadOnlyPropRenamedNonPublic(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_ReadOnlyPropToRenameNonPublic(int i) => get_ReadOnlyPropRenamedNonPublic(i);
+
+    private void set_WriteOnlyPropRenamedNonPublic(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    void IClass.set_WriteOnlyPropToRenameNonPublic(int i, string value) => set_WriteOnlyPropRenamedNonPublic(i, value);
+
+    internal virtual string get_PropToRenameNonPublic(int i)
+    {
+        throw new NotImplementedException();
+    }
+
+    internal virtual void set_PropToRenameNonPublic(int i, string value)
+    {
+        throw new NotImplementedException();
+    }
+
+    string IClass.get_PropToRenameNonPublic(int i) => get_PropToRenameNonPublic(i);
+    void IClass.set_PropToRenameNonPublic(int i, string value) => set_PropToRenameNonPublic(i, value);
+}");
+        }
+
+        [Fact]
         public async Task TestSealedMethodAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -545,7 +545,7 @@ internal partial class ChildClass : IClass
         }
 
         [Fact]
-        public async Task TestExplicitImplementationOfParametrizedPropertyAsync()
+        public async Task TestExplicitInterfaceOfParametrizedPropertyAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(
                 @"Interface IClass
@@ -2742,6 +2742,56 @@ public partial class Foo : BaseFoo
     }
 }");
         }
+
+        [Fact]
+        public async Task ExplicitPropertyImplementationWithDirectAccessAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Property ExplicitProp As Integer
+    ReadOnly Property ExplicitReadOnlyProp As Integer
+End Interface
+
+Public Class Foo
+    Implements IFoo
+    
+    Property ExplicitPropRenamed As Integer Implements IFoo.ExplicitProp
+    ReadOnly Property ExplicitRenamedReadOnlyProp As Integer Implements IFoo.ExplicitReadOnlyProp
+
+    Private Sub Consumer()
+        _ExplicitPropRenamed = 5
+        _ExplicitRenamedReadOnlyProp = 10
+    End Sub
+
+End Class", @"
+public partial interface IFoo
+{
+    int ExplicitProp { get; set; }
+    int ExplicitReadOnlyProp { get; }
+}
+
+public partial class Foo : IFoo
+{
+    public int ExplicitPropRenamed { get; set; }
+    int IFoo.ExplicitProp
+    {
+        get => ExplicitPropRenamed;
+        set => ExplicitPropRenamed = value;
+    }
+    public int ExplicitRenamedReadOnlyProp { get; private set; }
+    int IFoo.ExplicitReadOnlyProp
+    {
+        get => ExplicitRenamedReadOnlyProp;
+    }
+
+    private void Consumer()
+    {
+        ExplicitPropRenamed = 5;
+        ExplicitRenamedReadOnlyProp = 10;
+    }
+}");
+        }
         
         [Fact]
         public async Task ReadonlyRenamedPropertyImplementsMultipleInterfacesAsync()
@@ -2772,7 +2822,7 @@ public partial interface IBar
 
 public partial class Foo : IFoo, IBar
 {
-    public int ExplicitPropRenamed { get; }
+    public int ExplicitPropRenamed { get; private set; }
     int IFoo.ExplicitProp
     {
         get => ExplicitPropRenamed;

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -2547,6 +2547,51 @@ public partial class Foo : IFoo, IBar
 }");
         }
 
+        
+        [Fact]
+        public async Task ImplementMultipleRenamedPropertiesFromInterfaceAsAbstract()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Public Interface IFoo
+    Property ExplicitProp As Integer
+End Interface
+Public Interface IBar
+    Property ExplicitProp As Integer
+End Interface
+Public MustInherit Class Foo
+    Implements IFoo, IBar
+
+    Protected MustOverride Property ExplicitPropRenamed1 As Integer Implements IFoo.ExplicitProp
+    Protected MustOverride Property ExplicitPropRenamed2 As Integer Implements IBar.ExplicitProp
+End Class", @"
+public partial interface IFoo
+{
+    int ExplicitProp { get; set; }
+}
+
+public partial interface IBar
+{
+    int ExplicitProp { get; set; }
+}
+
+public abstract partial class Foo : IFoo, IBar
+{
+    protected abstract int ExplicitPropRenamed1 { get; set; }
+    int IFoo.ExplicitProp
+    {
+        get => ExplicitPropRenamed1;
+        set => ExplicitPropRenamed1 = value;
+    }
+    protected abstract int ExplicitPropRenamed2 { get; set; }
+    int IBar.ExplicitProp
+    {
+        get => ExplicitPropRenamed2;
+        set => ExplicitPropRenamed2 = value;
+    }
+}");
+        }
+
         [Fact]
         public async Task PrivatePropertyAccessorBlocksImplementsMultipleInterfacesAsync()
         {

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -499,6 +499,126 @@ internal partial class ChildClass : TestClass
         }
 
         [Fact]
+        public async Task TestReadOnlyOrWriteOnlyPropertyImplementedByNormalPropertyAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Interface IClass
+    ReadOnly Property ReadOnlyPropParam(i as Integer) As Integer
+    ReadOnly Property ReadOnlyProp As Integer
+
+    WriteOnly Property WriteOnlyPropParam(i as Integer) As Integer
+    WriteOnly Property WriteOnlyProp As Integer
+End Interface
+
+Class ChildClass
+    Implements IClass
+
+    Public Overridable Property RenamedPropertyParam(i As Integer) As Integer Implements IClass.ReadOnlyPropParam
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+
+    Public Overridable Property RenamedReadOnlyProperty As Integer Implements IClass.ReadOnlyProp ' Comment moves because this line gets split
+        Get
+            Return 2
+        End Get
+        Set
+        End Set
+    End Property
+
+    Public Overridable Property RenamedWriteOnlyPropParam(i As Integer) As Integer Implements IClass.WriteOnlyPropParam
+        Get
+            Return 1
+        End Get
+        Set
+        End Set
+    End Property
+
+    Public Overridable Property RenamedWriteOnlyProperty As Integer Implements IClass.WriteOnlyProp ' Comment moves because this line gets split
+        Get
+            Return 2
+        End Get
+        Set
+        End Set
+    End Property
+End Class
+", @"
+internal partial interface IClass
+{
+    int get_ReadOnlyPropParam(int i);
+
+    int ReadOnlyProp { get; }
+
+    void set_WriteOnlyPropParam(int i, int value);
+
+    int WriteOnlyProp { set; }
+}
+
+internal partial class ChildClass : IClass
+{
+    public virtual int get_RenamedPropertyParam(int i)
+    {
+        return 1;
+    }
+
+    public virtual void set_RenamedPropertyParam(int i, int value)
+    {
+    }
+
+    int IClass.get_ReadOnlyPropParam(int i) => get_RenamedPropertyParam(i);
+
+    public virtual int RenamedReadOnlyProperty
+    {
+        get
+        {
+            return 2;
+        }
+
+        set
+        {
+        }
+    }
+
+    int IClass.ReadOnlyProp // Comment moves because this line gets split
+    {
+        get => RenamedReadOnlyProperty;
+    }
+
+    public virtual int get_RenamedWriteOnlyPropParam(int i)
+    {
+        return 1;
+    }
+
+    public virtual void set_RenamedWriteOnlyPropParam(int i, int value)
+    {
+    }
+
+    void IClass.set_WriteOnlyPropParam(int i, int value) => set_RenamedWriteOnlyPropParam(i, value);
+
+    public virtual int RenamedWriteOnlyProperty
+    {
+        get
+        {
+            return 2;
+        }
+
+        set
+        {
+        }
+    }
+
+    int IClass.WriteOnlyProp // Comment moves because this line gets split
+    {
+        set => RenamedWriteOnlyProperty = value;
+    }
+}");
+        }
+
+        [Fact]
         public async Task TestReadOnlyAndWriteOnlyParametrizedPropertyAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/AnInterfaceImplementation.cs
@@ -3,7 +3,7 @@ namespace VbNetStandardLib
 {
     public class AnInterfaceImplementation : AnInterface
     {
-        string AnInterface.AnInterfaceProperty
+        public string APropertyWithDifferentName
         {
             get
             {
@@ -11,15 +11,15 @@ namespace VbNetStandardLib
             }
         }
 
-        public string APropertyWithDifferentName
+        string AnInterface.AnInterfaceProperty
         {
-            get => ((AnInterface)this).AnInterfaceProperty;
+            get => APropertyWithDifferentName;
         }
 
-        void AnInterface.AnInterfaceMethod()
+        public void AMethodWithDifferentName()
         {
         }
 
-        public void AMethodWithDifferentName() => ((AnInterface)this).AnInterfaceMethod();
+        void AnInterface.AnInterfaceMethod() => AMethodWithDifferentName();
     }
 }

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
@@ -48,7 +48,7 @@ Module Program
             Dim nonVirtualMethodGood2 = Me.F2() = 2
             Dim sharedMethodGood1 = MyClass.F3() = 3
             Dim sharedMethodGood2 = A.F3() = 3
-            Dim interfaceMethodGood = CType(Me, IA).F4() = 11
+            Dim interfaceMethodGood = CType(Me, IA).F4() = 44
 
             Dim virtualPropertyGood1 = MyClass.P1 = 1
             Dim virtualPropertyGood2 = Me.P1 = 11

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
@@ -15,6 +15,7 @@ Module Program
     Public Interface IA
         Function F4() As Integer
         Property P4() As Integer
+        ReadOnly Property P5() As Integer
     End Interface
 
     Public Class A
@@ -40,6 +41,11 @@ Module Program
         Property P2 As Integer = 2
         Shared Property P3 As Integer = 3
         Protected Overridable Property P4 As Integer = 4 Implements IA.P4
+        Protected Friend Overridable ReadOnly Property P5Renamed As Integer = 5 Implements IA.P5
+
+        Sub ChangeP5ViaDirectAccess()
+            MyClass._P5Renamed = 555
+        End Sub
 
         Public Function TestMethod() As Boolean
             Dim virtualMethodGood1 = MyClass.F1() = 1
@@ -52,11 +58,19 @@ Module Program
 
             Dim virtualPropertyGood1 = MyClass.P1 = 1
             Dim virtualPropertyGood2 = Me.P1 = 11
+            Dim virtualPropertyGood3 = Me.P5Renamed = 55
+            Dim virtualPropertyGood4 = MyClass.P5Renamed = 5
             Dim nonVirtualPropertyGood1 = MyClass.P2 = 2
             Dim nonVirtualPropertyGood2 = Me.P2 = 2
             Dim sharedPropertyGood1 = MyClass.P3 = 3
             Dim sharedPropertyGood2 = A.P3 = 3
-            Dim interfacePropertyGood = CType(Me, IA).P4() = 44
+            Dim interfacePropertyGood1 = CType(Me, IA).P4 = 44
+            Dim interfacePropertyGood2 = CType(Me, IA).P5 = 55
+
+            ChangeP5ViaDirectAccess()
+            Dim p5MyClassGood = MyClass.P5Renamed = 555
+            Dim p5MeGood = Me.P5Renamed = 55
+            Dim p5InterfaceGood =  CType(Me, IA).P5 = 55
 
             Dim methodsGood = virtualMethodGood1 AndAlso virtualMethodGood2 AndAlso
                               nonVirtualMethodGood1 AndAlso nonVirtualMethodGood2 AndAlso
@@ -64,7 +78,9 @@ Module Program
 
             Dim propertiesGood = virtualPropertyGood1 AndAlso virtualPropertyGood2 AndAlso
                                  nonVirtualPropertyGood1 AndAlso nonVirtualPropertyGood2 AndAlso
-                                 sharedPropertyGood1 AndAlso sharedPropertyGood2 AndAlso interfacePropertyGood
+                                 sharedPropertyGood1 AndAlso sharedPropertyGood2 AndAlso interfacePropertyGood1 AndAlso 
+                                 virtualPropertyGood3 AndAlso virtualPropertyGood4 AndAlso interfacePropertyGood2 AndAlso 
+                                 p5MyClassGood AndAlso p5MeGood AndAlso p5InterfaceGood
 
             Return methodsGood AndAlso propertiesGood
         End Function
@@ -89,5 +105,6 @@ Module Program
         End Function
 
         Protected Overrides Property P4 As Integer = 44
+        Protected Friend Overrides ReadOnly Property P5Renamed As Integer = 55
     End Class
 End Module

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/InheritanceTests.vb
@@ -5,14 +5,21 @@ Imports Xunit
 Module Program
 
     Public Class InheritanceTests
-    <Fact()>
+        <Fact()>
         Public Sub MyClassInheritance()
             Dim x As A = New B
             Assert.True(x.TestMethod())
         End Sub
     End Class
 
+    Public Interface IA
+        Function F4() As Integer
+        Property P4() As Integer
+    End Interface
+
     Public Class A
+        Implements IA
+
         Overridable Function F1() As Integer
             Return 1
         End Function
@@ -25,9 +32,14 @@ Module Program
             Return 3
         End Function
 
+        Protected Overridable Function F4() As Integer Implements IA.F4
+            Return 1
+        End Function
+
         Overridable ReadOnly Property P1 As Integer = 1
         Property P2 As Integer = 2
         Shared Property P3 As Integer = 3
+        Protected Overridable Property P4 As Integer = 4 Implements IA.P4
 
         Public Function TestMethod() As Boolean
             Dim virtualMethodGood1 = MyClass.F1() = 1
@@ -36,6 +48,7 @@ Module Program
             Dim nonVirtualMethodGood2 = Me.F2() = 2
             Dim sharedMethodGood1 = MyClass.F3() = 3
             Dim sharedMethodGood2 = A.F3() = 3
+            Dim interfaceMethodGood = CType(Me, IA).F4() = 11
 
             Dim virtualPropertyGood1 = MyClass.P1 = 1
             Dim virtualPropertyGood2 = Me.P1 = 11
@@ -43,17 +56,19 @@ Module Program
             Dim nonVirtualPropertyGood2 = Me.P2 = 2
             Dim sharedPropertyGood1 = MyClass.P3 = 3
             Dim sharedPropertyGood2 = A.P3 = 3
+            Dim interfacePropertyGood = CType(Me, IA).P4() = 44
 
             Dim methodsGood = virtualMethodGood1 AndAlso virtualMethodGood2 AndAlso
                               nonVirtualMethodGood1 AndAlso nonVirtualMethodGood2 AndAlso
-                              sharedMethodGood1 AndAlso sharedMethodGood2
+                              sharedMethodGood1 AndAlso sharedMethodGood2 AndAlso interfaceMethodGood
 
             Dim propertiesGood = virtualPropertyGood1 AndAlso virtualPropertyGood2 AndAlso
                                  nonVirtualPropertyGood1 AndAlso nonVirtualPropertyGood2 AndAlso
-                                 sharedPropertyGood1 AndAlso sharedPropertyGood2
+                                 sharedPropertyGood1 AndAlso sharedPropertyGood2 AndAlso interfacePropertyGood
 
             Return methodsGood AndAlso propertiesGood
         End Function
+
     End Class
 
 
@@ -68,5 +83,11 @@ Module Program
                 Return 11
             End Get
         End Property
+
+        Protected Overrides Function F4() As Integer
+            Return 44
+        End Function
+
+        Protected Overrides Property P4 As Integer = 44
     End Class
 End Module

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
@@ -10,10 +10,23 @@ Namespace [Aaa]
     End Class
     Partial Class z
     End Class
+	
+	Public Interface IBase
+		Sub UPper()
+		Property Foo As Boolean
+		
+		Function Fun() As Integer
+		Property Bar As Integer
+	End Interface
 
     MustInherit Class Base
-        MustOverride Sub UPPER()
-        MustOverride Property FOO As Boolean
+		Implements IBase
+		
+        MustOverride Sub UPPER() Implements IBase.UPPER
+        MustOverride Property FOO As Boolean Implements IBase.FOO
+		
+		MustOverride Function FunRenamed() As Integer Implements IBase.Fun
+		MustOverride Property BarRenamed As Integer Implements IBase.Bar
     End Class
     Class NotBase
         Inherits Base
@@ -21,6 +34,10 @@ Namespace [Aaa]
         Public Overrides Sub upper()
         End Sub
         Public Overrides Property foo As Boolean
+		
+		Public Overrides Function funRENAMED() As Integer
+		End Function
+		Public Overrides Property barRENAMED As Integer
     End Class
 End Namespace
 
@@ -50,5 +67,22 @@ Public Class NamespaceCasing
         Aaa.A.Foo()
         aaa.b.bar()
         Aaa.B.Bar()
+
+        Dim notBase As New Aaa.NotBase
+        Dim base As Aaa.Base = notBase
+		Dim interf As Aaa.IBase = notBase
+        notBase.upper()
+        base.UPPER()
+		interf.UPper()
+        notBase.foo = True
+        base.FOO = True
+		interf.Foo = True
+		
+		base.FunRenamed()
+		base.BarRenamed = 5
+		notBase.funRENAMED()
+		notBase.barRENAMED = 5
+		interf.Fun()
+		interf.Bar = 5
     End Sub
 End Class

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/NamespaceCasing.vb
@@ -11,22 +11,22 @@ Namespace [Aaa]
     Partial Class z
     End Class
 	
-	Public Interface IBase
-		Sub UPper()
-		Property Foo As Boolean
+    Public Interface IBase
+        Sub UPper()
+        Property Foo As Boolean
 		
-		Function Fun() As Integer
-		Property Bar As Integer
-	End Interface
+        Function Fun() As Integer
+        Property Bar As Integer
+    End Interface
 
     MustInherit Class Base
-		Implements IBase
+        Implements IBase
 		
         MustOverride Sub UPPER() Implements IBase.UPPER
         MustOverride Property FOO As Boolean Implements IBase.FOO
 		
-		MustOverride Function FunRenamed() As Integer Implements IBase.Fun
-		MustOverride Property BarRenamed As Integer Implements IBase.Bar
+        MustOverride Function FunRenamed() As Integer Implements IBase.Fun
+        MustOverride Property BarRenamed As Integer Implements IBase.Bar
     End Class
     Class NotBase
         Inherits Base
@@ -35,9 +35,9 @@ Namespace [Aaa]
         End Sub
         Public Overrides Property foo As Boolean
 		
-		Public Overrides Function funRENAMED() As Integer
-		End Function
-		Public Overrides Property barRENAMED As Integer
+        Public Overrides Function funRENAMED() As Integer
+        End Function
+        Public Overrides Property barRENAMED As Integer
     End Class
 End Namespace
 
@@ -70,19 +70,19 @@ Public Class NamespaceCasing
 
         Dim notBase As New Aaa.NotBase
         Dim base As Aaa.Base = notBase
-		Dim interf As Aaa.IBase = notBase
+        Dim interf As Aaa.IBase = notBase
         notBase.upper()
         base.UPPER()
-		interf.UPper()
+        interf.UPper()
         notBase.foo = True
         base.FOO = True
-		interf.Foo = True
+        interf.Foo = True
 		
-		base.FunRenamed()
-		base.BarRenamed = 5
-		notBase.funRENAMED()
-		notBase.barRENAMED = 5
-		interf.Fun()
-		interf.Bar = 5
+        base.FunRenamed()
+        base.BarRenamed = 5
+        notBase.funRENAMED()
+        notBase.barRENAMED = 5
+        interf.Fun()
+        interf.Bar = 5
     End Sub
 End Class

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/ParametrizedPropertiesInheritanceTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/ParametrizedPropertiesInheritanceTests.vb
@@ -1,0 +1,81 @@
+﻿Imports System
+Imports System.Linq
+Imports Xunit
+
+Module Program
+
+    Public Class ParametrizedPropertiesInheritanceTests
+        <Fact()>
+        Public Sub MyClassInheritance()
+            Dim x As A = New B
+            Assert.True(x.TestMethod())
+        End Sub
+    End Class
+
+    Public Interface IA
+        Property P1(Optional str As String = "") As Integer
+        Property P2(Optional str As String = "") As Integer
+    End Interface
+
+    Public Class A
+        Implements IA
+
+        Private _p1 As Integer = 1
+        Property P1(Optional str As String = "") As Integer Implements IA.P1
+            Get
+                Return _p1
+            End Get
+            Set
+                _p1 = Value
+            End Set
+        End Property
+
+        Private _p2 As Integer = 2
+        Protected Overridable Property P2(Optional str As String = "") As Integer Implements IA.P2
+            Get
+                Return _p2
+            End Get
+            Set
+                _p2 = Value
+            End Set
+        End Property
+
+        Public Function TestMethod() As Boolean
+            Dim nonVirtualPropertyMe = Me.P1() = 1
+            Dim interfaceProperty1 = CType(Me, IA).P1() = 1
+            Me.P1() = 11
+            Dim nonVirtualPropertyMeAfterSet = Me.P1() = 11
+            Dim interfaceProperty1AfterSet = CType(Me, IA).P1() = 11
+
+            Dim virtualPropertyMe = Me.P2() = 22
+            Dim interfaceProperty2 = CType(Me, IA).P2() = 22
+            Me.P2 = 33
+            Dim virtualPropertyMeAfterSet = Me.P2 = 33
+            Dim interfaceProperty2AfterSet = CType(Me, IA).P2() = 33
+
+            Dim P1Good = nonVirtualPropertyMe AndAlso interfaceProperty1 AndAlso 
+                         nonVirtualPropertyMeAfterSet AndAlso interfaceProperty1AfterSet
+
+            Dim P2Good = virtualPropertyMe AndAlso interfaceProperty2 AndAlso 
+                         virtualPropertyMeAfterSet AndAlso interfaceProperty2AfterSet
+
+            Return P1Good AndAlso P2Good
+        End Function
+
+    End Class
+
+
+    Public Class B
+        Inherits A
+
+        Private _p2 As Integer = 22
+        Protected Overrides Property P2(Optional str As String = "") As Integer
+            Get
+                Return _p2
+            End Get
+            Set
+                _p2 = Value
+            End Set
+        End Property
+    End Class
+End Module

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/ShadowsInheritanceTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/ShadowsInheritanceTests.vb
@@ -1,0 +1,79 @@
+﻿Imports System
+Imports System.Linq
+Imports Xunit
+
+Module Program
+
+    Public Class ShadowsInheritanceTests
+        <Fact()>
+        Public Sub MyClassInheritance()
+            Dim x As A = New B
+            Assert.True(x.TestMethod())
+        End Sub
+    End Class
+
+    Public Interface IA
+        Function F1() As Integer
+        Property P1() As Integer
+
+        Function F2() As Integer
+        Property P2() As Integer
+    End Interface
+
+    Public Class A
+        Implements IA
+
+        Overridable Function F1Renamed() As Integer Implements IA.F1
+            Return 1
+        End Function
+
+        Overridable Function F2() As Integer Implements IA.F2
+            Return 2
+        End Function
+
+        Overridable Property P1Renamed As Integer = 1 Implements IA.P1
+        Overridable Property P2 As Integer = 2 Implements IA.P2
+
+        Public Function TestMethod() As Boolean
+
+            Dim overridedPropertyGood1 = P1Renamed = 1
+            Dim overridedPropertyGood2 = CType(Me, IA).P1 = 1
+            Dim overridedPropertyGood3 = CType(Me, B).P1Renamed = 11
+            Dim shadowsPropertyGood1 = P2 = 2
+            Dim shadowsPropertyGood2 = CType(Me, IA).P2 = 2
+            Dim shadowsPropertyGood3 = CType(Me, B).P2 = 22
+
+            Dim overridedMethodGood1 = F1Renamed() = 1
+            Dim overridedMethodGood2 = CType(Me, IA).F1 = 1
+            Dim overridedMethodGood3 = CType(Me, B).F1Renamed = 11
+            Dim shadowsMethodGood1 = F2() = 2
+            Dim shadowsMethodGood2 = CType(Me, IA).F2 = 2
+            Dim shadowsMethodGood3 = CType(Me, B).F2 = 22
+
+            Dim methodsGood = overridedMethodGood1 AndAlso overridedMethodGood2 AndAlso overridedMethodGood3 AndAlso
+                              shadowsMethodGood1 AndAlso shadowsMethodGood2 AndAlso shadowsMethodGood3
+
+            Dim propertiesGood = overridedPropertyGood1 AndAlso overridedPropertyGood2 AndAlso overridedPropertyGood3 AndAlso
+                                 shadowsPropertyGood1 AndAlso shadowsPropertyGood2 AndAlso shadowsPropertyGood3
+
+            Return methodsGood AndAlso propertiesGood
+        End Function
+
+    End Class
+
+
+    Public Class B
+        Inherits A
+        Shadows Function F1Renamed() As Integer
+            Return 11
+        End Function
+
+        Shadows Function F2() As Integer
+            Return 22
+        End Function
+
+
+        Shadows Property P1Renamed As Integer = 11
+        Shadows Property P2 As Integer = 22
+    End Class
+End Module


### PR DESCRIPTION
Fixes #813 

Reworked explicit interface implementations for properties/parametrized properties and methods.
Now all explicit implementations have a delegate call to the implementation.
This simplifies the generated code (no casting is required) and fixes some issues like:
- Having a renamed implementation that is abstract. The old solution would generate delegating calls for abstract members which is not correct.
- ReadOnly/WriteOnly explicit interface implementations would have getter/setter which doesn't compile.
- Having a virtual implementation that is being overridden later by a child class. The old solution could change the logic.
- Having one property that implements two interfaces and there is a naming difference only in the second member e.g.:
`Property A As Integer Implements IBar.A, IFoo.B`