### PR TITLE
use explicit cast when integral numeric types are casted to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### VB -> C#
 
 * Xml Namespace Imports now converted [#836](https://github.com/icsharpcode/CodeConverter/issues/836)
+* Use explicit cast when integral numeric types are casted to enum [#861](https://github.com/icsharpcode/CodeConverter/issues/861)
 * Correct inconsistent casing of event handlers [#854](https://github.com/icsharpcode/CodeConverter/issues/854)
 
 ### C# -> VB

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -293,7 +293,8 @@ namespace ICSharpCode.CodeConverter.CSharp
         {
             var nodeForType = node;
             var convertMethodForKeyword = GetConvertMethodForKeywordOrNull(nodeForType);
-            if (_semanticModel.GetTypeInfo(nodeForType).Type is INamedTypeSymbol typeSymbol && typeSymbol.IsEnumType()) {
+            if (_semanticModel.GetTypeInfo(nodeForType).Type is INamedTypeSymbol typeSymbol && typeSymbol.IsEnumType() &&
+                _semanticModel.GetTypeInfo(node.Expression).Type is {} expressionType && !expressionType.IsIntegralType() && !expressionType.IsEnumType()) {
                 convertMethodForKeyword = GetConvertMethodForKeywordOrNull(typeSymbol.EnumUnderlyingType);
             } else if (convertMethodForKeyword != null) {
                 nodeForType = null;

--- a/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
@@ -260,6 +260,8 @@ namespace ICSharpCode.CodeConverter.Util.FromRoslyn
             return false;
         }
 
+        public static bool IsIntegralType(this ITypeSymbol? type) => type.IsNumericType() && !type.IsFractionalNumericType();
+
         public static bool IsFractionalNumericType(this ITypeSymbol? type)
         {
             if (type != null) {

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -257,6 +257,61 @@ internal partial class Class1
         }
 
         [Fact]
+        public async Task CastingIntegralTypeToEnumShouldUseExplicitCastAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(
+                @"
+Enum TestEnum
+    None = 0
+End Enum
+Enum TestEnum2
+    None = 1
+End Enum
+Class Class1
+    Private Sub Test()
+        Dim res = CType(5S, TestEnum)
+        res = CType(5D, TestEnum)
+        res = CType(5L, TestEnum)
+        res = CType(5.4F, TestEnum)
+        res = CType(5.7R, TestEnum)
+        res = CType(5UL, TestEnum)
+        res = CType(5, TestEnum)
+        
+        Dim otherEnum = TestEnum2.None
+        res = CType(otherEnum, TestEnum)
+    End Sub
+End Class",
+                @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal enum TestEnum
+{
+    None = 0
+}
+
+internal enum TestEnum2
+{
+    None = 1
+}
+
+internal partial class Class1
+{
+    private void Test()
+    {
+        TestEnum res = (TestEnum)5;
+        res = (TestEnum)Conversions.ToInteger(5m);
+        res = (TestEnum)5L;
+        res = (TestEnum)Conversions.ToInteger(5.4f);
+        res = (TestEnum)Conversions.ToInteger(5.7d);
+        res = (TestEnum)5UL;
+        res = (TestEnum)5;
+        var otherEnum = TestEnum2.None;
+        res = (TestEnum)otherEnum;
+    }
+}
+");
+        }
+
+        [Fact]
         public async Task TryCastObjectToGenericListAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
Ideally, I would just call ```Conversions.ToInteger``` when we cast strings to enums but it looks like VB.Net does some magic for fractional types as well.

