### PR TITLE
Issue #848, Modify starting project conversion message in SolutionCon…

### DIFF
--- a/CodeConverter/Shared/ProjectConversion.cs
+++ b/CodeConverter/Shared/ProjectConversion.cs
@@ -97,6 +97,8 @@ namespace ICSharpCode.CodeConverter.Shared
 
             var results = WithProjectFile(projectContentsConverter, textReplacementConverter, languageConversion, sourceFilePaths, convertProjectContents, replacements);
             await foreach (var result in results.WithCancellation(cancellationToken)) yield return result;
+
+            progress.Report(new ConversionProgress($"Finished converting {project.Name} at {DateTime.Now:hh:mm}..."));
         }
 
         /// <remarks>Perf: Keep lazy so that we don't keep an extra copy of all files in memory at once</remarks>

--- a/CodeConverter/Shared/SolutionConverter.cs
+++ b/CodeConverter/Shared/SolutionConverter.cs
@@ -96,7 +96,7 @@ namespace ICSharpCode.CodeConverter.Shared
         private IAsyncEnumerable<ConversionResult> ConvertProject(Project project)
         {
             var replacements = _projectReferenceReplacements.ToArray();
-            _progress.Report(new ConversionProgress($"Converting {project.Name}..."));
+            _progress.Report(new ConversionProgress($"Begin converting {project.Name} at {DateTime.Now:hh:mm}..."));
             return ProjectConversion.ConvertProject(project, _languageConversion, _textReplacementConverter, _progress, _cancellationToken, replacements);
         }
 


### PR DESCRIPTION
Modify starting project conversion message in SolutionConverter, add finished converting message to ConvertProject in ProjectConversion.

#848 

### Problem
It's nice to know how long the conversion has been running and when it finally finishes.

### Solution
It doesn't look like the output messages are being tested, so am not attempting to add a unit test for this change.


