### PR TITLE
Fix binary expressions for nullable types in VB->C# conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Xml Namespace Imports now converted [#836](https://github.com/icsharpcode/CodeConverter/issues/836)
 * Use explicit cast when integral numeric types are casted to enum [#861](https://github.com/icsharpcode/CodeConverter/issues/861)
 * Correct inconsistent casing of event handlers [#854](https://github.com/icsharpcode/CodeConverter/issues/854)
+* Fix binary expressions for nullable types in VB->C# conversion [#840](https://github.com/icsharpcode/CodeConverter/issues/840)
 
 ### C# -> VB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### VB -> C#
 
 * Convert immediately executed lambdas without causing a compiler error [#869](https://github.com/icsharpcode/CodeConverter/issues/869)
+* Fix binary expressions for nullable types in VB->C# conversion [#840](https://github.com/icsharpcode/CodeConverter/issues/840)
 
 ### C# -> VB
 
@@ -28,7 +29,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Xml Namespace Imports now converted [#836](https://github.com/icsharpcode/CodeConverter/issues/836)
 * Use explicit cast when integral numeric types are casted to enum [#861](https://github.com/icsharpcode/CodeConverter/issues/861)
 * Correct inconsistent casing of event handlers [#854](https://github.com/icsharpcode/CodeConverter/issues/854)
-* Fix binary expressions for nullable types in VB->C# conversion [#840](https://github.com/icsharpcode/CodeConverter/issues/840)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -53,8 +53,9 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         TriviaConvertingDeclarationVisitor = new CommentConvertingVisitorWrapper(this, _semanticModel.SyntaxTree);
         var expressionEvaluator = new ExpressionEvaluator(semanticModel, _visualBasicEqualityComparison);
         var typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, _extraUsingDirectives, _csSyntaxGenerator, expressionEvaluator);
+        var nullableExpressionsConverter = new VisualBasicNullableExpressionsConverter();
         CommonConversions = new CommonConversions(document, semanticModel, typeConversionAnalyzer, csSyntaxGenerator, compilation, csCompilation, _typeContext, _visualBasicEqualityComparison);
-        var expressionNodeVisitor = new ExpressionNodeVisitor(semanticModel, _visualBasicEqualityComparison, _typeContext, CommonConversions, _extraUsingDirectives, _xmlImportContext);
+        var expressionNodeVisitor = new ExpressionNodeVisitor(semanticModel, _visualBasicEqualityComparison, _typeContext, CommonConversions, _extraUsingDirectives, _xmlImportContext, nullableExpressionsConverter);
         _triviaConvertingExpressionVisitor = expressionNodeVisitor.TriviaConvertingExpressionVisitor;
         _createMethodBodyVisitorAsync = expressionNodeVisitor.CreateMethodBodyVisitorAsync;
         CommonConversions.TriviaConvertingExpressionVisitor = _triviaConvertingExpressionVisitor;

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -33,10 +33,11 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
     private readonly Lazy<IDictionary<ITypeSymbol, string>> _convertMethodsLookupByReturnType;
     private readonly LambdaConverter _lambdaConverter;
     private readonly INamedTypeSymbol _vbBooleanTypeSymbol;
+    private readonly VisualBasicNullableExpressionsConverter _visualBasicNullableTypesConverter;
 
     public ExpressionNodeVisitor(SemanticModel semanticModel,
         VisualBasicEqualityComparison visualBasicEqualityComparison, ITypeContext typeContext, CommonConversions commonConversions,
-        HashSet<string> extraUsingDirectives, XmlImportContext xmlImportContext)
+        HashSet<string> extraUsingDirectives, XmlImportContext xmlImportContext, VisualBasicNullableExpressionsConverter visualBasicNullableTypesConverter)
     {
         CommonConversions = commonConversions;
         _semanticModel = semanticModel;
@@ -47,6 +48,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         _typeContext = typeContext;
         _extraUsingDirectives = extraUsingDirectives;
         _xmlImportContext = xmlImportContext;
+        _visualBasicNullableTypesConverter = visualBasicNullableTypesConverter;
         _operatorConverter = VbOperatorConversion.Create(TriviaConvertingExpressionVisitor, semanticModel, visualBasicEqualityComparison, commonConversions.TypeConversionAnalyzer);
         // If this isn't needed, the assembly with Conversions may not be referenced, so this must be done lazily
         _convertMethodsLookupByReturnType =
@@ -765,7 +767,6 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var kind = VBasic.VisualBasicExtensions.Kind(node).ConvertToken(TokenContext.Local);
         SyntaxKind csTokenKind = CSharpUtil.GetExpressionOperatorTokenKind(kind);
 
-
         if (kind == SyntaxKind.LogicalNotExpression && _semanticModel.GetTypeInfo(node.Operand).ConvertedType is { } t) {
             if (t.IsNumericType() || t.IsEnumType()) {
                 csTokenKind = SyntaxKind.TildeToken;
@@ -786,8 +787,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         if (await _operatorConverter.ConvertReferenceOrNothingComparisonOrNullAsync(node.Operand.SkipIntoParens(), true) is { } nothingComparison) {
             return nothingComparison;
         }
-
-        if (operandConvertedType.GetNullableUnderlyingType()?.SpecialType == SpecialType.System_Boolean) {
+        if (operandConvertedType.GetNullableUnderlyingType()?.SpecialType == SpecialType.System_Boolean && node.AlwaysHasBooleanTypeInCSharp()) {
             return SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, expr, LiteralConversions.GetLiteralExpression(false));
         }
 
@@ -821,7 +821,6 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var rhs = await node.Right.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor);
 
         ITypeSymbol forceLhsTargetType = null;
-        ITypeSymbol forceRhsTargetType = null;
         bool omitRightConversion = false;
         bool omitConversion = false;
         if (lhsTypeInfo.Type != null && rhsTypeInfo.Type != null)
@@ -835,13 +834,6 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
                                  rhsTypeInfo.Type.SpecialType == SpecialType.System_String;
                 if (lhsTypeInfo.ConvertedType.SpecialType != SpecialType.System_String) {
                     forceLhsTargetType = _semanticModel.Compilation.GetTypeByMetadataName("System.String");
-                }
-            }
-            else if (node.AlwaysHasBooleanTypeInCSharp()) {
-                if (!node.Left.AlwaysHasBooleanTypeInCSharp() && lhsTypeInfo.Type.GetNullableUnderlyingType()?.SpecialType == SpecialType.System_Boolean) {
-                    forceLhsTargetType = _vbBooleanTypeSymbol;
-                } else if (!node.Right.AlwaysHasBooleanTypeInCSharp() && rhsTypeInfo.Type.GetNullableUnderlyingType()?.SpecialType == SpecialType.System_Boolean) {
-                    forceRhsTargetType = _vbBooleanTypeSymbol;
                 }
             }
         }
@@ -864,16 +856,16 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         omitConversion |= lhsTypeInfo.Type != null && rhsTypeInfo.Type != null &&
                           lhsTypeInfo.Type.IsEnumType() && Equals(lhsTypeInfo.Type, rhsTypeInfo.Type)
                           && !node.IsKind(VBasic.SyntaxKind.AddExpression, VBasic.SyntaxKind.SubtractExpression, VBasic.SyntaxKind.MultiplyExpression, VBasic.SyntaxKind.DivideExpression, VBasic.SyntaxKind.IntegerDivideExpression, VBasic.SyntaxKind.ModuloExpression)
-                          && forceLhsTargetType == null && forceRhsTargetType == null;
+                          && forceLhsTargetType == null;
         lhs = omitConversion ? lhs : CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Left, lhs, forceTargetType: forceLhsTargetType);
-        rhs = omitConversion || omitRightConversion ? rhs : CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Right, rhs, forceTargetType: forceRhsTargetType);
-
+        rhs = omitConversion || omitRightConversion ? rhs : CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Right, rhs);
 
         var kind = VBasic.VisualBasicExtensions.Kind(node).ConvertToken(TokenContext.Local);
         var op = SyntaxFactory.Token(CSharpUtil.GetExpressionOperatorTokenKind(kind));
 
         var csBinExp = SyntaxFactory.BinaryExpression(kind, lhs, op, rhs);
-        return node.Parent.IsKind(VBasic.SyntaxKind.SimpleArgument) ? csBinExp : csBinExp.AddParens();
+        var exp = _visualBasicNullableTypesConverter.WithLogicForNullableTypes(node, lhsTypeInfo, rhsTypeInfo, csBinExp, lhs, rhs);
+        return node.Parent.IsKind(VBasic.SyntaxKind.SimpleArgument) ? exp : exp.AddParens();
     }
 
     private async Task<CSharpSyntaxNode> WithRemovedRedundantConversionOrNullAsync(VBSyntax.InvocationExpressionSyntax conversionNode, ISymbol invocationSymbol)

--- a/CodeConverter/CSharp/VbSyntaxNodeExtensions.cs
+++ b/CodeConverter/CSharp/VbSyntaxNodeExtensions.cs
@@ -13,13 +13,21 @@ internal static class VbSyntaxNodeExtensions
     {
         bool parentIsBinaryExpression = node is VBSyntax.BinaryExpressionSyntax;
         bool parentIsLambda = node.Parent is VBSyntax.LambdaExpressionSyntax;
-        bool parentIsNonArgumentExpression = node.Parent is VBSyntax.ExpressionSyntax && !(node.Parent is VBSyntax.ArgumentSyntax);
+        bool parentIsNonArgumentExpression = node.Parent is VBSyntax.ExpressionSyntax && node.Parent is not VBSyntax.ArgumentSyntax;
         bool parentIsParenthesis = node.Parent is VBSyntax.ParenthesizedExpressionSyntax;
         bool parentIsMemberAccessExpression = node.Parent is VBSyntax.MemberAccessExpressionSyntax;
 
         return parentIsMemberAccessExpression || parentIsNonArgumentExpression && !parentIsBinaryExpression && !parentIsLambda && !parentIsParenthesis;
     }
 
-    public static bool AlwaysHasBooleanTypeInCSharp(this VBSyntax.ExpressionSyntax node) =>
-        node.SkipIntoParens().IsKind(VBasic.SyntaxKind.AndAlsoExpression, VBasic.SyntaxKind.AndExpression, VBasic.SyntaxKind.OrElseExpression, VBasic.SyntaxKind.OrExpression, VBasic.SyntaxKind.NotExpression);
+    public static bool AlwaysHasBooleanTypeInCSharp(this VBSyntax.ExpressionSyntax vbNode)
+    {
+        var parent = vbNode.SkipOutOfParens()?.Parent;
+
+        return parent is VBSyntax.SingleLineIfStatementSyntax singleLine && singleLine.Condition == vbNode ||
+               parent is VBSyntax.IfStatementSyntax ifStatement && ifStatement.Condition == vbNode ||
+               parent is VBSyntax.ElseIfStatementSyntax elseIfStatement && elseIfStatement.Condition == vbNode ||
+               parent is VBSyntax.TernaryConditionalExpressionSyntax ternary && ternary.Condition == vbNode ||
+               parent is VBSyntax.BinaryConditionalExpressionSyntax binary && binary.FirstExpression == vbNode;
+    }
 }

--- a/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
@@ -1,0 +1,176 @@
+﻿using ICSharpCode.CodeConverter.Util.FromRoslyn;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.CSharp;
+
+internal class VisualBasicNullableExpressionsConverter
+{
+    private static readonly IsPatternExpressionSyntax NotFormattedIsPattern = ((IsPatternExpressionSyntax)SyntaxFactory.ParseExpression("is {}"));
+
+    private static ExpressionSyntax CastToNullableBool(object literal) => ValidSyntaxFactory.CastExpression(NullableBoolType, LiteralConversions.GetLiteralExpression(literal));
+    private static readonly NullableTypeSyntax NullableBoolType = SyntaxFactory.NullableType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword)));
+    private static readonly ExpressionSyntax Null = CastToNullableBool(null);
+    private static readonly ExpressionSyntax False = CastToNullableBool(false);
+    private static readonly ExpressionSyntax True = CastToNullableBool(true);
+
+    private int _argCounter;
+
+    public ExpressionSyntax WithLogicForNullableTypes(VBSyntax.BinaryExpressionSyntax vbNode, TypeInfo lhsTypeInfo, TypeInfo rhsTypeInfo, BinaryExpressionSyntax csBinExp, ExpressionSyntax lhs, ExpressionSyntax rhs)
+    {
+        if (!IsSupported(vbNode.Kind()) || 
+            !lhsTypeInfo.ConvertedType.IsNullable() ||
+            !rhsTypeInfo.ConvertedType.IsNullable()) {
+            return csBinExp;
+        }
+
+        var isLhsNullable = lhsTypeInfo.Type.IsNullable();
+        var isRhsNullable = rhsTypeInfo.Type.IsNullable();
+        lhs = lhs.AddParens();
+        rhs = rhs.AddParens();
+
+        if (vbNode.IsKind(VBasic.SyntaxKind.AndAlsoExpression)) {
+            return ForAndAlsoOperator(vbNode, lhs, rhs, isLhsNullable, isRhsNullable).AddParens();
+        } 
+        if (vbNode.IsKind(VBasic.SyntaxKind.OrElseExpression)) {
+            return ForOrElseOperator(vbNode, lhs, rhs, isLhsNullable, isRhsNullable).AddParens();
+        }
+
+        return ForRelationalOperators(vbNode, csBinExp, lhs, rhs, isLhsNullable, isRhsNullable).AddParens();
+    }
+
+    private string GetArgName() => $"arg{Interlocked.Increment(ref _argCounter)}";
+
+    private ExpressionSyntax PatternVar(ExpressionSyntax expr, out ExpressionSyntax name)
+    {
+        var arg = GetArgName();
+        var identifier = SyntaxFactory.Identifier(arg);
+        name = SyntaxFactory.IdentifierName(identifier);
+
+        return SyntaxFactory.IsPatternExpression(expr, SyntaxFactory.VarPattern(SyntaxFactory.SingleVariableDesignation(identifier))).NormalizeWhitespace();
+    }
+
+    private ExpressionSyntax PatternObject(ExpressionSyntax expr, out ExpressionSyntax name)
+    {
+        var identifier = SyntaxFactory.Identifier(GetArgName());
+        name = SyntaxFactory.IdentifierName(identifier);
+        var variable = SyntaxFactory.SingleVariableDesignation(identifier);
+
+        var recursivePattern = (RecursivePatternSyntax)NotFormattedIsPattern.Pattern;
+        return NotFormattedIsPattern.WithExpression(expr).WithPattern(recursivePattern.WithDesignation(variable));
+    }
+
+    private static bool IsSupported(VBasic.SyntaxKind op)
+    {
+        return op switch {
+            VBasic.SyntaxKind.EqualsExpression => true,
+            VBasic.SyntaxKind.NotEqualsExpression => true,
+            VBasic.SyntaxKind.GreaterThanExpression => true,
+            VBasic.SyntaxKind.GreaterThanOrEqualExpression => true,
+            VBasic.SyntaxKind.LessThanExpression => true,
+            VBasic.SyntaxKind.LessThanOrEqualExpression => true,
+            VBasic.SyntaxKind.OrElseExpression => true,
+            VBasic.SyntaxKind.AndAlsoExpression => true,
+            _ => false
+        };
+    }
+
+    private ExpressionSyntax ForRelationalOperators(VBSyntax.BinaryExpressionSyntax vbNode,
+        BinaryExpressionSyntax csNode, ExpressionSyntax lhs, ExpressionSyntax rhs,
+        bool isLhsNullable, bool isRhsNullable)
+    {
+        ExpressionSyntax notNullCondition, lhsName, rhsName;
+        if (!isRhsNullable) {
+            var lhsPattern = PatternObject(lhs, out lhsName);
+            var rhsPattern = PatternVar(rhs, out rhsName);
+            notNullCondition = rhsPattern.And(lhsPattern);
+        } else {
+            var lhsPattern = PatternVar(lhs, out lhsName);
+            var rhsPattern = PatternObject(rhs, out rhsName);
+            notNullCondition = !isLhsNullable ? lhsPattern.And(rhsPattern) : lhsPattern.And(rhsPattern).AndHasValue(lhsName);
+        }
+
+        var bin = lhsName.Bin(rhsName, csNode.Kind());
+        return vbNode.AlwaysHasBooleanTypeInCSharp() ?
+            notNullCondition.And(bin) :
+            notNullCondition.Conditional(bin, Null);
+    }
+
+    private ExpressionSyntax ForAndAlsoOperator(VBSyntax.BinaryExpressionSyntax vbNode,
+        ExpressionSyntax lhs, ExpressionSyntax rhs,
+        bool isLhsNullable, bool isRhsNullable)
+    {
+        var lhsPattern = PatternVar(lhs, out var lhsName);
+        var rhsPattern = PatternObject(rhs, out var rhsName);
+
+        if (vbNode.AlwaysHasBooleanTypeInCSharp()) {
+            if (!isLhsNullable) {
+                return lhs.And(rhs.GetValueOrDefault());
+            }
+            if (!isRhsNullable) {
+                return lhsPattern.AndHasNoValue(lhsName).OrIsTrue(lhsName).And(rhs).AndHasValue(lhsName);
+            }
+            return FullAndExpression().EqualsTrue();
+        }
+
+        if (!isLhsNullable) {
+            return lhs.Conditional(rhs, False);
+        }
+        if (!isRhsNullable) {
+            return lhsPattern.AndHasValue(lhsName).AndIsFalse(lhsName).Conditional(False, rhs.Conditional(lhsName, False));
+        }
+        return FullAndExpression();
+
+        ExpressionSyntax FullAndExpression() => 
+            lhsPattern.AndHasValue(lhsName).AndIsFalse(lhsName)
+                .Conditional(False, rhsPattern.Negate().Conditional(Null, rhsName.Conditional(lhsName, False)));
+    }
+
+    private ExpressionSyntax ForOrElseOperator(VBSyntax.BinaryExpressionSyntax vbNode,
+        ExpressionSyntax lhs, ExpressionSyntax rhs, bool isLhsNullable, bool isRhsNullable)
+    {
+        if (vbNode.AlwaysHasBooleanTypeInCSharp()) {
+            if (!isLhsNullable) {
+                return lhs.Or(rhs.GetValueOrDefault());
+            }
+            return !isRhsNullable ?
+                lhs.GetValueOrDefault().Or(rhs) :
+                lhs.GetValueOrDefault().Or(rhs.GetValueOrDefault());
+        }
+
+        if (!isLhsNullable) {
+            return lhs.Conditional(True, rhs);
+        }
+
+        var lhsPattern = PatternVar(lhs, out var lhsName);
+        var rhsPattern = PatternObject(rhs, out var rhsName);
+
+        var whenFalse = !isRhsNullable ?
+            rhs.Conditional(True, lhsName) :
+            rhsPattern.Negate().Conditional(Null, rhsName.Conditional(True, lhsName));
+
+        return lhsPattern.And(lhsName.GetValueOrDefault()).Conditional(True, whenFalse);
+    }
+}
+
+internal static class NullableTypesLogicExtensions
+{
+    private static ExpressionSyntax HasValue(ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("HasValue"));
+    private static ExpressionSyntax HasNoValue(ExpressionSyntax node) => HasValue(node).Negate();
+    private static ExpressionSyntax Value(ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("Value"));
+
+    public static ExpressionSyntax GetValueOrDefault(this ExpressionSyntax node) => SyntaxFactory.InvocationExpression(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("GetValueOrDefault")));
+    public static ExpressionSyntax Negate(this ExpressionSyntax node) => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, node.AddParens());
+
+    public static ExpressionSyntax And(this ExpressionSyntax a, ExpressionSyntax b) => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, a.AddParens(), b.AddParens()).AddParens();
+    public static ExpressionSyntax AndHasValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, HasValue(b));
+    public static ExpressionSyntax AndHasNoValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, HasNoValue(b));
+    public static ExpressionSyntax AndIsFalse(this ExpressionSyntax a, ExpressionSyntax b) => And(a, Value(b).Negate());
+
+    public static ExpressionSyntax Or(this ExpressionSyntax a, ExpressionSyntax b) => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalOrExpression, a.AddParens(), b.AddParens()).AddParens();
+    public static ExpressionSyntax OrIsTrue(this ExpressionSyntax a, ExpressionSyntax b) => Or(a, Value(b));
+
+    public static ExpressionSyntax Conditional(this ExpressionSyntax condition, ExpressionSyntax whenTrue, ExpressionSyntax whenFalse) => SyntaxFactory.ConditionalExpression(condition.AddParens(), whenTrue.AddParens(), whenFalse.AddParens()).AddParens();
+    public static ExpressionSyntax Bin(this ExpressionSyntax a, ExpressionSyntax b, SyntaxKind op) => SyntaxFactory.BinaryExpression(op, a.AddParens(), b.AddParens()).AddParens();
+    public static ExpressionSyntax EqualsTrue(this ExpressionSyntax a) => SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, a.AddParens(), LiteralConversions.GetLiteralExpression(true)).AddParens();
+}

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -31,8 +31,8 @@
     <EmbeddedResource Include="Common\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
@@ -282,7 +282,7 @@ internal partial class TestClass
         bool x = false;
         if ((a & b) == true)
             return;
-        if ((a is var arg1 && arg1.HasValue && !arg1.Value ? (bool?)false : !(b is { } arg2) ? null : arg2 ? arg1 : false) == true)
+        if ((a is var arg1 && arg1.HasValue && !arg1.Value ? false : !(b is { } arg2) ? null : arg2 ? arg1 : false) == true)
             return;
         if ((a & x) == true)
             return;
@@ -293,7 +293,7 @@ internal partial class TestClass
         if (x && a.GetValueOrDefault())
             return;
         var res = a & b;
-        res = a is var arg7 && arg7.HasValue && !arg7.Value ? (bool?)false : !(b is { } arg8) ? null : arg8 ? arg7 : false;
+        res = a is var arg7 && arg7.HasValue && !arg7.Value ? false : !(b is { } arg8) ? null : arg8 ? arg7 : false;
         res = a & x;
         res = a is var arg9 && arg9.HasValue && !arg9.Value ? false : x ? arg9 : false;
         res = x & a;
@@ -347,7 +347,7 @@ internal partial class TestClass
         if (x || a.GetValueOrDefault())
             return;
         var res = a | b;
-        res = a is var arg1 && arg1.GetValueOrDefault() ? (bool?)true : !(b is { } arg2) ? null : arg2 ? true : arg1;
+        res = a is var arg1 && arg1.GetValueOrDefault() ? true : !(b is { } arg2) ? null : arg2 ? true : arg1;
         res = a | x;
         res = a is var arg3 && arg3.GetValueOrDefault() ? true : x ? true : arg3;
         res = x | a;
@@ -531,7 +531,7 @@ internal partial class TestClass712
     {
         bool? var1 = default;
         bool? var2 = default;
-        return var1 is var arg1 && arg1.GetValueOrDefault() ? (bool?)true : !(!var2 is { } arg2) ? null : arg2 ? true : arg1;
+        return (object)(var1 is var arg1 && arg1.GetValueOrDefault() ? true : !(!var2 is { } arg2) ? null : arg2 ? true : arg1);
     }
 }");
     }

--- a/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
@@ -196,11 +196,329 @@ internal partial class TestClass
     }
 }");
     }
+        [Fact]
+        public async Task CastNullableToNonNullableAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712
+    Private Function TestMethod() As Boolean
+        Dim x As Boolean? = Nothing
+        Return x
+    End Function
 
-    [Fact]
-    public async Task ImplicitBooleanConversion712Async()
+    Private Function TestMethod2() As Integer
+        Dim x As Integer? = Nothing
+        Return x
+    End Function
+End Class", @"
+internal partial class TestClass712
+{
+    private bool TestMethod()
     {
-        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712
+        bool? x = default;
+        return (bool)x;
+    }
+
+    private int TestMethod2()
+    {
+        int? x = default;
+        return (int)x;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task NotOperatorOnNullableBooleanAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712
+    Private Function TestMethod() As Integer
+        Dim x As Boolean? = Nothing
+        If Not x Then Return 1 Else Return 2
+    End Function
+End Class", @"
+internal partial class TestClass712
+{
+    private int TestMethod()
+    {
+        bool? x = default;
+        if (x == false)
+            return 1;
+        else
+            return 2;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task AndOperatorOnNullableBooleanAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim a As Boolean? = Nothing
+        Dim b As Boolean? = Nothing
+        Dim x As Boolean = False
+
+        If a And b Then Return
+        If a AndAlso b Then Return
+        If a And x Then Return
+        If a AndAlso x Then Return
+        If x And a Then Return
+        If x AndAlso a Then Return
+
+        Dim res As Boolean? = a And b
+        res = a AndAlso b
+        res = a And x
+        res = a AndAlso x 
+        res = x And a
+        res = x AndAlso a 
+        
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        bool? a = default;
+        bool? b = default;
+        bool x = false;
+        if ((a & b) == true)
+            return;
+        if ((a is var arg1 && arg1.HasValue && !arg1.Value ? (bool?)false : !(b is { } arg2) ? null : arg2 ? arg1 : false) == true)
+            return;
+        if ((a & x) == true)
+            return;
+        if ((a is var arg3 && !arg3.HasValue || arg3.Value) && x && arg3.HasValue)
+            return;
+        if ((x & a) == true)
+            return;
+        if (x && a.GetValueOrDefault())
+            return;
+        var res = a & b;
+        res = a is var arg7 && arg7.HasValue && !arg7.Value ? (bool?)false : !(b is { } arg8) ? null : arg8 ? arg7 : false;
+        res = a & x;
+        res = a is var arg9 && arg9.HasValue && !arg9.Value ? false : x ? arg9 : false;
+        res = x & a;
+        res = x ? a : false;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task OrOperatorOnNullableBooleanAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim a As Boolean? = Nothing
+        Dim b As Boolean? = Nothing
+        Dim x As Boolean = False
+
+        If a Or b Then Return
+        If a OrElse b Then Return
+        If a Or x Then Return
+        If a OrElse x Then Return
+        If x Or a Then Return
+        If x OrElse a Then Return
+
+        Dim res As Boolean? = a Or b
+        res = a OrElse b
+        res = a Or x
+        res = a OrElse x 
+        res = x Or a
+        res = x OrElse a 
+        
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        bool? a = default;
+        bool? b = default;
+        bool x = false;
+        if ((a | b) == true)
+            return;
+        if (a.GetValueOrDefault() || b.GetValueOrDefault())
+            return;
+        if ((a | x) == true)
+            return;
+        if (a.GetValueOrDefault() || x)
+            return;
+        if ((x | a) == true)
+            return;
+        if (x || a.GetValueOrDefault())
+            return;
+        var res = a | b;
+        res = a is var arg1 && arg1.GetValueOrDefault() ? (bool?)true : !(b is { } arg2) ? null : arg2 ? true : arg1;
+        res = a | x;
+        res = a is var arg3 && arg3.GetValueOrDefault() ? true : x ? true : arg3;
+        res = x | a;
+        res = x ? true : a;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task RelationalOperatorsOnNullableTypeAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim x As Integer? = Nothing
+        Dim y As Integer? = Nothing
+        Dim a As Integer = 0
+
+        Dim res As Boolean? = x = y
+        res = x <> y
+        res = x > y
+        res = x >= y
+        res = x < y
+        res = x <= y
+
+        res = a = y
+        res = a <> y
+        res = a > y
+        res = a >= y
+        res = a < y
+        res = a <= y
+
+        res = x = a
+        res = x <> a
+        res = x > a
+        res = x >= a
+        res = x < a
+        res = x <= a
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        int? x = default;
+        int? y = default;
+        int a = 0;
+        var res = x is var arg1 && y is { } arg2 && arg1.HasValue ? arg1 == arg2 : (bool?)null;
+        res = x is var arg3 && y is { } arg4 && arg3.HasValue ? arg3 != arg4 : (bool?)null;
+        res = x is var arg5 && y is { } arg6 && arg5.HasValue ? arg5 > arg6 : (bool?)null;
+        res = x is var arg7 && y is { } arg8 && arg7.HasValue ? arg7 >= arg8 : (bool?)null;
+        res = x is var arg9 && y is { } arg10 && arg9.HasValue ? arg9 < arg10 : (bool?)null;
+        res = x is var arg11 && y is { } arg12 && arg11.HasValue ? arg11 <= arg12 : (bool?)null;
+        res = a is var arg13 && y is { } arg14 ? arg13 == arg14 : (bool?)null;
+        res = a is var arg15 && y is { } arg16 ? arg15 != arg16 : (bool?)null;
+        res = a is var arg17 && y is { } arg18 ? arg17 > arg18 : (bool?)null;
+        res = a is var arg19 && y is { } arg20 ? arg19 >= arg20 : (bool?)null;
+        res = a is var arg21 && y is { } arg22 ? arg21 < arg22 : (bool?)null;
+        res = a is var arg23 && y is { } arg24 ? arg23 <= arg24 : (bool?)null;
+        res = a is var arg26 && x is { } arg25 ? arg25 == arg26 : (bool?)null;
+        res = a is var arg28 && x is { } arg27 ? arg27 != arg28 : (bool?)null;
+        res = a is var arg30 && x is { } arg29 ? arg29 > arg30 : (bool?)null;
+        res = a is var arg32 && x is { } arg31 ? arg31 >= arg32 : (bool?)null;
+        res = a is var arg34 && x is { } arg33 ? arg33 < arg34 : (bool?)null;
+        res = a is var arg36 && x is { } arg35 ? arg35 <= arg36 : (bool?)null;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task RelationalOperatorsOnNullableTypeInConditionAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim x As Integer? = Nothing
+        Dim y As Integer? = Nothing
+        Dim a As Integer = 0
+
+        If x = y Then Return
+        If x <> y Then Return
+        If x > y Then Return
+        If x >= y Then Return
+        If x < y Then Return
+        If x <= y Then Return
+
+        If a = y Then Return
+        If a <> y Then Return
+        If a > y Then Return
+        If a >= y Then Return
+        If a < y Then Return
+        If a <= y Then Return
+
+        IF x = a Then Return
+        IF x <> a Then Return
+        IF x > a Then Return
+        IF x >= a Then Return
+        IF x < a Then Return
+        IF x <= a Then Return
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        int? x = default;
+        int? y = default;
+        int a = 0;
+        if (x is var arg1 && y is { } arg2 && arg1.HasValue && arg1 == arg2)
+            return;
+        if (x is var arg3 && y is { } arg4 && arg3.HasValue && arg3 != arg4)
+            return;
+        if (x is var arg5 && y is { } arg6 && arg5.HasValue && arg5 > arg6)
+            return;
+        if (x is var arg7 && y is { } arg8 && arg7.HasValue && arg7 >= arg8)
+            return;
+        if (x is var arg9 && y is { } arg10 && arg9.HasValue && arg9 < arg10)
+            return;
+        if (x is var arg11 && y is { } arg12 && arg11.HasValue && arg11 <= arg12)
+            return;
+        if (a is var arg13 && y is { } arg14 && arg13 == arg14)
+            return;
+        if (a is var arg15 && y is { } arg16 && arg15 != arg16)
+            return;
+        if (a is var arg17 && y is { } arg18 && arg17 > arg18)
+            return;
+        if (a is var arg19 && y is { } arg20 && arg19 >= arg20)
+            return;
+        if (a is var arg21 && y is { } arg22 && arg21 < arg22)
+            return;
+        if (a is var arg23 && y is { } arg24 && arg23 <= arg24)
+            return;
+        if (a is var arg26 && x is { } arg25 && arg25 == arg26)
+            return;
+        if (a is var arg28 && x is { } arg27 && arg27 != arg28)
+            return;
+        if (a is var arg30 && x is { } arg29 && arg29 > arg30)
+            return;
+        if (a is var arg32 && x is { } arg31 && arg31 >= arg32)
+            return;
+        if (a is var arg34 && x is { } arg33 && arg33 < arg34)
+            return;
+        if (a is var arg36 && x is { } arg35 && arg35 <= arg36)
+            return;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task NullableBooleanComparedToNormalBooleanAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim var1 As Boolean? = Nothing
+        Dim a = var1 = False
+        Dim b = var1 = True
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        bool? var1 = default;
+        var a = false is var arg2 && var1 is { } arg1 ? arg1 == arg2 : (bool?)null;
+        var b = true is var arg4 && var1 is { } arg3 ? arg3 == arg4 : (bool?)null;
+    }
+}");
+        }
+
+        [Fact]
+        public async Task ImplicitBooleanConversion712Async()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712
     Private Function TestMethod()
         Dim var1 As Boolean? = Nothing
         Dim var2 As Boolean? = Nothing
@@ -213,7 +531,7 @@ internal partial class TestClass712
     {
         bool? var1 = default;
         bool? var2 = default;
-        return var1 == true || var2 == false;
+        return var1 is var arg1 && arg1.GetValueOrDefault() ? (bool?)true : !(!var2 is { } arg2) ? null : arg2 ? true : arg1;
     }
 }");
     }
@@ -234,7 +552,7 @@ internal partial class TestClass712
     {
         bool? var1 = default;
         bool? var2 = default;
-        if (var1 == true || var2 == false)
+        if (var1.GetValueOrDefault() || (!var2).GetValueOrDefault())
             return true;
         else
             return false;

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/BooleanTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/BooleanTests.vb
@@ -1,138 +1,524 @@
 ﻿Imports System
+Imports System.Collections.Generic
 Imports System.Linq
+Imports System.Runtime.CompilerServices
 Imports Xunit
 
-
-''' <summary>
-''' An if statement calls GetValueOrDefault on Nullables
-''' The Not operator propagates nulls and only inverts true/false values
-''' </summary>
 Public Class BooleanTests
 
+    Private Property CallsA As Integer
+    Private _a As Boolean?
+    Private Property A As Boolean?
+        Get
+            CallsA += 1
+            Return _a
+        End Get
+        Set
+            _a = Value
+        End Set
+    End Property
+
+    Private Property CallsB As Integer
+    Private _b As Boolean?
+    Private Property B As Boolean?
+        Get
+            CallsB += 1
+            Return _b
+        End Get
+        Set
+            _b = Value
+        End Set
+    End Property
+
+    Private Property CallsBoolProp As Integer
+    Private _boolProp As Boolean
+    Private Property BoolProp As Boolean
+        Get
+            CallsBoolProp += 1
+            Return _boolProp
+        End Get
+        Set
+            _boolProp = Value
+        End Set
+    End Property
+
+    <Fact>
+    Public Sub CastingNullableBooleanToBoolean()
+        Dim nullBoolean As Boolean? = Nothing
+        Dim trueBool As Boolean? = True
+        Dim falseBool As Boolean? = False
+
+        Dim act = Sub()
+            Dim x As Boolean = nullBoolean
+        End Sub 
+        Dim a As Boolean = trueBool
+        Dim b As Boolean = falseBool
+
+        Assert.Throws(Of InvalidOperationException)(act)
+        Assert.True(a)
+        Assert.False(b)
+    End Sub
+
+    <Fact>
+    Public Sub ComplexBinaryExpressionsAreCorrectlyEvaluated()
+        Dim a As Integer? = 5
+        Dim b As Integer? = Nothing
+        Dim result As Boolean
+
+        If a <> 0 AndAlso a <> b Then result = True Else result = False
+        Assert.False(result)
+
+        If a <> 0 OrElse a <> b Then result = True Else result = False
+        Assert.True(result)
+
+        If a <> 0 And a <> b Then result = True Else result = False
+        Assert.False(result)
+
+        If a <> 0 Or a <> b Then result = True Else result = False
+        Assert.True(result)
+
+        If b <> 0 OrElse b = 5 AndAlso (a <> 4 OrElse a = 5) Then result = True Else result = False
+        Assert.False(result)
+
+        If True <> (b = 3) Then result = True Else result = False
+        Assert.False(result)
+
+    End Sub
+
     <Theory>
+    <InlineData(Nothing, Nothing, Nothing)>
+    <InlineData(Nothing, True, Nothing)>
+    <InlineData(Nothing, False, Nothing)>
+    <InlineData(True, Nothing, Nothing)>
     <InlineData(True, True, False)>
     <InlineData(True, False, True)>
+    <InlineData(False, Nothing, Nothing)>
     <InlineData(False, True, True)>
     <InlineData(False, False, False)>
     Public Sub NotEqualOperatorsOnNullableBoolean(a As Boolean?, b As Boolean?, result As Boolean?)
-        Dim actualResult = a <> b
+        Dim actualResult= a <> b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
+    <InlineData(True, Nothing, Nothing)>
     <InlineData(True, True, False)>
     <InlineData(True, False, True)>
+    <InlineData(False, Nothing, Nothing)>
     <InlineData(False, True, True)>
     <InlineData(False, False, False)>
     Public Sub NotEqualOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?)
-        Dim actualResult = a <> b
+        Dim actualResult= a <> b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
+    <InlineData(Nothing, True, Nothing)>
+    <InlineData(Nothing, False, Nothing)>
     <InlineData(True, True, False)>
     <InlineData(True, False, True)>
     <InlineData(False, True, True)>
     <InlineData(False, False, False)>
     Public Sub NotEqualOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?)
-        Dim actualResult = a <> b
+        Dim actualResult= a <> b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
+    <InlineData(Nothing, Nothing, Nothing)>
+    <InlineData(Nothing, True, Nothing)>
+    <InlineData(Nothing, False, Nothing)>
+    <InlineData(True, Nothing, Nothing)>
     <InlineData(True, True, True)>
     <InlineData(True, False, False)>
+    <InlineData(False, Nothing, Nothing)>
     <InlineData(False, True, False)>
     <InlineData(False, False, True)>
     Public Sub EqualOperatorsOnNullableBoolean(a As Boolean?, b As Boolean?, result As Boolean?)
-        Dim actualResult = a = b
+        Dim actualResult= a = b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
+    <InlineData(True, Nothing, Nothing)>
     <InlineData(True, True, True)>
     <InlineData(True, False, False)>
+    <InlineData(False, Nothing, Nothing)>
     <InlineData(False, True, False)>
     <InlineData(False, False, True)>
     Public Sub EqualOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?)
-        Dim actualResult = a = b
+        Dim actualResult= a = b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
+    <InlineData(Nothing, True, Nothing)>
+    <InlineData(Nothing, False, Nothing)>
     <InlineData(True, True, True)>
     <InlineData(True, False, False)>
     <InlineData(False, True, False)>
     <InlineData(False, False, True)>
     Public Sub EqualOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?)
-        Dim actualResult = a = b
+        Dim actualResult= a = b
         Assert.Equal(actualResult, result)
         Assert.Equal(Not actualResult, Not result)
     End Sub
 
     <Theory>
-    <InlineData(True, True, True)>
-    <InlineData(True, False, False)>
-    <InlineData(False, Nothing, False)>
-    <InlineData(False, True, False)>
-    <InlineData(False, False, False)>
-    Public Sub AndOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?)
-        Dim actualResultAnd = a And b
-        Dim actualResultAndAlso = a AndAlso b
-        Assert.Equal(actualResultAnd, result)
-        Assert.Equal(actualResultAndAlso, result)
-        Assert.Equal(Not actualResultAnd, Not result)
-        Assert.Equal(Not actualResultAndAlso, Not result)
+    <InlineData(Nothing, Nothing, Nothing, 21505, 10, 6)>
+    <InlineData(Nothing, True, Nothing, 21505, 10, 6)>
+    <InlineData(Nothing, False, False, 21505, 9, 6)>
+    <InlineData(True, Nothing, Nothing, 21505, 10, 6)>
+    <InlineData(True, True, True, 5187, 10, 6)>
+    <InlineData(True, False, False, 21505, 9, 6)>
+    <InlineData(False, Nothing, False, 21505, 10, 3)>
+    <InlineData(False, True, False, 21505, 10, 3)>
+    <InlineData(False, False, False, 21505, 9, 3)>
+    Public Sub AndOperatorsOnNullableBoolean(a As Boolean?, b As Boolean?, result As Boolean?, expectedCheck as Integer, expectedCallsA As Integer, expectedCallsB As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.A = a
+        Me.B = b
+        
+        Dim actual = a And b
+        Dim actualAndAlso = a AndAlso b
+
+        Dim actualAndProp = Me.A And Me.B
+        Dim actualAndAlsoProp = Me.A AndAlso Me.B
+
+        Dim actualAndMix = b And Me.A
+        Dim actualAndAlsoMix = b AndAlso Me.A
+        Dim actualAndMix2 = Me.A And b
+        Dim actualAndAlsoMix2 = Me.A AndAlso b
+
+        If a And b Then check1 *= 3 Else check1 *= 5
+        If a AndAlso b Then check1 *= 7 Else check1 *= 11
+        If Me.A And Me.B Then check1 *= 13 Else check1 *= 17
+        If Me.A AndAlso Me.B Then check1 *= 19 Else check1 *= 23
+
+        If a And Me.B Then check2 *= 3 Else check2 *= 5
+        If a AndAlso Me.B Then check2 *= 7 Else check2 *= 11
+        If Me.A And b Then check2 *= 13 Else check2 *= 17
+        If Me.A AndAlso b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actual)
+        Assert.Equal(result, actualAndAlso)
+        Assert.Equal(Not result, Not actual)
+        Assert.Equal(Not result, Not actualAndAlso)
+
+        Assert.Equal(result, actualAndProp)
+        Assert.Equal(result, actualAndAlsoProp)
+        Assert.Equal(Not result, Not actualAndProp)
+        Assert.Equal(Not result, Not actualAndAlsoProp)
+
+        Assert.Equal(result, actualAndMix)
+        Assert.Equal(result, actualAndAlsoMix)
+        Assert.Equal(result, actualAndMix2)
+        Assert.Equal(result, actualAndAlsoMix2)
+        Assert.Equal(Not result, Not actualAndMix)
+        Assert.Equal(Not result, Not actualAndAlsoMix)
+        Assert.Equal(Not result, Not actualAndMix2)
+        Assert.Equal(Not result, Not actualAndAlsoMix2)
+
+        Assert.Equal(expectedCallsA, Me.CallsA)
+        Assert.Equal(expectedCallsB, Me.CallsB)
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
     End Sub
 
     <Theory>
-    <InlineData(Nothing, False, False)>
-    <InlineData(True, True, True)>
-    <InlineData(True, False, False)>
-    <InlineData(False, True, False)>
-    <InlineData(False, False, False)>
-    Public Sub AndOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?)
-        Dim actualResultAnd = a And b
-        Dim actualResultAndAlso = a AndAlso b
-        Assert.Equal(actualResultAnd, result)
-        Assert.Equal(actualResultAndAlso, result)
-        Assert.Equal(Not actualResultAnd, Not result)
-        Assert.Equal(Not actualResultAndAlso, Not result)
+    <InlineData(True, Nothing, Nothing, 21505, 7)>
+    <InlineData(True, True, True, 5187, 7)>
+    <InlineData(True, False, False, 21505, 7)>
+    <InlineData(False, Nothing, False, 21505, 4)>
+    <InlineData(False, True, False, 21505, 4)>
+    <InlineData(False, False, False, 21505, 4)>
+    Public Sub AndOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?, expectedCheck As Integer, expectedCallsB As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.BoolProp = a
+        Me.B = b
+
+        Dim actualAnd = a And b
+        Dim actualAndAlso = a AndAlso b
+        Dim actualAndWithConst = False And b
+        Dim actualAndAlsoWithConst = False AndAlso b
+        Dim actualAndProp = Me.BoolProp And Me.B
+        Dim actualAndAlsoProp = Me.BoolProp AndAlso Me.B
+        Dim actualAndPropWithConst = False And Me.B
+        Dim actualAndAlsoPropWithConst = False AndAlso Me.B
+
+        If Me.BoolProp And Me.B Then check1 *= 3 Else check1 *= 5
+        If Me.BoolProp AndAlso Me.B Then check1 *= 7 Else check1 *= 11
+        If a And Me.B Then check1 *= 13 Else check1 *= 17
+        If a AndAlso Me.B Then check1 *= 19 Else check1 *= 23
+
+        If Me.BoolProp And b Then check2 *= 3 Else check2 *= 5
+        If Me.BoolProp AndAlso b Then check2 *= 7 Else check2 *= 11
+        If a And b Then check2 *= 13 Else check2 *= 17
+        If a AndAlso b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actualAnd)
+        Assert.Equal(result, actualAndAlso)
+        Assert.Equal(False, actualAndWithConst)
+        Assert.Equal(False, actualAndAlsoWithConst)
+        Assert.Equal(result, actualAndProp)
+        Assert.Equal(result, actualAndAlsoProp)
+        Assert.Equal(False, actualAndPropWithConst)
+        Assert.Equal(False, actualAndAlsoPropWithConst)
+
+        Assert.Equal(Not result, Not actualAnd)
+        Assert.Equal(Not result, Not actualAndAlso)
+        Assert.Equal(True, Not actualAndWithConst)
+        Assert.Equal(True, Not actualAndAlsoWithConst)
+
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
+        Assert.Equal(expectedCallsB, Me.CallsB)
+        Assert.Equal(6, Me.CallsBoolProp)
     End Sub
 
     <Theory>
-    <InlineData(True, Nothing, True)>
-    <InlineData(True, True, True)>
-    <InlineData(True, False, True)>
-    <InlineData(False, True, True)>
-    <InlineData(False, False, False)>
-    Public Sub OrOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?)
-        Dim actualResultOr = a Or b
-        Dim actualResultOrElse = a OrElse b
-        Assert.Equal(actualResultOr, result)
-        Assert.Equal(actualResultOrElse, result)
-        Assert.Equal(Not actualResultOr, Not result)
-        Assert.Equal(Not actualResultOrElse, Not result)
+    <InlineData(Nothing, True, Nothing, 21505, 6)>
+    <InlineData(Nothing, False, False, 21505, 6)>
+    <InlineData(True, True, True, 5187, 6)>
+    <InlineData(True, False, False, 21505, 6)>
+    <InlineData(False, True, False, 21505, 3)>
+    <InlineData(False, False, False, 21505, 3)>
+    Public Sub AndOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?, expectedCheck As Integer, expectedCallsBoolProp As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.A = a
+        Me.BoolProp = b
+
+        Dim actualAnd = a And b
+        Dim actualAndAlso = a AndAlso b
+        Dim actualAndWithConst = a And False
+        Dim actualAndAlsoWithConst = a AndAlso False
+        Dim actualAndProp = Me.A And Me.BoolProp
+        Dim actualAndAlsoProp = Me.A AndAlso Me.BoolProp
+        Dim actualAndPropWithConst = Me.A And False
+        Dim actualAndAlsoPropWithConst = Me.A AndAlso False
+
+        If Me.A And Me.BoolProp Then check1 *= 3 Else check1 *= 5
+        If Me.A AndAlso Me.BoolProp Then check1 *= 7 Else check1 *= 11
+        If Me.A And b Then check1 *= 13 Else check1 *= 17
+        If Me.A AndAlso b Then check1 *= 19 Else check1 *= 23
+
+        If a And Me.BoolProp Then check2 *= 3 Else check2 *= 5
+        If a AndAlso Me.BoolProp Then check2 *= 7 Else check2 *= 11
+        If a And b Then check2 *= 13 Else check2 *= 17
+        If a AndAlso b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actualAnd)
+        Assert.Equal(result, actualAndAlso)
+        Assert.Equal(False, actualAndWithConst)
+        Assert.Equal(False, actualAndAlsoWithConst)
+        Assert.Equal(result, actualAndProp)
+        Assert.Equal(result, actualAndAlsoProp)
+        Assert.Equal(False, actualAndPropWithConst)
+        Assert.Equal(False, actualAndAlsoPropWithConst)
+
+        Assert.Equal(Not result, Not actualAnd)
+        Assert.Equal(Not result, Not actualAndAlso)
+        Assert.Equal(True, Not actualAndWithConst)
+        Assert.Equal(True, Not actualAndAlsoWithConst)
+
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
+        Assert.Equal(8, Me.CallsA)
+        Assert.Equal(expectedCallsBoolProp, Me.CallsBoolProp)
     End Sub
 
     <Theory>
-    <InlineData(Nothing, True, True)>
-    <InlineData(True, True, True)>
-    <InlineData(True, False, True)>
-    <InlineData(False, True, True)>
-    <InlineData(False, False, False)>
-    Public Sub OrOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?)
-        Dim actualResultOr = a Or b
-        Dim actualResultOrElse = a OrElse b
-        Assert.Equal(actualResultOr, result)
-        Assert.Equal(actualResultOrElse, result)
-        Assert.Equal(Not actualResultOr, Not result)
-        Assert.Equal(Not actualResultOrElse, Not result)
+    <InlineData(Nothing, Nothing, Nothing, 21505, 10, 6)>
+    <InlineData(Nothing, True, True, 5187, 9, 6)>
+    <InlineData(Nothing, False, Nothing, 21505, 10, 6)>
+    <InlineData(True, Nothing, True, 5187, 10, 3)>
+    <InlineData(True, True, True, 5187, 9, 3)>
+    <InlineData(True, False, True, 5187, 10, 3)>
+    <InlineData(False, Nothing, Nothing, 21505, 10, 6)>
+    <InlineData(False, True, True, 5187, 9, 6)>
+    <InlineData(False, False, False, 21505, 10, 6)>
+    Public Sub OrOperatorsOnNullableBoolean(a As Boolean?, b As Boolean?, result As Boolean?, expectedCheck as Integer, expectedCallsA As Integer, expectedCallsB As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.A = a
+        Me.B = b
+        
+        Dim actual = a Or b
+        Dim actualOrElse = a OrElse b
+
+        Dim actualOrProp = Me.A Or Me.B
+        Dim actualOrElseProp = Me.A OrElse Me.B
+
+        Dim actualOrMix = b Or Me.A
+        Dim actualOrElseMix = b OrElse Me.A
+        Dim actualOrMix2 = Me.A Or b
+        Dim actualOrElseMix2 = Me.A OrElse b
+
+        If a Or b Then check1 *= 3 Else check1 *= 5
+        If a OrElse b Then check1 *= 7 Else check1 *= 11
+        If Me.A Or Me.B Then check1 *= 13 Else check1 *= 17
+        If Me.A OrElse Me.B Then check1 *= 19 Else check1 *= 23
+
+        If a Or Me.B Then check2 *= 3 Else check2 *= 5
+        If a OrElse Me.B Then check2 *= 7 Else check2 *= 11
+        If Me.A Or b Then check2 *= 13 Else check2 *= 17
+        If Me.A OrElse b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actual)
+        Assert.Equal(result, actualOrElse)
+        Assert.Equal(Not result, Not actual)
+        Assert.Equal(Not result, Not actualOrElse)
+
+        Assert.Equal(result, actualOrProp)
+        Assert.Equal(result, actualOrElseProp)
+        Assert.Equal(Not result, Not actualOrProp)
+        Assert.Equal(Not result, Not actualOrElseProp)
+
+        Assert.Equal(result, actualOrMix)
+        Assert.Equal(result, actualOrElseMix)
+        Assert.Equal(result, actualOrMix2)
+        Assert.Equal(result, actualOrElseMix2)
+        Assert.Equal(Not result, Not actualOrMix)
+        Assert.Equal(Not result, Not actualOrElseMix)
+        Assert.Equal(Not result, Not actualOrMix2)
+        Assert.Equal(Not result, Not actualOrElseMix2)
+
+        Assert.Equal(expectedCallsA, Me.CallsA)
+        Assert.Equal(expectedCallsB, Me.CallsB)
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
+    End Sub
+
+    <Theory>
+    <InlineData(True, Nothing, True, 5187, 4)>
+    <InlineData(True, True, True, 5187, 4)>
+    <InlineData(True, False, True, 5187, 4)>
+    <InlineData(False, Nothing, Nothing, 21505, 7)>
+    <InlineData(False, True, True, 5187, 7)>
+    <InlineData(False, False, False, 21505, 7)>
+    Public Sub OrOperatorsOnNormalAndNullableBooleans(a As Boolean, b As Boolean?, result As Boolean?, expectedCheck As Integer, expectedCallsB As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.BoolProp = a
+        Me.B = b
+
+        Dim actualOr = a Or b
+        Dim actualOrElse = a OrElse b
+        Dim actualOrWithConst = True Or b
+        Dim actualOrElseWithConst = True OrElse b
+        Dim actualOrProp = Me.BoolProp Or Me.B
+        Dim actualOrElseProp = Me.BoolProp OrElse Me.B
+        Dim actualOrPropWithConst = True Or Me.B
+        Dim actualOrElsePropWithConst = True OrElse Me.B
+
+        If Me.BoolProp Or Me.B Then check1 *= 3 Else check1 *= 5
+        If Me.BoolProp OrElse Me.B Then check1 *= 7 Else check1 *= 11
+        If a Or Me.B Then check1 *= 13 Else check1 *= 17
+        If a OrElse Me.B Then check1 *= 19 Else check1 *= 23
+
+        If Me.BoolProp Or b Then check2 *= 3 Else check2 *= 5
+        If Me.BoolProp OrElse b Then check2 *= 7 Else check2 *= 11
+        If a Or b Then check2 *= 13 Else check2 *= 17
+        If a OrElse b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actualOr)
+        Assert.Equal(result, actualOrElse)
+        Assert.Equal(True, actualOrWithConst)
+        Assert.Equal(True, actualOrElseWithConst)
+        Assert.Equal(result, actualOrProp)
+        Assert.Equal(result, actualOrElseProp)
+        Assert.Equal(True, actualOrPropWithConst)
+        Assert.Equal(True, actualOrElsePropWithConst)
+
+        Assert.Equal(Not result, Not actualOr)
+        Assert.Equal(Not result, Not actualOrElse)
+        Assert.Equal(False, Not actualOrWithConst)
+        Assert.Equal(False, Not actualOrElseWithConst)
+
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
+        Assert.Equal(expectedCallsB, Me.CallsB)
+        Assert.Equal(6, Me.CallsBoolProp)
+    End Sub
+
+    <Theory>
+    <InlineData(Nothing, True, True, 5187, 6)>
+    <InlineData(Nothing, False, Nothing, 21505, 6)>
+    <InlineData(True, True, True, 5187, 3)>
+    <InlineData(True, False, True, 5187, 3)>
+    <InlineData(False, True, True, 5187, 6)>
+    <InlineData(False, False, False, 21505, 6)>
+    Public Sub OrOperatorsOnNullableAndNormalBoolean(a As Boolean?, b As Boolean, result As Boolean?, expectedCheck As Integer, expectedCallsBoolProp As Integer)
+        Dim check1 As Integer = 1
+        Dim check2 As Integer = 1
+        Me.A = a
+        Me.BoolProp = b
+
+        Dim actualOr = a Or b
+        Dim actualOrElse = a OrElse b
+        Dim actualOrWithConst = a Or True
+        Dim actualOrElseWithConst = a OrElse True
+        Dim actualOrProp = Me.A Or Me.BoolProp
+        Dim actualOrElseProp = Me.A OrElse Me.BoolProp
+        Dim actualOrPropWithConst = Me.A Or True
+        Dim actualOrElsePropWithConst = Me.A OrElse True
+
+        If Me.A Or Me.BoolProp Then check1 *= 3 Else check1 *= 5
+        If Me.A OrElse Me.BoolProp Then check1 *= 7 Else check1 *= 11
+        If Me.A Or b Then check1 *= 13 Else check1 *= 17
+        If Me.A OrElse b Then check1 *= 19 Else check1 *= 23
+
+        If a Or Me.BoolProp Then check2 *= 3 Else check2 *= 5
+        If a OrElse Me.BoolProp Then check2 *= 7 Else check2 *= 11
+        If a Or b Then check2 *= 13 Else check2 *= 17
+        If a OrElse b Then check2 *= 19 Else check2 *= 23
+
+        Assert.Equal(result, actualOr)
+        Assert.Equal(result, actualOrElse)
+        Assert.Equal(True, actualOrWithConst)
+        Assert.Equal(True, actualOrElseWithConst)
+        Assert.Equal(result, actualOrProp)
+        Assert.Equal(result, actualOrElseProp)
+        Assert.Equal(True, actualOrPropWithConst)
+        Assert.Equal(True, actualOrElsePropWithConst)
+
+        Assert.Equal(Not result, Not actualOr)
+        Assert.Equal(Not result, Not actualOrElse)
+        Assert.Equal(False, Not actualOrWithConst)
+        Assert.Equal(False, Not actualOrElseWithConst)
+
+        Assert.Equal(expectedCheck, check1)
+        Assert.Equal(expectedCheck, check2)
+        Assert.Equal(8, Me.CallsA)
+        Assert.Equal(expectedCallsBoolProp, Me.CallsBoolProp)
+    End Sub
+
+    <Theory>
+    <InlineData(Nothing, Nothing, 55, 2)>
+    <InlineData(True, False, 55, 2)>
+    <InlineData(False, True, 21, 2)>
+    Public Sub NegateNullableBoolean(x as Boolean?, expectedResult As Boolean?, expectedCheck As Integer, expectedCalls As Integer)
+        Dim check As Integer = 1
+        Me.A = x
+
+        Dim result1 = Not x
+        Dim result2 = Not Me.A
+
+        If Not x Then check *= 3 Else check *= 5
+        If Not Me.A Then check *= 7 Else check *= 11
+
+        Assert.Equal(expectedResult, result1)
+        Assert.Equal(expectedResult, result2)
+        Assert.Equal(expectedCheck, check)
+        Assert.Equal(expectedCalls, Me.CallsA)
     End Sub
 
     <Fact>

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/NullableRelationalOperators.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/NullableRelationalOperators.vb
@@ -1,0 +1,326 @@
+﻿Imports System
+Imports System.Linq
+Imports Xunit
+
+Public Class NullableRelationalOperatorsTests
+
+    Private Property CallsA As Integer
+    Private _a As Integer?
+    Private Property A As Integer?
+        Get
+            CallsA += 1
+            Return _a
+        End Get
+        Set
+            _a = Value
+        End Set
+    End Property
+
+    Private Property CallsB As Integer
+    Private _b As Integer?
+    Private Property B As Integer?
+        Get
+            CallsB += 1
+            Return _b
+        End Get
+        Set
+            _b = Value
+        End Set
+    End Property
+
+    Private Property CallsIntProp As Integer
+    Private _intProp As Integer
+    Private Property IntProp As Integer
+        Get
+            CallsIntProp += 1
+            Return _intProp
+        End Get
+        Set
+            _intProp = Value
+        End Set
+    End Property
+
+    <Theory>
+    <InlineData(Nothing, Nothing, Nothing, 21505)>
+    <InlineData(Nothing, 1, Nothing, 21505)>
+    <InlineData(1, Nothing, Nothing, 21505)>
+    <InlineData(1, 1, True, 5187)>
+    <InlineData(1, 0, False, 21505)>
+    <InlineData(0, 1, False, 21505)>
+    Public Sub CallCheckOnNullableComparison(a As Integer?, b As Integer?, result As Boolean?, expectedCheck as Integer)
+        Dim check As Integer = 1
+        Me.A = a
+        Me.B = b
+        
+        Dim actual1 = a = b
+        Dim actual2 = Me.A = Me.B
+        Dim actual3 = a = Me.B
+        Dim actual4 = Me.A = b
+
+        If a = b Then check *= 3 Else check *= 5
+        If Me.A = Me.B Then check *= 7 Else check *= 11
+        If a = Me.B Then check *= 13 Else check *= 17
+        If Me.A = b Then check *= 19 Else check *= 23
+
+        Assert.Equal(result, actual1)
+        Assert.Equal(result, actual2)
+        Assert.Equal(result, actual3)
+        Assert.Equal(result, actual4)
+
+        Assert.Equal(expectedCheck, check)
+        Assert.Equal(4, Me.CallsA)
+        Assert.Equal(4, Me.CallsB)
+    End Sub
+
+    <Theory>
+    <InlineData(Nothing, 1, Nothing, 21505)>
+    <InlineData(1, 1, True, 5187)>
+    <InlineData(1, 0, False, 21505)>
+    <InlineData(0, 1, False, 21505)>
+    Public Sub CallCheckOnNullableAndNormalComparison(a As Integer?, b As Integer, result As Boolean?, expectedCheck as Integer)
+        Dim check As Integer = 1
+        Me.A = a
+        Me.IntProp = b
+        
+        Dim actual1 = a = b
+        Dim actual2 = Me.A = b
+        Dim actual3 = a = Me.IntProp
+        Dim actual4 = Me.A = Me.IntProp
+
+        If a = b Then check *= 3 Else check *= 5
+        If Me.A = b Then check *= 7 Else check *= 11
+        If a = Me.IntProp Then check *= 13 Else check *= 17
+        If Me.A = Me.IntProp Then check *= 19 Else check *= 23
+
+        Assert.Equal(result, actual1)
+        Assert.Equal(result, actual2)
+        Assert.Equal(result, actual3)
+        Assert.Equal(result, actual4)
+
+        Assert.Equal(expectedCheck, check)
+        Assert.Equal(4, Me.CallsA)
+        Assert.Equal(4, Me.CallsIntProp)
+    End Sub
+
+    <Theory>
+    <InlineData(1, Nothing, Nothing, 21505)>
+    <InlineData(1, 1, True, 5187)>
+    <InlineData(1, 0, False, 21505)>
+    <InlineData(0, 1, False, 21505)>
+    Public Sub CallCheckOnNormalAndNullableComparison(a As Integer, b As Integer?, result As Boolean?, expectedCheck as Integer)
+        Dim check As Integer = 1
+        Me.IntProp = a
+        Me.B = b
+        
+        Dim actual1 = a = b
+        Dim actual2 = Me.IntProp = b
+        Dim actual3 = a = Me.B
+        Dim actual4 = Me.IntProp = Me.B
+
+        If a = b Then check *= 3 Else check *= 5
+        If Me.IntProp = b Then check *= 7 Else check *= 11
+        If a = Me.B Then check *= 13 Else check *= 17
+        If Me.IntProp = Me.B Then check *= 19 Else check *= 23
+
+        Assert.Equal(result, actual1)
+        Assert.Equal(result, actual2)
+        Assert.Equal(result, actual3)
+        Assert.Equal(result, actual4)
+
+        Assert.Equal(expectedCheck, check)
+        Assert.Equal(4, Me.CallsB)
+        Assert.Equal(4, Me.CallsIntProp)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableComparisonWithReferenceType()
+        Dim x As New ReferenceType
+        Dim nullableInt As Integer? = 5
+        Dim isEqual = x = nullableInt
+        Dim isEqual2 = nullableInt = x
+        Dim isNotEqual = x <> nullableInt
+        Dim isNotEqual2 = nullableInt <> x
+        
+        Dim check = isEqual AndAlso isEqual2 AndAlso Not isNotEqual AndAlso Not isNotEqual2
+
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableComparisonWithValueType()
+        Dim x As New ValueType
+        Dim nullableInt As Integer? = 5
+        Dim isEqual = x = nullableInt
+        Dim isEqual2 = nullableInt = x
+        Dim isNotEqual = x <> nullableInt
+        Dim isNotEqual2 = nullableInt <> x
+        
+        Dim check = isEqual AndAlso isEqual2 AndAlso Not isNotEqual AndAlso Not isNotEqual2
+
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableComparisonWithNullableValueType()
+        Dim x As New ValueType?
+        Dim y As New ValueType?
+        Dim isEqual = x = y
+        Dim isEqual2 = y = x
+        Dim isNotEqual = x <> y
+        Dim isNotEqual2 = y <> x
+        
+        Dim check = isEqual Is Nothing AndAlso isEqual2 Is Nothing AndAlso isNotEqual Is Nothing AndAlso isNotEqual2 Is Nothing AndAlso 
+                    Not isEqual.HasValue AndAlso Not isEqual2.HasValue AndAlso Not isNotEqual.HasValue AndAlso Not isNotEqual2.HasValue 
+
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableEqualityProducesNullableBoolean()
+        Dim x As Integer? = Nothing
+        Dim isEqual = x = 5
+        Dim isEqual2 = 5 = x
+        Dim isNotEqual = x <> 5
+        Dim isNotEqual2 = 5 <> x
+        
+        Dim check = isEqual Is Nothing AndAlso isEqual2 Is Nothing AndAlso
+                    isNotEqual Is Nothing AndAlso isNotEqual2 Is Nothing AndAlso
+                    Not isEqual.HasValue AndAlso Not isEqual2.HasValue AndAlso Not isNotEqual.HasValue AndAlso Not isNotEqual2.HasValue
+
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableWithLessOrGreaterProducesNullableBoolean()
+        Dim x As Integer? = Nothing
+        Dim isLess = x < 5
+        Dim isLess2 = 5 < x
+        Dim isGreater = x > 5
+        Dim isGreater2 = 5 > x
+        
+        Dim check = isLess Is Nothing AndAlso isLess2 Is Nothing AndAlso
+                    isGreater Is Nothing AndAlso isGreater2 Is Nothing AndAlso
+                    Not isLess.HasValue AndAlso Not isLess2.HasValue AndAlso Not isGreater.HasValue AndAlso Not isGreater2.HasValue
+
+        Assert.True(check)
+    End Sub
+    
+    
+    <Fact>
+    Public Sub TestNullableWithLessGreaterOrEqualProducesNullableBoolean()
+        Dim x As Integer? = Nothing
+        Dim isLess = x <= 5
+        Dim isLess2 = 5 <= x
+        Dim isGreater = x >= 5
+        Dim isGreater2 = 5 >= x
+        
+        Dim check = isLess Is Nothing AndAlso isLess2 Is Nothing AndAlso
+                    isGreater Is Nothing AndAlso isGreater2 Is Nothing AndAlso
+                    Not isLess.HasValue AndAlso Not isLess2.HasValue AndAlso Not isGreater.HasValue AndAlso Not isGreater2.HasValue
+
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableEqualityProducesTrueOrFalse()
+        Dim x As Integer? = 5
+        Dim isEqual = x = 5
+        Dim isEqual2 = 5 = x
+        Dim isNotEqual = x <> 5
+        Dim isNotEqual2 = 5 <> x
+        
+        Dim check = isEqual AndAlso isEqual2 AndAlso Not isNotEqual AndAlso Not isNotEqual2 AndAlso
+                    isEqual.HasValue AndAlso isEqual2.HasValue AndAlso isNotEqual.HasValue AndAlso isNotEqual2.HasValue
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableWithLessOrGreaterProducesTrueOrFalse()
+        Dim x As Integer? = 5
+        Dim isLess = x < 6
+        Dim isLess2 = 6 < x
+        Dim isGreater = x > 6
+        Dim isGreater2 = 6 > x
+        
+        Dim check = isLess AndAlso Not isLess2 AndAlso Not isGreater AndAlso isGreater2 AndAlso
+                    isLess.HasValue AndAlso isLess2.HasValue AndAlso isGreater.HasValue AndAlso isGreater2.HasValue
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableWithLessGreaterOrEqualProducesTrueOrFalse()
+        Dim x As Integer? = 5
+        Dim isLess = x <= 5
+        Dim isLess2 = 5 <= x
+        Dim isGreater = x >= 5
+        Dim isGreater2 = 5 >= x
+        
+        Dim check = isLess AndAlso isLess2 AndAlso isGreater AndAlso isGreater2 AndAlso
+                    isLess.HasValue AndAlso isLess2.HasValue AndAlso isGreater.HasValue AndAlso isGreater2.HasValue
+        Assert.True(check)
+    End Sub
+
+    <Fact>
+    Public Sub TestNullableInCondition()
+        Assert.True(NullableInIfCondition(Nothing))
+        Assert.True(NullableInConditionalOperator(Nothing))
+        Assert.True(NullableInConditionalOperator(Nothing))
+    End Sub
+
+    Private Function NullableInIfCondition(x As Integer?) As Boolean
+        If x <> 10 AndAlso x >= 10 Then Return False
+        Return True
+    End Function
+
+    Private Function NullableInConditionalOperator(x As Integer?) As Boolean
+        Return If(x <> 10 AndAlso x <= 10, False, True)
+    End Function
+
+    Private Function ComplexStatementInConditionalOperator(x As Integer?) As Boolean
+        Return If((x <> 10 OrElse x > 5 And x = x) AndAlso (x <= 10 AndAlso (x > 0 OrElse x < 0)), False, True)
+    End Function
+
+    Public Class ReferenceType
+        Public Shared Operator =(left as ReferenceType, right as Integer?) as Boolean
+            Return True
+        End Operator
+
+        Public Shared Operator <>(left as ReferenceType, right as Integer?) as Boolean
+            Return False
+        End Operator
+
+        Public Shared Operator =(left as Integer?, right as ReferenceType) as Boolean
+            Return True
+        End Operator
+
+        Public Shared Operator <>(left as Integer?, right as ReferenceType) as Boolean
+            Return False
+        End Operator
+    End Class
+
+    Public Structure ValueType
+        Public Shared Operator =(left as ValueType, right as ValueType) as Boolean
+            Return True
+        End Operator
+
+        Public Shared Operator <>(left as ValueType, right as ValueType) as Boolean
+            Return False
+        End Operator
+
+        Public Shared Operator =(left as ValueType, right as Integer?) as Boolean
+            Return True
+        End Operator
+
+        Public Shared Operator <>(left as ValueType, right as Integer?) as Boolean
+            Return False
+        End Operator
+
+        Public Shared Operator =(left as Integer?, right as ValueType) as Boolean
+            Return True
+        End Operator
+
+        Public Shared Operator <>(left as Integer?, right as ValueType) as Boolean
+            Return False
+        End Operator
+    End Structure
+End Class

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Build against VS 15.7 -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.8.2" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.0.1" ExcludeAssets="runtime" />
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.4201-preview4">


### PR DESCRIPTION
Fixes #840 

I finally found some time to put all pieces together and create a PR.
Few things to note:

1. I had to update roslyn version to ```3.4.0``` so I can use recursive patterns. I guess it would mean end of support for VS2017? 
Is converter still supporting it?
https://docs.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022
BTW I noticed that some projects are already using ```3.4.0``` version but CodeConverter project was referencing ```2.8.2```

2. I couldn't force ```x is {} a``` to format nicely. Roslyn was creating something very ugly:
    ```csharp
    x is 
    {
    } a
    ```
    I tried to play with removing trivia etc but it didn't work. The only solution I found was to use ```Parse``` method. Look at ```NotFormattedIsPattern```.
3. The code it generates is correct and passes all tests that I could think of. 
Unfortunately, when dealing with complex binary expressions the result can quickly become hard to read. Although Resharper/Roslynator are quite handy in simplifying them I'm still not convinced that this solution is the way to go.
There is some room for improvement like using patterns only if required (variables, auto-properties, constants etc).
