### PR TITLE
Issue #854: Fix conversion error when Handle clause property differs by case from actual property

### DIFF
--- a/CodeConverter/CSharp/HandledEventsAnalyzer.cs
+++ b/CodeConverter/CSharp/HandledEventsAnalyzer.cs
@@ -94,10 +94,10 @@ namespace ICSharpCode.CodeConverter.CSharp
                 .SelectMany(mss => mss.HandlesClause.Events, (_, e) => {
                 var eventSymbol = semanticModel.GetSymbolInfo(e.EventMember).Symbol as IEventSymbol;
                 // TODO: Need to either use the semantic model containing the event symbol, or bundle up the Event member with the possible symbol here for later use (otherwise it's null)
-                return (CreateEventContainer(e.EventContainer), new EventDescriptor(e.EventMember, eventSymbol), HandlingMethod: methodSymbol);
+                return (CreateEventContainer(e.EventContainer, semanticModel), new EventDescriptor(e.EventMember, eventSymbol), HandlingMethod: methodSymbol);
             });
         }
-        private HandledEventsAnalysis.EventContainer CreateEventContainer(Microsoft.CodeAnalysis.VisualBasic.Syntax.EventContainerSyntax p)
+        private HandledEventsAnalysis.EventContainer CreateEventContainer(Microsoft.CodeAnalysis.VisualBasic.Syntax.EventContainerSyntax p, SemanticModel semanticModel)
         {
             switch (p) {
                 //For me, trying to use "MyClass" in a Handles expression is a syntax error. Events aren't overridable anyway so I'm not sure how this would get used.
@@ -106,7 +106,7 @@ namespace ICSharpCode.CodeConverter.CSharp
                 case Microsoft.CodeAnalysis.VisualBasic.Syntax.KeywordEventContainerSyntax _:
                     return new HandledEventsAnalysis.EventContainer(HandledEventsAnalysis.EventContainerKind.This, null);
                 case Microsoft.CodeAnalysis.VisualBasic.Syntax.WithEventsEventContainerSyntax weecs:
-                    return new HandledEventsAnalysis.EventContainer(HandledEventsAnalysis.EventContainerKind.Property, weecs.Identifier.Text);
+                    return new HandledEventsAnalysis.EventContainer(HandledEventsAnalysis.EventContainerKind.Property, semanticModel.GetSymbolInfo(weecs).Symbol.Name);
                 case Microsoft.CodeAnalysis.VisualBasic.Syntax.WithEventsPropertyEventContainerSyntax wepecs:
                     return new HandledEventsAnalysis.EventContainer(HandledEventsAnalysis.EventContainerKind.Property, wepecs.Property.Identifier.Text);
                 default:

--- a/Tests/VB/CaseSensitivityTests.cs
+++ b/Tests/VB/CaseSensitivityTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Threading.Tasks;
+
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+using ICSharpCode.CodeConverter.VB;
+
+using Xunit;
+
+namespace ICSharpCode.CodeConverter.Tests.VB
+{
+
+    public class CaseSensitivityTests : ConverterTestBase
+    {
+        [Fact]
+        public async Task HandlesWithDifferingCaseTestAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Public Class VBIsCaseInsensitive
+    Inherits System.Web.UI.Page
+
+    Private Sub btnOK_Click(sender As Object, e As System.EventArgs) Handles btnOK.Click
+    End Sub
+End Class
+
+Partial Public Class VBIsCaseInsensitive
+    Protected WithEvents btnOk As Global.System.Web.UI.WebControls.Button
+End Class
+",
+@"using System;
+using System.Runtime.CompilerServices;
+
+public partial class VBIsCaseInsensitive : System.Web.UI.Page
+{
+    private void btnOK_Click(object sender, EventArgs e)
+    {
+    }
+}
+
+public partial class VBIsCaseInsensitive
+{
+    private System.Web.UI.WebControls.Button _btnOk;
+
+    protected virtual System.Web.UI.WebControls.Button btnOk
+    {
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        get
+        {
+            return _btnOk;
+        }
+
+        [MethodImpl(MethodImplOptions.Synchronized)]
+        set
+        {
+            if (_btnOk != null)
+            {
+                _btnOk.Click -= btnOK_Click;
+            }
+
+            _btnOk = value;
+            if (_btnOk != null)
+            {
+                _btnOk.Click += btnOK_Click;
+            }
+        }
+    }
+}", hasLineCommentConversionIssue: true /*Fields re-ordered*/);
+        }
+
+
+
+    }
+}


### PR DESCRIPTION
Link to issue(s) this covers
#854 

### Problem
When the property declaration and the property reference in the Handles clause, differ by case, the conversion fails trying to create two event containers.

### Solution
* Pass the semantic model to CreateEventContainer so it can be used to get the name from the property declaration
* Change is relatively minor, all unit test continue to pass
* Added new unit test, unit test fails without change, passes after change.
* Copied "hasLineCommentConversionIssue: true /*Fields re-ordered*/);" from another test, not sure what that actually means.
