### PR TITLE
Fix NotImplementedException when converting property with VB Static local

### DIFF
--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -113,18 +113,22 @@ namespace ICSharpCode.CodeConverter.CSharp
                         var variable = decl.Declaration.Variables.Single();
                         var initializeValue = variable.Initializer?.Value;
                         string methodName;
-                        VBSyntax.MethodBaseSyntax methodOrSubNewStatement;
+                        VBSyntax.MethodBaseSyntax blockStatement;
                         if (_methodNode is VBSyntax.MethodBlockSyntax methodBlock) {
-                            var methodStatement = methodBlock.BlockStatement as VBSyntax.MethodStatementSyntax;
-                            methodOrSubNewStatement = methodStatement;
+                            blockStatement = methodBlock.BlockStatement;
+                            var methodStatement = blockStatement as VBSyntax.MethodStatementSyntax;
                             methodName = methodStatement.Identifier.Text;
                         } else if (_methodNode is VBSyntax.ConstructorBlockSyntax constructorBlock) {
-                            methodOrSubNewStatement = constructorBlock.BlockStatement as VBSyntax.SubNewStatementSyntax;
+                            blockStatement = constructorBlock.BlockStatement;
                             methodName = null;
+                        } else if (_methodNode is VBSyntax.AccessorBlockSyntax accessorBlock) {
+                            blockStatement = accessorBlock.BlockStatement;
+                            var propertyBlock = _methodNode.Parent as VBSyntax.PropertyBlockSyntax;
+                            methodName = propertyBlock.PropertyStatement.Identifier.Text;
                         } else {
                             throw new NotImplementedException(_methodNode.GetType() + " not implemented!");
                         }
-                        var isVbShared = methodOrSubNewStatement.Modifiers.Any(a => a.IsKind(VBasic.SyntaxKind.SharedKeyword));
+                        var isVbShared = blockStatement.Modifiers.Any(a => a.IsKind(VBasic.SyntaxKind.SharedKeyword));
                         _perScopeState.HoistToTopLevel(new HoistedFieldFromVbStaticVariable(methodName, variable.Identifier.Text, initializeValue, decl.Declaration.Type, isVbShared));
                     }
                 } else {

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -3691,6 +3691,50 @@ internal partial class StaticLocalConvertedToField
         }
 
         [Fact]
+        public async Task TestPropertyStaticLocalConvertedToFieldAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+@"Class StaticLocalConvertedToField
+    Readonly Property OtherName() As Integer
+        Get
+            Static sPrevPosition As Integer = 3 ' Comment moves with declaration
+            Console.WriteLine(sPrevPosition)
+            Return sPrevPosition
+        End Get
+    End Property
+    Readonly Property OtherName(x As Integer) as Integer
+        Get
+            Static sPrevPosition As Integer
+            sPrevPosition += 1
+            Return sPrevPosition
+        End Get
+    End Property
+End Class", @"using System;
+
+internal partial class StaticLocalConvertedToField
+{
+    private int _OtherName_sPrevPosition = 3; // Comment moves with declaration
+
+    public int OtherName
+    {
+        get
+        {
+            Console.WriteLine(_OtherName_sPrevPosition);
+            return _OtherName_sPrevPosition;
+        }
+    }
+
+    private int _OtherName_sPrevPosition1 = default;
+
+    public int get_OtherName(int x)
+    {
+        _OtherName_sPrevPosition1 += 1;
+        return _OtherName_sPrevPosition1;
+    }
+}");
+        }
+
+        [Fact]
         public async Task TestStaticLocalConvertedToFieldAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
### Problem
The part that extracts the member name which is used as part of the generated field name was not prepared for the case where the static local is inside a property, throwing a NotImplementedException.

### Solution
* Implemented the missing case, extracting the name from the parent PropertyBlock
* [x] At least one test covering the code changed

