### PR TITLE
Issue/485

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * Fix access modifiers for explicit interface implementations. [#819](https://github.com/icsharpcode/CodeConverter/issues/819)
 * Fix code generation for explicit interface implementations. [#813](https://github.com/icsharpcode/CodeConverter/issues/813)
+* Add support for converting multiple selected files and folders. [#485](https://github.com/icsharpcode/CodeConverter/issues/485)
 * Replace VB-specific library methods with idiomatic framework alternatives [#814](https://github.com/icsharpcode/CodeConverter/pull/814)
 * Remove redundant break expressions in switch-case statements. [#432](https://github.com/icsharpcode/CodeConverter/issues/432)
 

--- a/CodeConverter/CSharp/AdditionalInitializers.cs
+++ b/CodeConverter/CSharp/AdditionalInitializers.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using Microsoft.CodeAnalysis;

--- a/CodeConverter/CSharp/HandledEventsAnalysis.cs
+++ b/CodeConverter/CSharp/HandledEventsAnalysis.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/CodeConverter/CSharp/Replacements/SimpleMethodReplacement.cs
+++ b/CodeConverter/CSharp/Replacements/SimpleMethodReplacement.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;

--- a/CodeConverter/CSharp/SemanticModelExtensions.cs
+++ b/CodeConverter/CSharp/SemanticModelExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;

--- a/CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using Microsoft.CodeAnalysis;

--- a/CodeConverter/Shared/EnumerableExtensions.cs
+++ b/CodeConverter/Shared/EnumerableExtensions.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace ICSharpCode.CodeConverter.Util
+namespace ICSharpCode.CodeConverter.Shared
 {
-    internal static partial class EnumerableExtensions
+    public static partial class EnumerableExtensions
     {
         public static IEnumerable<T> Do<T>(this IEnumerable<T> source, Action<T> action)
         {

--- a/CodeConverter/Shared/ProjectConversion.cs
+++ b/CodeConverter/Shared/ProjectConversion.cs
@@ -9,8 +9,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Util;
+using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Document = Microsoft.CodeAnalysis.Document;
 
 namespace ICSharpCode.CodeConverter.Shared
 {
@@ -26,21 +28,23 @@ namespace ICSharpCode.CodeConverter.Shared
         private readonly CancellationToken _cancellationToken;
 
         private ProjectConversion(IProjectContentsConverter projectContentsConverter, IEnumerable<Document> documentsToConvert, IEnumerable<TextDocument> additionalDocumentsToConvert,
-            ILanguageConversion languageConversion, CancellationToken cancellationToken, bool showCompilationErrors, bool returnSelectedNode = false)
+            ILanguageConversion languageConversion, CancellationToken cancellationToken)
         {
             _projectContentsConverter = projectContentsConverter;
             _languageConversion = languageConversion;
             _documentsToConvert = documentsToConvert.ToList();
             _additionalDocumentsToConvert = additionalDocumentsToConvert.ToList();
-            _showCompilationErrors = showCompilationErrors;
-            _returnSelectedNode = returnSelectedNode;
+            if (languageConversion.ConversionOptions is SingleConversionOptions singleOptions) {
+                _returnSelectedNode = singleOptions.SelectedTextSpan.Length > 0;
+                _showCompilationErrors = singleOptions.ShowCompilationErrors;
+            }
+
             _cancellationToken = cancellationToken;
         }
 
         public static async Task<ConversionResult> ConvertTextAsync<TLanguageConversion>(string text, TextConversionOptions conversionOptions, IProgress<ConversionProgress> progress = null, CancellationToken cancellationToken = default) where TLanguageConversion : ILanguageConversion, new()
         {
-            progress ??= new Progress<ConversionProgress>();
-            using var roslynEntryPoint = await RoslynEntryPointAsync(progress);
+            using var roslynEntryPoint = await RoslynEntryPointAsync(progress ??= new Progress<ConversionProgress>());
 
             var languageConversion = new TLanguageConversion { ConversionOptions = conversionOptions };
             var syntaxTree = languageConversion.MakeFullCompilationUnit(text, out var textSpan);
@@ -52,23 +56,13 @@ namespace ICSharpCode.CodeConverter.Shared
 
         public static async Task<ConversionResult> ConvertSingleAsync<TLanguageConversion>(Document document, SingleConversionOptions conversionOptions, IProgress<ConversionProgress> progress = null, CancellationToken cancellationToken = default) where TLanguageConversion : ILanguageConversion, new()
         {
-            progress ??= new Progress<ConversionProgress>();
-            using var roslynEntryPoint = await RoslynEntryPointAsync(progress);
-
-            var languageConversion = new TLanguageConversion { ConversionOptions = conversionOptions };
-
-            bool returnSelectedNode = conversionOptions.SelectedTextSpan.Length > 0;
-            if (returnSelectedNode) {
-                document = await WithAnnotatedSelectionAsync(document, conversionOptions.SelectedTextSpan);
+            if (conversionOptions.SelectedTextSpan is { Length: > 0 } span) {
+                document = await WithAnnotatedSelectionAsync(document, span);
             }
-
-            var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(document.Project, progress, cancellationToken);
-
-            document = projectContentsConverter.SourceProject.GetDocument(document.Id);
-
-            var conversion = new ProjectConversion(projectContentsConverter, new[] { document }, Enumerable.Empty<TextDocument>(), languageConversion, cancellationToken, conversionOptions.ShowCompilationErrors, returnSelectedNode);
-            var conversionResults = await conversion.Convert(progress).ToArrayAsync(cancellationToken);
-            return GetSingleResultForDocument(conversionResults, document);
+            var conversionResults = await ConvertDocumentsAsync<TLanguageConversion>(new[] {document}, conversionOptions, progress, cancellationToken).ToArrayAsync(cancellationToken);
+            var codeResult = conversionResults.First(r => r.SourcePathOrNull == document.FilePath);
+            codeResult.Exceptions = conversionResults.SelectMany(x => x.Exceptions).ToArray();
+            return codeResult;
         }
 
         public static async IAsyncEnumerable<ConversionResult> ConvertDocumentsAsync<TLanguageConversion>(
@@ -77,24 +71,17 @@ namespace ICSharpCode.CodeConverter.Shared
             IProgress<ConversionProgress> progress = null, 
             [EnumeratorCancellation] CancellationToken cancellationToken = default) where TLanguageConversion : ILanguageConversion, new()
         {
-            progress ??= new Progress<ConversionProgress>();
-            using var roslynEntryPoint = await RoslynEntryPointAsync(progress);
+            using var roslynEntryPoint = await RoslynEntryPointAsync(progress ??= new Progress<ConversionProgress>());
 
             var languageConversion = new TLanguageConversion { ConversionOptions = conversionOptions };
+            
             var project = documents.First().Project;
             var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(project, progress, cancellationToken);
 
             documents = documents.Select(doc => projectContentsConverter.SourceProject.GetDocument(doc.Id)).ToList();
 
-            var conversion = new ProjectConversion(projectContentsConverter, documents, Enumerable.Empty<TextDocument>(), languageConversion, cancellationToken, false);
+            var conversion = new ProjectConversion(projectContentsConverter, documents, Enumerable.Empty<TextDocument>(), languageConversion, cancellationToken);
             await foreach (var result in conversion.Convert(progress).WithCancellation(cancellationToken)) yield return result;
-        }
-
-        private static ConversionResult GetSingleResultForDocument(ConversionResult[] conversionResults, Document document)
-        {
-            var codeResult = conversionResults.First(r => r.SourcePathOrNull == document.FilePath);
-            codeResult.Exceptions = conversionResults.SelectMany(x => x.Exceptions).ToArray();
-            return codeResult;
         }
 
         public static async IAsyncEnumerable<ConversionResult> ConvertProject(Project project,
@@ -103,8 +90,7 @@ namespace ICSharpCode.CodeConverter.Shared
             [EnumeratorCancellation] CancellationToken cancellationToken,
             params (string Find, string Replace, bool FirstOnly)[] replacements)
         {
-            progress ??= new Progress<ConversionProgress>();
-            using var roslynEntryPoint = await RoslynEntryPointAsync(progress);
+            using var roslynEntryPoint = await RoslynEntryPointAsync(progress ??= new Progress<ConversionProgress>());
             var projectContentsConverter = await languageConversion.CreateProjectContentsConverterAsync(project, progress, cancellationToken);
             var sourceFilePaths = project.Documents.Concat(projectContentsConverter.SourceProject.AdditionalDocuments).Select(d => d.FilePath).ToImmutableHashSet();
             var convertProjectContents = ConvertProjectContents(projectContentsConverter, languageConversion, progress, cancellationToken);
@@ -191,7 +177,7 @@ namespace ICSharpCode.CodeConverter.Shared
             //Perf heuristic: Decrease memory pressure on the simplification phase by converting large files first https://github.com/icsharpcode/CodeConverter/issues/524#issuecomment-590301594
             var documentsToConvert = documentsWithLengths.OrderByDescending(d => d.Length).Select(d => d.Doc);
 
-            var projectConversion = new ProjectConversion(projectContentsConverter, documentsToConvert, projectContentsConverter.SourceProject.AdditionalDocuments, languageConversion, cancellationToken, false);
+            var projectConversion = new ProjectConversion(projectContentsConverter, documentsToConvert, projectContentsConverter.SourceProject.AdditionalDocuments, languageConversion, cancellationToken);
 
             var results = projectConversion.Convert(progress);
             await foreach (var result in results.WithCancellation(cancellationToken)) yield return result;

--- a/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using ICSharpCode.CodeConverter.Shared;
 using Microsoft.CodeAnalysis;
 using Roslyn.Utilities;
 

--- a/CodeConverter/Util/ITypeSymbolExtensions.cs
+++ b/CodeConverter/Util/ITypeSymbolExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using Microsoft.CodeAnalysis;
 

--- a/CodeConverter/VB/SemanticModelSymbolSetExtensions.cs
+++ b/CodeConverter/VB/SemanticModelSymbolSetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ICSharpCode.CodeConverter.Shared;
 using ICSharpCode.CodeConverter.Util;
 using Microsoft.CodeAnalysis;
 using CS = Microsoft.CodeAnalysis.CSharp;

--- a/CommandLine/CodeConv.Shared/Util/EnumerableExtensions.cs
+++ b/CommandLine/CodeConv.Shared/Util/EnumerableExtensions.cs
@@ -20,10 +20,5 @@ namespace ICSharpCode.CodeConverter.CommandLine.Util
             dictionary[key] = element;
             return true;
         }
-
-        public static IEnumerable<T> Yield<T>(this T singleElement)
-        {
-            yield return singleElement;
-        }
     }
 }

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -71,8 +71,8 @@ namespace ICSharpCode.CodeConverter.VsExtension
         public async Task ConvertDocumentsAsync<TLanguageConversion>(IReadOnlyCollection<string> documentsFilePath, CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
         {
             try {
-                var containingProjects = await VisualStudioInteraction.GetProjectsContainingAsync(documentsFilePath);
-                await EnsureBuiltAsync(containingProjects);
+                var containingProject = await VisualStudioInteraction.GetFirstProjectContainingAsync(documentsFilePath.First());
+                await EnsureBuiltAsync(containingProject is null ? Array.Empty<Project>() : new[]{containingProject});
                 await _joinableTaskFactory.RunAsync(async () => {
                     var result = ConvertDocumentsUnhandled<TLanguageConversion>(documentsFilePath, cancellationToken);
                     await WriteConvertedFilesAndShowSummaryAsync(result);

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -68,6 +68,22 @@ namespace ICSharpCode.CodeConverter.VsExtension
             }
         }
 
+        public async Task ConvertDocumentsAsync<TLanguageConversion>(IReadOnlyCollection<string> documentsFilePath, CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
+        {
+            try {
+                var containingProjects = await VisualStudioInteraction.GetProjectsContainingAsync(documentsFilePath);
+                await EnsureBuiltAsync(containingProjects);
+                await _joinableTaskFactory.RunAsync(async () => {
+                    var result = ConvertDocumentsUnhandled<TLanguageConversion>(documentsFilePath, cancellationToken);
+                    await WriteConvertedFilesAndShowSummaryAsync(result);
+                });
+            } catch (OperationCanceledException) {
+                if (!_packageCancellation.CancelAll.IsCancellationRequested) {
+                    await _outputWindow.WriteToOutputWindowAsync(Environment.NewLine + "Previous conversion cancelled", forceShow: true);
+                }
+            }
+        }
+
         public async Task ConvertDocumentAsync<TLanguageConversion>(string documentFilePath, Span selected, CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
         {
             try {
@@ -82,7 +98,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
                 if ((await GetOptions()).CopyResultToClipboardForSingleDocument) {
                     await SetClipboardTextOnUiThreadAsync(conversionResult.ConvertedCode ?? conversionResult.GetExceptionsAsString());
                     await _outputWindow.WriteToOutputWindowAsync(Environment.NewLine + "Conversion result copied to clipboard.");
-                    await VisualStudioInteraction.ShowMessageBoxAsync(_serviceProvider, "Conversion result copied to clipboard.", $"Conversion result copied to clipboard. {conversionResult.GetExceptionsAsString()}", false);
+                    await VisualStudioInteraction.ShowMessageBoxAsync("Conversion result copied to clipboard.", $"Conversion result copied to clipboard. {conversionResult.GetExceptionsAsString()}", false);
                 }
             } catch (OperationCanceledException) {
                 if (!_packageCancellation.CancelAll.IsCancellationRequested) {
@@ -180,8 +196,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
             var maxExamples = 30; // Avoid a huge unreadable dialog going off the screen
             var exampleText = pathsToOverwrite.Count > maxExamples ? $". First {maxExamples} examples" : "";
             await _outputWindow.WriteToOutputWindowAsync(Environment.NewLine + "Awaiting user confirmation for overwrite....", forceShow: true);
-            bool shouldOverwrite = await VisualStudioInteraction.ShowMessageBoxAsync(_serviceProvider,
-                "Overwrite solution and referencing projects?",
+            bool shouldOverwrite = await VisualStudioInteraction.ShowMessageBoxAsync("Overwrite solution and referencing projects?",
                 $@"The current solution file and any referencing projects will be overwritten to reference the new project(s){exampleText}:
 * {string.Join(Environment.NewLine + "* ", pathsToOverwrite.Take(maxExamples))}
 
@@ -244,6 +259,24 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             return await ProjectConversion.ConvertSingleAsync<TLanguageConversion>(document, new SingleConversionOptions {SelectedTextSpan = selectedTextSpan, AbandonOptionalTasksAfter = await GetAbandonOptionalTasksAfterAsync()}, CreateOutputWindowProgress(), cancellationToken);
         }
 
+        private async IAsyncEnumerable<ConversionResult> ConvertDocumentsUnhandled<TLanguageConversion>(
+            IReadOnlyCollection<string> documentsPath,
+            [EnumeratorCancellation] CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
+        {
+            await _outputWindow.WriteToOutputWindowAsync($"Converting {documentsPath.Count} files...", true, true);
+
+            var documentsIds = documentsPath.Select(t => _visualStudioWorkspace.CurrentSolution.GetDocumentIdsWithFilePath(t).FirstOrDefault()).ToList();
+            if (documentsIds.Any(t => t == null)) {
+                await _outputWindow.WriteToOutputWindowAsync("One or more file is not part of a compiling project, using best effort text conversion (less accurate).");
+                var convertedTexts = documentsPath.Select(t => ConvertFileTextAsync<TLanguageConversion>(t, Span.FromBounds(0, 0), cancellationToken));
+                foreach (var convertedText in convertedTexts) yield return await convertedText;
+            }
+
+            var documents = documentsIds.Select(t => _visualStudioWorkspace.CurrentSolution.GetDocument(t)).ToList();
+            var convertedDocuments = ProjectConversion.ConvertDocumentsAsync<TLanguageConversion>(documents, new ConversionOptions {AbandonOptionalTasksAfter = await GetAbandonOptionalTasksAfterAsync()}, CreateOutputWindowProgress(), cancellationToken);
+            await foreach (var convertedDocument in convertedDocuments.WithCancellation(cancellationToken)) yield return convertedDocument;
+        }
+
         private async Task<ConversionResult> ConvertFileTextAsync<TLanguageConversion>(string documentPath,
             Span selected, CancellationToken cancellationToken)
             where TLanguageConversion : ILanguageConversion, new()
@@ -292,6 +325,8 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             return fileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool IsCSFileName(IEnumerable<string> fileNames) => fileNames.All(IsCSFileName);
+
         /// <remarks>https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb#L45-L52</remarks>
         public static bool IsVBFileName(string fileName)
         {
@@ -308,6 +343,8 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             }
             return false;
         }
+
+        public static bool IsVBFileName(IEnumerable<string> fileNames) => fileNames.All(IsVBFileName);
 
         public async Task PasteAsAsync<TLanguageConversion>(CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
         {

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -325,8 +325,6 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             return fileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool IsCSFileName(IEnumerable<string> fileNames) => fileNames.All(IsCSFileName);
-
         /// <remarks>https://github.com/dotnet/roslyn/blob/91571a3bb038e05e7bf2ab87510273a1017faed0/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb#L45-L52</remarks>
         public static bool IsVBFileName(string fileName)
         {
@@ -343,8 +341,6 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
             }
             return false;
         }
-
-        public static bool IsVBFileName(IEnumerable<string> fileNames) => fileNames.All(IsVBFileName);
 
         public async Task PasteAsAsync<TLanguageConversion>(CancellationToken cancellationToken) where TLanguageConversion : ILanguageConversion, new()
         {

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -270,6 +270,7 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
                 await _outputWindow.WriteToOutputWindowAsync("One or more file is not part of a compiling project, using best effort text conversion (less accurate).");
                 var convertedTexts = documentsPath.Select(t => ConvertFileTextAsync<TLanguageConversion>(t, Span.FromBounds(0, 0), cancellationToken));
                 foreach (var convertedText in convertedTexts) yield return await convertedText;
+                yield break;
             }
 
             var documents = documentsIds.Select(t => _visualStudioWorkspace.CurrentSolution.GetDocument(t)).ToList();

--- a/Vsix/CodeConverterPackage.cs
+++ b/Vsix/CodeConverterPackage.cs
@@ -46,12 +46,6 @@ namespace ICSharpCode.CodeConverter.VsExtension
     [ProvideUIContextRule(VbEditorMenuVisibilityGuid, name: nameof(VbEditorMenuVisibilityGuid),
         expression: "Vb", termNames: new[] { "Vb" },
         termValues: new[] { "ActiveEditorContentType:Basic" })]
-    [ProvideUIContextRule(CsFileMenuVisibilityGuid, name: nameof(CsFileMenuVisibilityGuid),
-        expression: "DotCs", termNames: new[] { "DotCs" },
-        termValues: new[] { "HierSingleSelectionName:.cs$"})]
-    [ProvideUIContextRule(VbFileMenuVisibilityGuid, name: nameof(VbFileMenuVisibilityGuid),
-        expression: "DotVb", termNames: new[] { "DotVb" },
-        termValues: new[] { "HierSingleSelectionName:.vb$"})]
     [ProvideUIContextRule(CsProjMenuVisibilityGuid, name: nameof(CsProjMenuVisibilityGuid),
         expression: "Csproj", termNames: new[] { "Csproj" },
         termValues: new[] { "ActiveProjectCapability:CSharp" })]
@@ -74,8 +68,6 @@ namespace ICSharpCode.CodeConverter.VsExtension
 
         public const string CsEditorMenuVisibilityGuid = "64448be3-dcfe-467c-8659-408d672a9909";
         public const string VbEditorMenuVisibilityGuid = "8eb86734-0b20-4986-9f20-9ed22824d0e2";
-        public const string CsFileMenuVisibilityGuid = "e32d529f-034b-4fe8-8e27-33a8ecf8f9ca";
-        public const string VbFileMenuVisibilityGuid = "207ed41c-1bf3-4e92-ad4f-f910b461acfc";
         public const string CsProjMenuVisibilityGuid = "045a3ed1-4cb2-4c47-95be-0d99948e854f";
         public const string VbProjMenuVisibilityGuid = "11700acc-38d7-4fc1-88dd-9e316aa5d6d5";
         public const string CsSolutionMenuVisibilityGuid = "cbe34396-af03-49ab-8945-3611a641abf6";

--- a/Vsix/CodeConverterPackage.cs
+++ b/Vsix/CodeConverterPackage.cs
@@ -46,6 +46,18 @@ namespace ICSharpCode.CodeConverter.VsExtension
     [ProvideUIContextRule(VbEditorMenuVisibilityGuid, name: nameof(VbEditorMenuVisibilityGuid),
         expression: "Vb", termNames: new[] { "Vb" },
         termValues: new[] { "ActiveEditorContentType:Basic" })]
+    [ProvideUIContextRule(CsFileMenuVisibilityGuid, name: nameof(CsFileMenuVisibilityGuid),
+        expression: "Csproj", termNames: new[] { "Csproj" },
+        termValues: new[] { "ActiveProjectCapability:CSharp"})]
+    [ProvideUIContextRule(VbFileMenuVisibilityGuid, name: nameof(VbFileMenuVisibilityGuid),
+        expression: "Vbproj", termNames: new[] { "Vbproj" },
+        termValues: new[] { "ActiveProjectCapability:VB"})]
+    [ProvideUIContextRule(CsNodeMenuVisibilityGuid, name: nameof(CsNodeMenuVisibilityGuid),
+        expression: "Csproj", termNames: new[] { "Csproj" },
+        termValues: new[] { "ActiveProjectCapability:CSharp"})]
+    [ProvideUIContextRule(VbNodeMenuVisibilityGuid, name: nameof(VbNodeMenuVisibilityGuid),
+        expression: "Vbproj", termNames: new[] { "Vbproj" },
+        termValues: new[] { "ActiveProjectCapability:VB"})]
     [ProvideUIContextRule(CsProjMenuVisibilityGuid, name: nameof(CsProjMenuVisibilityGuid),
         expression: "Csproj", termNames: new[] { "Csproj" },
         termValues: new[] { "ActiveProjectCapability:CSharp" })]
@@ -68,6 +80,10 @@ namespace ICSharpCode.CodeConverter.VsExtension
 
         public const string CsEditorMenuVisibilityGuid = "64448be3-dcfe-467c-8659-408d672a9909";
         public const string VbEditorMenuVisibilityGuid = "8eb86734-0b20-4986-9f20-9ed22824d0e2";
+        public const string CsFileMenuVisibilityGuid = "e32d529f-034b-4fe8-8e27-33a8ecf8f9ca";
+        public const string VbFileMenuVisibilityGuid = "207ed41c-1bf3-4e92-ad4f-f910b461acfc";
+        public const string CsNodeMenuVisibilityGuid = "1c92cd03-4bcc-4426-8c66-d34b081df30c";
+        public const string VbNodeMenuVisibilityGuid = "3151fbb3-0dd3-4804-8371-3340f65fd05d";
         public const string CsProjMenuVisibilityGuid = "045a3ed1-4cb2-4c47-95be-0d99948e854f";
         public const string VbProjMenuVisibilityGuid = "11700acc-38d7-4fc1-88dd-9e316aa5d6d5";
         public const string CsSolutionMenuVisibilityGuid = "cbe34396-af03-49ab-8945-3611a641abf6";

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -15,6 +15,9 @@
       <Group guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" priority="0x0300">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE" />
       </Group>
+      <Group guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterNodeItemCtxMenuGroup" priority="0x0300">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_FOLDERNODE" />
+      </Group>
       <Group guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectCtxMenuGroup" priority="0x0300" />
       <Group guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterSolutionCtxMenuGroup" priority="0x0300" />
  </Groups>
@@ -39,6 +42,12 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
+        <Strings>
+          <ButtonText>Convert to VB</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBNodeItemCtxCommandId" type="Button" priority="0x0300">
+        <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterNodeItemCtxMenuGroup" />
         <Strings>
           <ButtonText>Convert to VB</ButtonText>
         </Strings>
@@ -87,6 +96,12 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
+        <Strings>
+          <ButtonText>Convert to C#</ButtonText>
+        </Strings>
+      </Button>
+      <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSNodeItemCtxCommandId" type="Button" priority="0x0300">
+        <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterNodeItemCtxMenuGroup" />
         <Strings>
           <ButtonText>Convert to C#</ButtonText>
         </Strings>
@@ -161,16 +176,19 @@
       <IDSymbol name="CodeConverterProjectItemCtxMenuGroup" value="0x1022" />
       <IDSymbol name="CodeConverterProjectCtxMenuGroup" value="0x1023" />
       <IDSymbol name="CodeConverterSolutionCtxMenuGroup" value="0x1024" />
+      <IDSymbol name="CodeConverterNodeItemCtxMenuGroup" value="0x1025" />
       <IDSymbol name="ConvertCSToVBCommandId" value="0x0100" />
       <IDSymbol name="ConvertCSToVBCtxCommandId" value="0x0101" />
       <IDSymbol name="ConvertCSToVBProjectItemCtxCommandId" value="0x0102" />
       <IDSymbol name="ConvertCSToVBProjectCtxCommandId" value="0x0103" />
       <IDSymbol name="ConvertCSToVBSolutionCtxCommandId" value="0x0104" />
+      <IDSymbol name="ConvertCSToVBNodeItemCtxCommandId" value="0x0105" />
       <IDSymbol name="ConvertVBToCSCommandId" value="0x0200" />
       <IDSymbol name="ConvertVBToCSCtxCommandId" value="0x0201" />
       <IDSymbol name="ConvertVBToCSProjectItemCtxCommandId" value="0x0202" />
       <IDSymbol name="ConvertVBToCSProjectCtxCommandId" value="0x0203" />
       <IDSymbol name="ConvertVBToCSSolutionCtxCommandId" value="0x0204" />
+      <IDSymbol name="ConvertVBToCSNodeItemCtxCommandId" value="0x0205" />
       <IDSymbol name="PasteAsVBCommandId" value="0x0300" />
       <IDSymbol name="PasteAsCSCommandId" value="0x0400" />
     </GuidSymbol>

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -39,8 +39,6 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to VB</ButtonText>
         </Strings>
@@ -89,8 +87,6 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to C#</ButtonText>
         </Strings>
@@ -128,8 +124,6 @@
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="PasteAsVBCommandId" context="VbEditorMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBCtxCommandId" context="CsEditorMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSCtxCommandId" context="VbEditorMenuVisibilityGuid" />
-    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" context="CsFileMenuVisibilityGuid" />
-    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" context="VbFileMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectCtxCommandId" context="CsProjMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectCtxCommandId" context="VbProjMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionCtxCommandId" context="CsSolutionMenuVisibilityGuid" />
@@ -155,8 +149,6 @@
 
     <GuidSymbol name="CsEditorMenuVisibilityGuid" value="{64448be3-dcfe-467c-8659-408d672a9909}" />
     <GuidSymbol name="VbEditorMenuVisibilityGuid" value="{8eb86734-0b20-4986-9f20-9ed22824d0e2}" />
-    <GuidSymbol name="CsFileMenuVisibilityGuid" value="{e32d529f-034b-4fe8-8e27-33a8ecf8f9ca}" />
-    <GuidSymbol name="VbFileMenuVisibilityGuid" value="{207ed41c-1bf3-4e92-ad4f-f910b461acfc}" />
     <GuidSymbol name="CsProjMenuVisibilityGuid" value="{045a3ed1-4cb2-4c47-95be-0d99948e854f}" />
     <GuidSymbol name="VbProjMenuVisibilityGuid" value="{11700acc-38d7-4fc1-88dd-9e316aa5d6d5}" />
     <GuidSymbol name="CsSolutionMenuVisibilityGuid" value="{cbe34396-af03-49ab-8945-3611a641abf6}" />

--- a/Vsix/REConverterPackage.vsct
+++ b/Vsix/REConverterPackage.vsct
@@ -42,12 +42,16 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to VB</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBNodeItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterNodeItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to VB</ButtonText>
         </Strings>
@@ -96,12 +100,16 @@
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterProjectItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to C#</ButtonText>
         </Strings>
       </Button>
       <Button guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSNodeItemCtxCommandId" type="Button" priority="0x0300">
         <Parent guid="guidCodeConverterCommandPackageCmdSet" id="CodeConverterNodeItemCtxMenuGroup" />
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
           <ButtonText>Convert to C#</ButtonText>
         </Strings>
@@ -139,6 +147,10 @@
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="PasteAsVBCommandId" context="VbEditorMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBCtxCommandId" context="CsEditorMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSCtxCommandId" context="VbEditorMenuVisibilityGuid" />
+    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectItemCtxCommandId" context="CsFileMenuVisibilityGuid" />
+    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectItemCtxCommandId" context="VbFileMenuVisibilityGuid" />
+    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBNodeItemCtxCommandId" context="CsNodeMenuVisibilityGuid" />
+    <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSNodeItemCtxCommandId" context="VbNodeMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBProjectCtxCommandId" context="CsProjMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertVBToCSProjectCtxCommandId" context="VbProjMenuVisibilityGuid" />
     <VisibilityItem guid="guidCodeConverterCommandPackageCmdSet" id="ConvertCSToVBSolutionCtxCommandId" context="CsSolutionMenuVisibilityGuid" />
@@ -164,6 +176,10 @@
 
     <GuidSymbol name="CsEditorMenuVisibilityGuid" value="{64448be3-dcfe-467c-8659-408d672a9909}" />
     <GuidSymbol name="VbEditorMenuVisibilityGuid" value="{8eb86734-0b20-4986-9f20-9ed22824d0e2}" />
+    <GuidSymbol name="CsFileMenuVisibilityGuid" value="{e32d529f-034b-4fe8-8e27-33a8ecf8f9ca}" />
+    <GuidSymbol name="VbFileMenuVisibilityGuid" value="{207ed41c-1bf3-4e92-ad4f-f910b461acfc}" />
+    <GuidSymbol name="CsNodeMenuVisibilityGuid" value="{1c92cd03-4bcc-4426-8c66-d34b081df30c}" />
+    <GuidSymbol name="VbNodeMenuVisibilityGuid" value="{3151fbb3-0dd3-4804-8371-3340f65fd05d}" />
     <GuidSymbol name="CsProjMenuVisibilityGuid" value="{045a3ed1-4cb2-4c47-95be-0d99948e854f}" />
     <GuidSymbol name="VbProjMenuVisibilityGuid" value="{11700acc-38d7-4fc1-88dd-9e316aa5d6d5}" />
     <GuidSymbol name="CsSolutionMenuVisibilityGuid" value="{cbe34396-af03-49ab-8945-3611a641abf6}" />

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -77,7 +77,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
                 var filesPath = files.Select(t => t.Properties.Item("FullPath").Value as string).Where(fileFilter);
                 allSelectedFiles.AddRange(filesPath);
 
-                projectItems = folders.SelectMany(t => t.ProjectItems?.OfType<ProjectItem>() ?? Enumerable.Empty<ProjectItem>()).ToList();
+                projectItems = folders.Concat(files).SelectMany(t => t.ProjectItems?.OfType<ProjectItem>() ?? Enumerable.Empty<ProjectItem>()).ToList();
             }
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -74,7 +74,8 @@ namespace ICSharpCode.CodeConverter.VsExtension
             while (projectItems.Count > 0) {
                 var folders = projectItems.Where(t => string.Equals(t.Kind, folderKind, StringComparison.OrdinalIgnoreCase));
                 var files = projectItems.Where(t => string.Equals(t.Kind, fileKind, StringComparison.OrdinalIgnoreCase));
-                allSelectedFiles.AddRange(files.Select(t => t.Properties.Item("FullPath").Value as string).Where(fileFilter));
+                var filesPath = files.Select(t => t.Properties.Item("FullPath").Value as string).Where(fileFilter);
+                allSelectedFiles.AddRange(filesPath);
 
                 projectItems = folders.SelectMany(t => t.ProjectItems?.OfType<ProjectItem>() ?? Enumerable.Empty<ProjectItem>()).ToList();
             }
@@ -265,21 +266,6 @@ namespace ICSharpCode.CodeConverter.VsExtension
             var containingProject = Dte.Solution.FindProjectItem(documentFilePath)?.ContainingProject;
             await TaskScheduler.Default;
             return containingProject;
-        }
-
-        public static async Task<List<Project>> GetProjectsContainingAsync(IEnumerable<string> documentsFilePath)
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
-#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
-            var containingProjects = documentsFilePath
-                .Select(t => Dte.Solution.FindProjectItem(t)?.ContainingProject)
-                .Where(t => t != null)
-                .GroupBy(t => t.UniqueName)
-                .Select(t => t.First())
-                .ToList();
-#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
-            await TaskScheduler.Default;
-            return containingProjects;
         }
 
         internal class CaretPosition

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -73,7 +73,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
             while (projectItems.Count > 0) {
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 var folders = projectItems.Where(t => string.Equals(t.Kind, folderKind, StringComparison.OrdinalIgnoreCase));
-                var files = projectItems.Where(t => string.Equals(t.Kind, fileKind, StringComparison.OrdinalIgnoreCase));
+                var files = projectItems.Where(t => string.Equals(t.Kind, fileKind, StringComparison.OrdinalIgnoreCase)).ToList();
                 var filesPath = files.Select(t => t.Properties.Item("FullPath").Value as string).Where(fileFilter);
                 allSelectedFiles.AddRange(filesPath);
 

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -61,13 +61,16 @@ namespace ICSharpCode.CodeConverter.VsExtension
             CancelAllToken = packageCancellation.CancelAll;
         }
 
-        public static async Task<string> GetSingleSelectedItemPathOrDefaultAsync()
+        public static async Task<List<string>> GetSelectedItemsPathAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
-            var selectedItem = await GetSingleSelectedItemOrDefaultAsync();
-            var itemPath = selectedItem?.ItemPath;
+
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+            var itemPaths = GetSelectedSolutionExplorerItems<ProjectItem>().Select(t => t.Properties.Item("FullPath").Value as string).ToList();
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
+
             await TaskScheduler.Default;
-            return itemPath;
+            return itemPaths;
         }
 
         public static async Task<Window> OpenFileAsync(FileInfo fileInfo)
@@ -84,6 +87,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
             ((TextSelection)window?.Document?.Selection)?.SelectAll(); // https://github.com/icsharpcode/CodeConverter/issues/770
             await TaskScheduler.Default;
         }
+
         public static async Task<IReadOnlyCollection<Project>> GetSelectedProjectsAsync(string projectExtension)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
@@ -159,7 +163,7 @@ namespace ICSharpCode.CodeConverter.VsExtension
         }
 
         /// <returns>true iff the user answers "OK"</returns>
-        public static async Task<bool> ShowMessageBoxAsync(IAsyncServiceProvider serviceProvider, string title, string msg, bool showCancelButton, bool defaultOk = true)
+        public static async Task<bool> ShowMessageBoxAsync(string title, string msg, bool showCancelButton, bool defaultOk = true)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
             if (CancelAllToken.IsCancellationRequested) return false;
@@ -169,6 +173,8 @@ namespace ICSharpCode.CodeConverter.VsExtension
                 defaultOk || !showCancelButton ? MessageBoxResult.OK : MessageBoxResult.Cancel);
             return userAnswer == MessageBoxResult.OK;
         }
+
+        public static async Task ShowMessageBoxAsync(string msg) => await ShowMessageBoxAsync(m_Title, msg, showCancelButton: false);
 
         public static async Task EnsureBuiltAsync(IReadOnlyCollection<Project> projects, Func<string, Task> writeMessageAsync)
         {
@@ -250,6 +256,21 @@ namespace ICSharpCode.CodeConverter.VsExtension
             return containingProject;
         }
 
+        public static async Task<List<Project>> GetProjectsContainingAsync(IEnumerable<string> documentsFilePath)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+            var containingProjects = documentsFilePath
+                .Select(t => Dte.Solution.FindProjectItem(t)?.ContainingProject)
+                .Where(t => t != null)
+                .GroupBy(t => t.UniqueName)
+                .Select(t => t.First())
+                .ToList();
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
+            await TaskScheduler.Default;
+            return containingProjects;
+        }
+
         internal class CaretPosition
         {
             private readonly ITextEdit _textEdit;
@@ -270,37 +291,6 @@ namespace ICSharpCode.CodeConverter.VsExtension
             }
         }
 
-        private static async Task<VsDocument> GetSingleSelectedItemOrDefaultAsync()
-        {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(CancelAllToken);
-            var monitorSelection = Package.GetGlobalService(typeof(SVsShellMonitorSelection)) as IVsMonitorSelection;
-            var solution = Package.GetGlobalService(typeof(SVsSolution)) as IVsSolution;
-
-            if ((monitorSelection == null) || (solution == null))
-                return null;
-
-            var hResult = monitorSelection.GetCurrentSelection(out var hierarchyPtr, out uint itemId, out var multiItemSelect, out var selectionContainerPtr);
-            try {
-                if (ErrorHandler.Failed(hResult) || hierarchyPtr == IntPtr.Zero || itemId == VSConstants.VSITEMID_NIL ||
-                    multiItemSelect != null || itemId == VSConstants.VSITEMID_ROOT ||
-                    !(Marshal.GetObjectForIUnknown(hierarchyPtr) is IVsHierarchy hierarchy)) {
-                    return null;
-                }
-
-                int result = solution.GetGuidOfProject(hierarchy, out Guid guidProjectId);
-                // ReSharper disable once SuspiciousTypeConversion.Global - COM Object
-                return ErrorHandler.Succeeded(result) ? new VsDocument((IVsProject) hierarchy, guidProjectId, itemId) : null;
-
-            } finally {
-                if (selectionContainerPtr != IntPtr.Zero) {
-                    Marshal.Release(selectionContainerPtr);
-                }
-
-                if (hierarchyPtr != IntPtr.Zero) {
-                    Marshal.Release(hierarchyPtr);
-                }
-            }
-        }
         private static IEnumerable<T> GetSelectedSolutionExplorerItems<T>() where T: class
         {
             ThreadHelper.ThrowIfNotOnUIThread();

--- a/Vsix/VisualStudioInteraction.cs
+++ b/Vsix/VisualStudioInteraction.cs
@@ -67,19 +67,19 @@ namespace ICSharpCode.CodeConverter.VsExtension
             const string folderKind = "{6BB5F8EF-4483-11D3-8BCF-00C04F8EC28C}";
             const string fileKind = "{6BB5F8EE-4483-11D3-8BCF-00C04F8EC28C}";
 
-#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
             var allSelectedFiles = new List<string>();
             var projectItems = GetSelectedSolutionExplorerItems<ProjectItem>().ToList();
 
             while (projectItems.Count > 0) {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
                 var folders = projectItems.Where(t => string.Equals(t.Kind, folderKind, StringComparison.OrdinalIgnoreCase));
                 var files = projectItems.Where(t => string.Equals(t.Kind, fileKind, StringComparison.OrdinalIgnoreCase));
                 var filesPath = files.Select(t => t.Properties.Item("FullPath").Value as string).Where(fileFilter);
                 allSelectedFiles.AddRange(filesPath);
 
                 projectItems = folders.Concat(files).SelectMany(t => t.ProjectItems?.OfType<ProjectItem>() ?? Enumerable.Empty<ProjectItem>()).ToList();
-            }
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
+            }
 
             await TaskScheduler.Default;
             return allSelectedFiles;


### PR DESCRIPTION
Fixes #485 

Implemented the idea from the issue so both menu items for files/folders are always visible (removed dynamic visibility).
When ```CodeConverterPackage``` is not loaded both of them are active:
![image](https://user-images.githubusercontent.com/9254709/153767902-091cbe2c-24a6-4f1f-9cb5-6208a894774e.png)
but when you try to convert VB->VB (or C#->C#) then the following message will appear:
![image](https://user-images.githubusercontent.com/9254709/153767931-01705fbd-2f41-4dcd-a0da-d088f21c9039.png)

Once ```CodeConverterPackage``` is loaded then the ```BeforeQueryStatusAsync``` will fire and one of them will be greyed out:
![image](https://user-images.githubusercontent.com/9254709/153767981-b848fa4a-b2b4-4151-8d03-78a524139bd7.png)

