### PR TITLE
Add post-assignment to hoisted by-ref argument

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1662,14 +1662,19 @@ namespace ICSharpCode.CodeConverter.CSharp
                     return propertySymbol.IsReadOnly ? RefConversion.PreAssigment : RefConversion.PreAndPostAssignment;
                 }
 
-                var typeInfo = _semanticModel.GetTypeInfo(expression);
-                bool isTypeMismatch = typeInfo.Type == null || !typeInfo.Type.Equals(typeInfo.ConvertedType);
-
-                if (isTypeMismatch || DeclaredInUsing(symbolInfo)) return RefConversion.PreAssigment;
+                if (DeclaredInUsing(symbolInfo)) return RefConversion.PreAssigment;
 
                 if (expression is VBasic.Syntax.IdentifierNameSyntax || expression is VBSyntax.MemberAccessExpressionSyntax ||
                     IsRefArrayAcces(expression)) {
-                    return RefConversion.Inline;
+
+                    var typeInfo = _semanticModel.GetTypeInfo(expression);
+                    bool isTypeMismatch = typeInfo.Type == null || !typeInfo.Type.Equals(typeInfo.ConvertedType);
+
+                    if (isTypeMismatch) {
+                        return RefConversion.PreAndPostAssignment;
+                    } else {
+                        return RefConversion.Inline;
+                    }
                 }
 
                 return RefConversion.PreAssigment;

--- a/Tests/CSharp/ExpressionTests/ByRefTests.cs
+++ b/Tests/CSharp/ExpressionTests/ByRefTests.cs
@@ -108,8 +108,10 @@ public partial class Class1
         C1 = (Class1)argclass12;
         object argclass13 = _c2;
         Bar(ref argclass13);
+        _c2 = (Class1)argclass13;
         object argclass14 = _c2;
         Bar(ref argclass14);
+        _c2 = (Class1)argclass14;
         Bar(ref _o1);
         Bar(ref _o1);
     }
@@ -610,5 +612,42 @@ internal static partial class Other
     public static List<object> lst2 = new List<object>(new[] { 1.ToString(), 2.ToString(), 3.ToString() });
 }");
         }
+
+        [Fact]
+        public async Task Issue856Async()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Public Class Issue856
+    Sub Main()
+        Dim decimalTarget As Decimal
+        Double.TryParse(""123"", decimalTarget)
+        
+        Dim longTarget As Long
+        Integer.TryParse(""123"", longTarget)
+        
+        Dim intTarget As Integer
+        Long.TryParse(""123"", intTarget)
+    End Sub
+
+End Class", @"
+public partial class Issue856
+{
+    public void Main()
+    {
+        var decimalTarget = default(decimal);
+        double argresult = (double)decimalTarget;
+        double.TryParse(""123"", out argresult);
+        decimalTarget = (decimal)argresult;
+        var longTarget = default(long);
+        int argresult1 = (int)longTarget;
+        int.TryParse(""123"", out argresult1);
+        longTarget = argresult1;
+        var intTarget = default(int);
+        long argresult2 = intTarget;
+        long.TryParse(""123"", out argresult2);
+        intTarget = (int)argresult2;
+    }
+}");
+        }
+
     }
 }

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/AClass.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/AClass.cs
@@ -26,6 +26,7 @@ namespace VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         private void UseEnumFromOtherFileInSolution(AnEnumType m)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/Module1.cs
@@ -14,6 +14,7 @@ namespace VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         public static void Main()

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/AClass.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/AClass.cs
@@ -26,6 +26,7 @@ namespace Prefix.VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         private void UseEnumFromOtherFileInSolution(AnEnumType m)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/Module1.cs
@@ -13,6 +13,7 @@ namespace Prefix.VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         public static void Main()

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/AClass.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/AClass.cs
@@ -26,6 +26,7 @@ namespace VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         private void UseEnumFromOtherFileInSolution(AnEnumType m)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/Module1.cs
@@ -14,6 +14,7 @@ namespace VbLibrary
             var x = default(object);
             int argvalue = Conversions.ToInteger(x);
             dict.TryGetValue(1, out argvalue);
+            x = argvalue;
         }
 
         public static void Main()


### PR DESCRIPTION
Add post-assignment to hoisted by-ref argument when argument is an identifer, member access, or array access. Fixes #856

Link to issue(s) this covers
https://github.com/icsharpcode/CodeConverter/issues/856

### Problem
https://github.com/icsharpcode/CodeConverter/issues/856

### Solution
* Return PreAndPostAssignment when expression is a candidate for inline passing if not for the type mismatch.
* All other cases (such as when expression is NothingLiteralSyntax, ObjectCreationSyntax, etc) still just return PreAssignment as before.

* [x] At least one test covering the code changed

