### PR TITLE
When passing a property ByRef, don't try to assign it back afterwards…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Replace VB-specific library methods with idiomatic framework alternatives [#814](https://github.com/icsharpcode/CodeConverter/pull/814)
 * Remove redundant break expressions in switch-case statements. [#432](https://github.com/icsharpcode/CodeConverter/issues/432)
 * Generate out parameter instead of ref for implementations of external methods. [#831](https://github.com/icsharpcode/CodeConverter/issues/831)
+* When passing a property ByRef, don't try to assign it back afterwards [#843](https://github.com/icsharpcode/CodeConverter/issues/843)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1626,7 +1626,9 @@ namespace ICSharpCode.CodeConverter.CSharp
             RefConversion GetRefConversion(VBSyntax.ExpressionSyntax expression)
             {
                 var symbolInfo = GetSymbolInfoInDocument<ISymbol>(expression);
-                if (symbolInfo.IsKind(SymbolKind.Property)) return RefConversion.PreAndPostAssignment;
+                if (symbolInfo is IPropertySymbol propertySymbol) {
+                    return propertySymbol.IsReadOnly ? RefConversion.PreAssigment : RefConversion.PreAndPostAssignment;
+                }
 
                 var typeInfo = _semanticModel.GetTypeInfo(expression);
                 bool isTypeMismatch = typeInfo.Type == null || !typeInfo.Type.Equals(typeInfo.ConvertedType);

--- a/Tests/CSharp/ExpressionTests/ByRefTests.cs
+++ b/Tests/CSharp/ExpressionTests/ByRefTests.cs
@@ -363,6 +363,65 @@ public partial class Class1
         }
 
         [Fact]
+        public async Task ReadOnlyPropertyRef_Issue843Async()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Module Module1
+
+    Public Class TestClass
+        Public ReadOnly Property Foo As String
+
+        Public Sub New()
+            Foo = ""abc""
+        End Sub
+    End Class
+
+    Sub Main()
+        Test02()
+    End Sub
+
+    Private Sub Test02()
+        Dim t As New TestClass
+        Test02Sub(t.Foo)
+    End Sub
+
+    Private Sub Test02Sub(ByRef value As String)
+        Console.WriteLine(value)
+    End Sub
+
+End Module", @"using System;
+
+internal static partial class Module1
+{
+    public partial class TestClass
+    {
+        public string Foo { get; private set; }
+
+        public TestClass()
+        {
+            Foo = ""abc"";
+        }
+    }
+
+    public static void Main()
+    {
+        Test02();
+    }
+
+    private static void Test02()
+    {
+        var t = new TestClass();
+        string argvalue = t.Foo;
+        Test02Sub(ref argvalue);
+    }
+
+    private static void Test02Sub(ref string value)
+    {
+        Console.WriteLine(value);
+    }
+}");
+        }
+
+        [Fact]
         public async Task AssignsBackToPropertyAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(@"Imports System


### PR DESCRIPTION
Fixes #843

* [x] At least one test covering the code changed
* [x] Could check if there are other similar cases, e.g. "With" construct
  *  With blocks don't write back to a property

