### PR TITLE
Fix invalid call to Conversions.ToInteger for nullable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Use string.IsNullOrEmpty when comparing string to string.Empty [#874](https://github.com/icsharpcode/CodeConverter/issues/874)
 * Make an effort to maintain line-spacing between statements [#879](https://github.com/icsharpcode/CodeConverter/issues/879)
 * Correctly convert nested calls passing properties as ref arguments [#876](https://github.com/icsharpcode/CodeConverter/issues/876)
+* Improve conversion between nullable and not-nullable integrals/fractional/enum types [#865](https://github.com/icsharpcode/CodeConverter/issues/865)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -52,8 +52,8 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         _visualBasicEqualityComparison = new VisualBasicEqualityComparison(_semanticModel, _extraUsingDirectives);
         TriviaConvertingDeclarationVisitor = new CommentConvertingVisitorWrapper(this, _semanticModel.SyntaxTree);
         var expressionEvaluator = new ExpressionEvaluator(semanticModel, _visualBasicEqualityComparison);
-        var typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, _extraUsingDirectives, _csSyntaxGenerator, expressionEvaluator);
         var nullableExpressionsConverter = new VisualBasicNullableExpressionsConverter();
+        var typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, _extraUsingDirectives, _csSyntaxGenerator, expressionEvaluator, nullableExpressionsConverter);
         CommonConversions = new CommonConversions(document, semanticModel, typeConversionAnalyzer, csSyntaxGenerator, compilation, csCompilation, _typeContext, _visualBasicEqualityComparison);
         var expressionNodeVisitor = new ExpressionNodeVisitor(semanticModel, _visualBasicEqualityComparison, _typeContext, CommonConversions, _extraUsingDirectives, _xmlImportContext, nullableExpressionsConverter);
         _triviaConvertingExpressionVisitor = expressionNodeVisitor.TriviaConvertingExpressionVisitor;

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -852,7 +852,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var op = SyntaxFactory.Token(CSharpUtil.GetExpressionOperatorTokenKind(kind));
 
         var csBinExp = SyntaxFactory.BinaryExpression(kind, lhs, op, rhs);
-        var exp = _visualBasicNullableTypesConverter.WithLogicForNullableTypes(node, lhsTypeInfo, rhsTypeInfo, csBinExp, lhs, rhs);
+        var exp = _visualBasicNullableTypesConverter.WithBinaryExpressionLogicForNullableTypes(node, lhsTypeInfo, rhsTypeInfo, csBinExp, lhs, rhs);
         return node.Parent.IsKind(VBasic.SyntaxKind.SimpleArgument) ? exp : exp.AddParens();
     }
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -282,15 +282,10 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
 
     public override async Task<CSharpSyntaxNode> VisitCTypeExpression(VBasic.Syntax.CTypeExpressionSyntax node)
     {
-        var nodeForType = node;
-        var convertMethodForKeyword = GetConvertMethodForKeywordOrNull(nodeForType);
-        if (_semanticModel.GetTypeInfo(nodeForType).Type is INamedTypeSymbol typeSymbol && typeSymbol.IsEnumType() &&
-            _semanticModel.GetTypeInfo(node.Expression).Type is {} expressionType && !expressionType.IsIntegralType() && !expressionType.IsEnumType()) {
-            convertMethodForKeyword = GetConvertMethodForKeywordOrNull(typeSymbol.EnumUnderlyingType);
-        } else if (convertMethodForKeyword != null) {
-            nodeForType = null;
-        }
-        return await ConvertCastExpressionAsync(node, convertMethodForKeyword, nodeForType?.Type);
+        var csharpArg = await node.Expression.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor);
+        var typeInfo = _semanticModel.GetTypeInfo(node);
+        var forceTargetType = typeInfo.ConvertedType;
+        return CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Expression, csharpArg, forceTargetType: forceTargetType, defaultToCast: true).AddParens();
     }
 
     public override async Task<CSharpSyntaxNode> VisitDirectCastExpression(VBasic.Syntax.DirectCastExpressionSyntax node)
@@ -1506,7 +1501,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var simplifiedOrNull = await WithRemovedRedundantConversionOrNullAsync(node, node.Expression);
         if (simplifiedOrNull != null) return simplifiedOrNull;
         var expressionSyntax = await node.Expression.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor);
-        if (!(_semanticModel.GetOperation(node) is IConversionOperation co) || !co.Conversion.IsIdentity) {
+        if (_semanticModel.GetOperation(node) is not IConversionOperation { Conversion.IsIdentity: true }) {
             if (convertMethodOrNull != null) {
                 expressionSyntax = Invoke(convertMethodOrNull, expressionSyntax);
             }

--- a/CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -337,7 +337,7 @@ internal class TypeConversionAnalyzer
             return TypeConversionKind.NonDestructiveCast;
         }
 
-        if (vbConversion.IsNarrowing && vbConversion.IsString && vbConversion.ToString().Contains("InvolvesEnumTypeConversions")) {
+        if (vbConversion.IsNarrowing && vbConversion.IsString && vbConversion.IsKind(VbConversionKind.InvolvesEnumTypeConversions)) {
             return TypeConversionKind.EnumConversionThenCast;
         }
         if (vbConversion.IsNarrowing) {

--- a/CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -260,11 +260,11 @@ internal class TypeConversionAnalyzer
         var csConversion = _csCompilation.ClassifyConversion(csType, csConvertedType);
 
         bool isConvertToString =
-                (vbConversion.IsString || vbConversion.IsReference && vbConversion.IsNarrowing)  && vbConvertedType.SpecialType == SpecialType.System_String;
-        bool isConvertFractionalToInt = 
-                !csConversion.IsImplicit && 
-                (vbType.IsFractionalNumericType() || vbType.IsNullable(out var underlyingType) && underlyingType.IsFractionalNumericType()) && 
-                vbConvertedType.IsIntegralType();
+            (vbConversion.IsString || vbConversion.IsReference && vbConversion.IsNarrowing) && vbConvertedType.SpecialType == SpecialType.System_String;
+        bool isConvertFractionalToInt =
+            !csConversion.IsImplicit &&
+            (vbType.IsFractionalNumericType() || vbType.IsNullable(out var underlyingType) && underlyingType.IsFractionalNumericType()) &&
+            vbConvertedType.IsIntegralType();
 
         if (!csConversion.Exists || csConversion.IsUnboxing) {
             if (ConvertStringToCharLiteral(vbNode, vbConvertedType, out _)) {

--- a/CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -80,7 +80,7 @@ internal class TypeConversionAnalyzer
                 csNode = AddRoundInvocation(csNode);
                 return AddTypeConversion(vbNode, csNode, TypeConversionKind.NonDestructiveCast, addParenthesisIfNeeded, vbType, vbConvertedType);
             case TypeConversionKind.NullableFractionalNumberRoundThenCast:
-                csNode = AddRoundInvocation(csNode.Value());
+                csNode = AddRoundInvocation(csNode.NullableGetValueExpression());
                 return AddTypeConversion(vbNode, csNode, TypeConversionKind.NonDestructiveCast, addParenthesisIfNeeded, vbType, vbConvertedType);
             case TypeConversionKind.EnumConversionThenCast:
                 var underlyingType = ((INamedTypeSymbol) vbConvertedType).EnumUnderlyingType;

--- a/CodeConverter/CSharp/ValidSyntaxFactory.cs
+++ b/CodeConverter/CSharp/ValidSyntaxFactory.cs
@@ -102,4 +102,8 @@ public static class ValidSyntaxFactory
     public static IdentifierNameSyntax NameOf() => SyntaxFactory.IdentifierName(
         SyntaxFactory.Identifier(SyntaxTriviaList.Empty, SyntaxKind.NameOfKeyword, "nameof", "nameof", SyntaxTriviaList.Empty)
     );
+
+    public static ExpressionSyntax NullableHasValueExpression(this ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("HasValue"));
+    public static ExpressionSyntax NullableGetValueExpression(this ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("Value"));
+
 }

--- a/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
@@ -167,20 +167,16 @@ internal class VisualBasicNullableExpressionsConverter
 
 internal static class NullableTypesLogicExtensions
 {
-    private static ExpressionSyntax HasValue(ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("HasValue"));
-    private static ExpressionSyntax HasNoValue(ExpressionSyntax node) => HasValue(node).Negate();
-    public static ExpressionSyntax Value(this ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("Value"));
-
     public static ExpressionSyntax GetValueOrDefault(this ExpressionSyntax node) => SyntaxFactory.InvocationExpression(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("GetValueOrDefault")));
     public static ExpressionSyntax Negate(this ExpressionSyntax node) => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, node.AddParens());
 
     public static ExpressionSyntax And(this ExpressionSyntax a, ExpressionSyntax b) => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, a.AddParens(), b.AddParens()).AddParens();
-    public static ExpressionSyntax AndHasValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, HasValue(b));
-    public static ExpressionSyntax AndHasNoValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, HasNoValue(b));
-    public static ExpressionSyntax AndIsFalse(this ExpressionSyntax a, ExpressionSyntax b) => And(a, Value(b).Negate());
+    public static ExpressionSyntax AndHasValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, b.NullableHasValueExpression());
+    public static ExpressionSyntax AndHasNoValue(this ExpressionSyntax a, ExpressionSyntax b) => And(a, b.NullableHasValueExpression().Negate());
+    public static ExpressionSyntax AndIsFalse(this ExpressionSyntax a, ExpressionSyntax b) => And(a, b.NullableGetValueExpression().Negate());
 
     public static ExpressionSyntax Or(this ExpressionSyntax a, ExpressionSyntax b) => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalOrExpression, a.AddParens(), b.AddParens()).AddParens();
-    public static ExpressionSyntax OrIsTrue(this ExpressionSyntax a, ExpressionSyntax b) => Or(a, Value(b));
+    public static ExpressionSyntax OrIsTrue(this ExpressionSyntax a, ExpressionSyntax b) => Or(a, b.NullableGetValueExpression());
 
     public static ExpressionSyntax Conditional(this ExpressionSyntax condition, ExpressionSyntax whenTrue, ExpressionSyntax whenFalse) => SyntaxFactory.ConditionalExpression(condition.AddParens(), whenTrue.AddParens(), whenFalse.AddParens()).AddParens();
     public static ExpressionSyntax Bin(this ExpressionSyntax a, ExpressionSyntax b, SyntaxKind op) => SyntaxFactory.BinaryExpression(op, a.AddParens(), b.AddParens()).AddParens();

--- a/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
@@ -17,14 +17,13 @@ internal class VisualBasicNullableExpressionsConverter
 
     private int _argCounter;
 
-    public ExpressionSyntax InvokeConversionWhenNotNull(ExpressionSyntax expression, MemberAccessExpressionSyntax conversionMethod, TypeSyntax? castType = null)
+    public ExpressionSyntax InvokeConversionWhenNotNull(ExpressionSyntax expression, MemberAccessExpressionSyntax conversionMethod, TypeSyntax castType)
     {
         var pattern = PatternObject(expression, out var argName);
         var arguments = SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(SyntaxFactory.Argument(argName)));
         ExpressionSyntax invocation = SyntaxFactory.InvocationExpression(conversionMethod, arguments);
-        if (castType != null) {
-            invocation = ValidSyntaxFactory.CastExpression(castType, invocation);
-        }
+        invocation = ValidSyntaxFactory.CastExpression(castType, invocation);
+
         return pattern.Conditional(invocation, ValidSyntaxFactory.NullExpression).AddParens();
     }
 

--- a/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
@@ -169,7 +169,7 @@ internal static class NullableTypesLogicExtensions
 {
     private static ExpressionSyntax HasValue(ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("HasValue"));
     private static ExpressionSyntax HasNoValue(ExpressionSyntax node) => HasValue(node).Negate();
-    private static ExpressionSyntax Value(ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("Value"));
+    public static ExpressionSyntax Value(this ExpressionSyntax node) => SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("Value"));
 
     public static ExpressionSyntax GetValueOrDefault(this ExpressionSyntax node) => SyntaxFactory.InvocationExpression(SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, node.AddParens(), SyntaxFactory.IdentifierName("GetValueOrDefault")));
     public static ExpressionSyntax Negate(this ExpressionSyntax node) => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, node.AddParens());

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -41,6 +41,10 @@
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />

--- a/CodeConverter/Util/FromRoslyn/ConversionExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/ConversionExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace ICSharpCode.CodeConverter.Util.FromRoslyn;
+
+internal static class ConversionExtensions
+{
+    public static bool IsKind(this VBasic.Conversion conversion, VbConversionKind kind)
+    {
+        if (!Enum.TryParse<VbConversionKind>(conversion.ToString(), ignoreCase: true, out var conversionKind)) {
+            throw new ArgumentException($"Invalid vb conversion kind {conversion}", nameof(conversion));
+        }
+
+        return (conversionKind & kind) != 0;
+    }
+}

--- a/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/ITypeSymbolExtensions.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ICSharpCode.CodeConverter.Util.FromRoslyn;
 
@@ -43,8 +44,8 @@ internal static class ITypeSymbolExtensions
         => symbol?.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
 
     public static bool IsNullable(
-        this ITypeSymbol? symbol,
-        out ITypeSymbol? underlyingType)
+         this ITypeSymbol? symbol,
+         [NotNullWhen(true)] out ITypeSymbol? underlyingType)
     {
         if (symbol != null && IsNullable(symbol)) {
             underlyingType = ((INamedTypeSymbol)symbol).TypeArguments[0];
@@ -257,6 +258,7 @@ internal static class ITypeSymbolExtensions
     }
 
     public static bool IsIntegralType(this ITypeSymbol? type) => type.IsNumericType() && !type.IsFractionalNumericType();
+    public static bool IsIntegralOrEnumType(this ITypeSymbol? type) => type.IsIntegralType() || type.IsEnumType();
 
     public static bool IsFractionalNumericType(this ITypeSymbol? type)
     {
@@ -527,8 +529,12 @@ internal static class ITypeSymbolExtensions
         return allTypeArgs1.AreMoreSpecificThan(allTypeArgs2);
     }
 
-    public static bool IsEnumType(this ITypeSymbol type)
+    public static bool IsEnumType(this ITypeSymbol? type)
     {
+        if (type == null) {
+            return false;
+        }
+
         return type.IsValueType && type.TypeKind == TypeKind.Enum;
     }
 

--- a/CodeConverter/Util/FromRoslyn/VbConversionKind.cs
+++ b/CodeConverter/Util/FromRoslyn/VbConversionKind.cs
@@ -1,0 +1,119 @@
+﻿namespace ICSharpCode.CodeConverter.Util.FromRoslyn;
+
+[Flags]
+internal enum VbConversionKind
+{
+    // If there is a conversion, either [Widening] or [Narrowing] bit must be set, but not both.
+    // All VB conversions are either Widening or Narrowing.
+    // 
+    // To indicate the fact that no conversion exists:
+    // 1) Neither [Widening] nor [Narrowing] are set.
+    // 2) Additional flags may be set in order to provide specific reason.
+    // 
+    // Bits from the following values are never set at the same time :
+    // Identity, Numeric, Nullable, Reference, Array, TypeParameter, Value, [String], WideningNothingLiteral, InterpolatedString
+
+    FailedDueToNumericOverflow = 1 << 31, // Failure flag
+    FailedDueToIntegerOverflow = FailedDueToNumericOverflow | 1 << 30, // Failure flag
+    FailedDueToNumericOverflowMask = FailedDueToNumericOverflow | FailedDueToIntegerOverflow,
+    FailedDueToQueryLambdaBodyMismatch = 1 << 29, // Failure flag to indicate that conversion failed because body of a query lambda couldn't be converted to the target delegate return type.
+    FailedDueToArrayLiteralElementConversion = 1 << 28, // Failed because array literal element could not be converted to the target element type.
+
+    // If there is a conversion, one and only one of the following two bits must be set.
+    // All VB conversions are either Widening or Narrowing.
+    Widening = 1 << 0,
+    Narrowing = 1 << 1,
+
+    /// <summary>
+    /// Because flags can be combined, use the method IsIdentityConversion when testing for ConversionKind.Identity
+    /// </summary>
+    Identity = Widening | 1 << 2, // According to VB spec, identity conversion is Widening
+    Numeric = 1 << 3,
+    WideningNumeric = Widening | Numeric,
+    NarrowingNumeric = Narrowing | Numeric,
+
+    /// <summary>
+    /// Can be combined with <see cref="VbConversionKind.Tuple"/> to indicate that the underlying value conversion is a predefined tuple conversion
+    /// </summary>
+    Nullable = 1 << 4,
+    WideningNullable = Widening | Nullable,
+    NarrowingNullable = Narrowing | Nullable,
+    Reference = 1 << 5,
+    WideningReference = Widening | Reference,
+    NarrowingReference = Narrowing | Reference,
+    Array = 1 << 6,
+    WideningArray = Widening | Array,
+    NarrowingArray = Narrowing | Array,
+    TypeParameter = 1 << 7,
+    WideningTypeParameter = Widening | TypeParameter,
+    NarrowingTypeParameter = Narrowing | TypeParameter,
+    Value = 1 << 8,
+    WideningValue = Widening | Value,
+    NarrowingValue = Narrowing | Value,
+    String = 1 << 9,
+    WideningString = Widening | String,
+    NarrowingString = Narrowing | String,
+    Boolean = 1 << 10,
+    // Note: there are no widening boolean conversions.
+    NarrowingBoolean = Narrowing | Boolean,
+    WideningNothingLiteral = Widening | 1 << 11,
+
+    // Compiler might be interested in knowing if constant numeric conversion involves narrowing
+    // for constant's original type. When user-defined conversions are involved, this flag can be
+    // combined with widening conversions other than WideningNumericConstant.
+    // 
+    // If this flag is combined with Narrowing, there should be no other reasons to treat
+    // conversion as narrowing. In some scenarios overload resolution is likely to dismiss
+    // narrowing in presence of this flag. Also, it appears that with Option Strict On, Dev10
+    // compiler does not report errors for narrowing conversions from an integral constant
+    // expression to an integral type (assuming integer overflow checks are disabled) or from a
+    // floating constant to a floating type.
+    InvolvesNarrowingFromNumericConstant = 1 << 12,
+
+    // This flag is set when conversion involves conversion enum <-> underlying type,
+    // or conversion between two enums, etc 
+    InvolvesEnumTypeConversions = 1 << 13,
+
+    // Lambda conversion
+    Lambda = 1 << 14,
+
+    // Delegate relaxation levels for Lambda and Delegate conversions
+    DelegateRelaxationLevelNone = 0, // Identity / Whidbey
+    DelegateRelaxationLevelWidening = 1 << 15,
+    DelegateRelaxationLevelWideningDropReturnOrArgs = 2 << 15,
+    DelegateRelaxationLevelWideningToNonLambda = 3 << 15,
+    DelegateRelaxationLevelNarrowing = 4 << 15,  // OrcasStrictOff
+    DelegateRelaxationLevelInvalid = 5 << 15, // Keep invalid the biggest number
+    DelegateRelaxationLevelMask = 7 << 15, // Three bits used!
+
+    // Can be combined with Narrowing
+    VarianceConversionAmbiguity = 1 << 18,
+
+    // This bit can be combined with NoConversion to indicate that, even though there is no conversion
+    // from the language point of view, there is a slight chance that conversion might succeed at run-time
+    // under the right circumstances. It is used to detect possibly ambiguous variance conversions to an
+    // interface, so it is set only for scenarios that are relevant to variance conversions to an
+    // interface. 
+    MightSucceedAtRuntime = 1 << 19,
+    AnonymousDelegate = 1 << 20,
+    NeedAStub = 1 << 21,
+    ConvertedToExpressionTree = 1 << 22,   // Combined with Lambda, indicates a conversion of lambda to Expression(Of T).
+    UserDefined = 1 << 23,
+
+    // Some variance delegate conversions are treated as special narrowing (Dev10 #820752).
+    // This flag is combined with Narrowing to indicate the fact.
+    NarrowingDueToContraVarianceInDelegate = 1 << 24,
+
+    // Interpolated string conversions
+    InterpolatedString = Widening | 1 << 25,
+
+    // Tuple conversions
+    /// <summary>
+    /// Can be combined with <see cref="VbConversionKind.Nullable"/> to indicate that the underlying value conversion is a predefined tuple conversion
+    /// </summary>
+    Tuple = 1 << 26,
+    WideningTuple = Widening | Tuple,
+    NarrowingTuple = Narrowing | Tuple,
+    WideningNullableTuple = WideningNullable | Tuple,
+    NarrowingNullableTuple = NarrowingNullable | Tuple
+}

--- a/CodeConverter/Util/FromRoslyn/VbConversionKind.cs
+++ b/CodeConverter/Util/FromRoslyn/VbConversionKind.cs
@@ -1,5 +1,9 @@
 ﻿namespace ICSharpCode.CodeConverter.Util.FromRoslyn;
+#pragma warning disable CA1069 // Enums values should not be duplicated
 
+/// <summary>
+/// Converted from https://github.com/dotnet/roslyn/blob/85f155be47147a702305c8f49c64eaf51a53d734/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb#L282
+/// </summary>
 [Flags]
 internal enum VbConversionKind
 {

--- a/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
@@ -196,37 +196,8 @@ internal partial class TestClass
     }
 }");
     }
-        [Fact]
-        public async Task CastNullableToNonNullableAsync()
-        {
-            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712
-    Private Function TestMethod() As Boolean
-        Dim x As Boolean? = Nothing
-        Return x
-    End Function
 
-    Private Function TestMethod2() As Integer
-        Dim x As Integer? = Nothing
-        Return x
-    End Function
-End Class", @"
-internal partial class TestClass712
-{
-    private bool TestMethod()
-    {
-        bool? x = default;
-        return (bool)x;
-    }
-
-    private int TestMethod2()
-    {
-        int? x = default;
-        return (int)x;
-    }
-}");
-        }
-
-        [Fact]
+    [Fact]
         public async Task NotOperatorOnNullableBooleanAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(@"Class TestClass712

--- a/Tests/CSharp/StatementTests/StatementTests.cs
+++ b/Tests/CSharp/StatementTests/StatementTests.cs
@@ -1766,7 +1766,7 @@ internal partial class Issue707SelectCaseAsyncClass
 {
     private bool? Exists(char? sort)
     {
-        switch (Strings.LCase(Conversions.ToString(sort) + """") ?? """")
+        switch (Strings.LCase(Conversions.ToString(sort.Value) + """") ?? """")
         {
             case var @case when @case == """":
             case var case1 when case1 == """":

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -191,16 +191,45 @@ public partial class AShape
     }
 
     [Fact]
-    public async Task CTypeFractionalAndBooleanToIntAsync()
+    public async Task CTypeFractionalAndBooleanToIntegralsAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(
             @"
+Enum TestEnum
+    None = 1
+End Enum
+
 Class Class1
     Private Sub Test(b as Boolean, f as Single, d as Double, m as Decimal)
         Dim i = CType(b, Integer)
         i = CType(f, Integer)
         i = CType(d, Integer)
         i = CType(m, Integer)
+
+        Dim ui = CType(b, UInteger)
+        ui = CType(f, UInteger)
+        ui = CType(d, UInteger)
+        ui = CType(m, UInteger)
+
+        Dim s = CType(b, Short)
+        s = CType(f, Short)
+        s = CType(d, Short)
+        s = CType(m, Short)
+
+        Dim l = CType(b, Long)
+        l = CType(f, Long)
+        l = CType(d, Long)
+        l = CType(m, Long)
+
+        Dim byt = CType(b, Byte)
+        byt = CType(f, Byte)
+        byt = CType(d, Byte)
+        byt = CType(m, Byte)
+
+        Dim e = CType(b, TestEnum)
+        e = CType(f, TestEnum)
+        e = CType(d, TestEnum)
+        e = CType(m, TestEnum)
     End Sub
 
     Private Sub TestNullable(b as Boolean?, f as Single?, d as Double?, m as Decimal?)
@@ -208,10 +237,40 @@ Class Class1
         i = CType(f, Integer)
         i = CType(d, Integer)
         i = CType(m, Integer)
+
+        Dim ui = CType(b, UInteger)
+        ui = CType(f, UInteger)
+        ui = CType(d, UInteger)
+        ui = CType(m, UInteger)
+
+        Dim s = CType(b, Short)
+        s = CType(f, Short)
+        s = CType(d, Short)
+        s = CType(m, Short)
+
+        Dim l = CType(b, Long)
+        l = CType(f, Long)
+        l = CType(d, Long)
+        l = CType(m, Long)
+
+        Dim byt = CType(b, Byte)
+        byt = CType(f, Byte)
+        byt = CType(d, Byte)
+        byt = CType(m, Byte)
+
+        Dim e = CType(b, TestEnum)
+        e = CType(f, TestEnum)
+        e = CType(d, TestEnum)
+        e = CType(m, TestEnum)
     End Sub
 End Class",
             @"using System;
 using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal enum TestEnum
+{
+    None = 1
+}
 
 internal partial class Class1
 {
@@ -221,19 +280,222 @@ internal partial class Class1
         i = (int)Math.Round(f);
         i = (int)Math.Round(d);
         i = (int)Math.Round(m);
+
+        uint ui = Conversions.ToUInteger(b);
+        ui = (uint)Math.Round(f);
+        ui = (uint)Math.Round(d);
+        ui = (uint)Math.Round(m);
+
+        short s = Conversions.ToShort(b);
+        s = (short)Math.Round(f);
+        s = (short)Math.Round(d);
+        s = (short)Math.Round(m);
+
+        long l = Conversions.ToLong(b);
+        l = (long)Math.Round(f);
+        l = (long)Math.Round(d);
+        l = (long)Math.Round(m);
+
+        byte byt = Conversions.ToByte(b);
+        byt = (byte)Math.Round(f);
+        byt = (byte)Math.Round(d);
+        byt = (byte)Math.Round(m);
+
+        TestEnum e = (TestEnum)Conversions.ToInteger(b);
+        e = (TestEnum)Math.Round(f);
+        e = (TestEnum)Math.Round(d);
+        e = (TestEnum)Math.Round(m);
     }
 
     private void TestNullable(bool? b, float? f, double? d, decimal? m)
     {
-        int i = Conversions.ToInteger(b);
+        int i = Conversions.ToInteger(b.Value);
         i = (int)Math.Round(f.Value);
         i = (int)Math.Round(d.Value);
         i = (int)Math.Round(m.Value);
+
+        uint ui = Conversions.ToUInteger(b.Value);
+        ui = (uint)Math.Round(f.Value);
+        ui = (uint)Math.Round(d.Value);
+        ui = (uint)Math.Round(m.Value);
+
+        short s = Conversions.ToShort(b.Value);
+        s = (short)Math.Round(f.Value);
+        s = (short)Math.Round(d.Value);
+        s = (short)Math.Round(m.Value);
+
+        long l = Conversions.ToLong(b.Value);
+        l = (long)Math.Round(f.Value);
+        l = (long)Math.Round(d.Value);
+        l = (long)Math.Round(m.Value);
+
+        byte byt = Conversions.ToByte(b.Value);
+        byt = (byte)Math.Round(f.Value);
+        byt = (byte)Math.Round(d.Value);
+        byt = (byte)Math.Round(m.Value);
+
+        TestEnum e = (TestEnum)Conversions.ToInteger(b.Value);
+        e = (TestEnum)Math.Round(f.Value);
+        e = (TestEnum)Math.Round(d.Value);
+        e = (TestEnum)Math.Round(m.Value);
     }
 }
 ");
     }
 
+    [Fact]
+    public async Task CTypeFractionalAndBooleanToNullableIntegralsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Enum TestEnum
+    None = 1
+End Enum
+
+Class Class1
+    Private Sub Test(b as Boolean, f as Single, d as Double, m as Decimal)
+        Dim i = CType(b, Integer?)
+        i = CType(f, Integer?)
+        i = CType(d, Integer?)
+        i = CType(m, Integer?)
+
+        Dim ui = CType(b, UInteger?)
+        ui = CType(f, UInteger?)
+        ui = CType(d, UInteger?)
+        ui = CType(m, UInteger?)
+
+        Dim s = CType(b, Short?)
+        s = CType(f, Short?)
+        s = CType(d, Short?)
+        s = CType(m, Short?)
+
+        Dim l = CType(b, Long?)
+        l = CType(f, Long?)
+        l = CType(d, Long?)
+        l = CType(m, Long?)
+
+        Dim byt = CType(b, Byte?)
+        byt = CType(f, Byte?)
+        byt = CType(d, Byte?)
+        byt = CType(m, Byte?)
+
+        Dim e = CType(b, TestEnum?)
+        e = CType(f, TestEnum?)
+        e = CType(d, TestEnum?)
+        e = CType(m, TestEnum?)
+    End Sub
+
+    Private Sub TestNullable(b as Boolean?, f as Single?, d as Double?, m as Decimal?)
+        Dim i = CType(b, Integer?)
+        i = CType(f, Integer?)
+        i = CType(d, Integer?)
+        i = CType(m, Integer?)
+
+        Dim ui = CType(b, UInteger?)
+        ui = CType(f, UInteger?)
+        ui = CType(d, UInteger?)
+        ui = CType(m, UInteger?)
+
+        Dim s = CType(b, Short?)
+        s = CType(f, Short?)
+        s = CType(d, Short?)
+        s = CType(m, Short?)
+
+        Dim l = CType(b, Long?)
+        l = CType(f, Long?)
+        l = CType(d, Long?)
+        l = CType(m, Long?)
+
+        Dim byt = CType(b, Byte?)
+        byt = CType(f, Byte?)
+        byt = CType(d, Byte?)
+        byt = CType(m, Byte?)
+
+        Dim e = CType(b, TestEnum?)
+        e = CType(f, TestEnum?)
+        e = CType(d, TestEnum?)
+        e = CType(m, TestEnum?)
+    End Sub
+End Class",
+            @"using System;
+using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal enum TestEnum
+{
+    None = 1
+}
+
+internal partial class Class1
+{
+    private void Test(bool b, float f, double d, decimal m)
+    {
+        int? i = Conversions.ToInteger(b);
+        i = (int?)Math.Round(f);
+        i = (int?)Math.Round(d);
+        i = (int?)Math.Round(m);
+
+        uint? ui = Conversions.ToUInteger(b);
+        ui = (uint?)Math.Round(f);
+        ui = (uint?)Math.Round(d);
+        ui = (uint?)Math.Round(m);
+
+        short? s = Conversions.ToShort(b);
+        s = (short?)Math.Round(f);
+        s = (short?)Math.Round(d);
+        s = (short?)Math.Round(m);
+
+        long? l = Conversions.ToLong(b);
+        l = (long?)Math.Round(f);
+        l = (long?)Math.Round(d);
+        l = (long?)Math.Round(m);
+
+        byte? byt = Conversions.ToByte(b);
+        byt = (byte?)Math.Round(f);
+        byt = (byte?)Math.Round(d);
+        byt = (byte?)Math.Round(m);
+
+        TestEnum? e = (TestEnum?)Conversions.ToInteger(b);
+        e = (TestEnum?)Math.Round(f);
+        e = (TestEnum?)Math.Round(d);
+        e = (TestEnum?)Math.Round(m);
+    }
+
+    private void TestNullable(bool? b, float? f, double? d, decimal? m)
+    {
+        int? i = b is { } arg1 ? (int?)Conversions.ToInteger(arg1) : null;
+        i = f is { } arg2 ? (int?)Math.Round(arg2) : null;
+        i = d is { } arg3 ? (int?)Math.Round(arg3) : null;
+        i = m is { } arg4 ? (int?)Math.Round(arg4) : null;
+
+        uint? ui = b is { } arg5 ? (uint?)Conversions.ToUInteger(arg5) : null;
+        ui = f is { } arg6 ? (uint?)Math.Round(arg6) : null;
+        ui = d is { } arg7 ? (uint?)Math.Round(arg7) : null;
+        ui = m is { } arg8 ? (uint?)Math.Round(arg8) : null;
+
+        short? s = b is { } arg9 ? (short?)Conversions.ToShort(arg9) : null;
+        s = f is { } arg10 ? (short?)Math.Round(arg10) : null;
+        s = d is { } arg11 ? (short?)Math.Round(arg11) : null;
+        s = m is { } arg12 ? (short?)Math.Round(arg12) : null;
+
+        long? l = b is { } arg13 ? (long?)Conversions.ToLong(arg13) : null;
+        l = f is { } arg14 ? (long?)Math.Round(arg14) : null;
+        l = d is { } arg15 ? (long?)Math.Round(arg15) : null;
+        l = m is { } arg16 ? (long?)Math.Round(arg16) : null;
+
+        byte? byt = b is { } arg17 ? (byte?)Conversions.ToByte(arg17) : null;
+        byt = f is { } arg18 ? (byte?)Math.Round(arg18) : null;
+        byt = d is { } arg19 ? (byte?)Math.Round(arg19) : null;
+        byt = m is { } arg20 ? (byte?)Math.Round(arg20) : null;
+
+        TestEnum? e = b is { } arg21 ? (TestEnum?)Conversions.ToInteger(arg21) : null;
+        e = f is { } arg22 ? (TestEnum?)Math.Round(arg22) : null;
+        e = d is { } arg23 ? (TestEnum?)Math.Round(arg23) : null;
+        e = m is { } arg24 ? (TestEnum?)Math.Round(arg24) : null;
+    }
+}
+");
+    }
+    
     [Fact]
     public async Task CastObjectToGenericListAsync()
     {
@@ -396,6 +658,97 @@ internal partial class Class1
         res = (TestEnum)s;
         res = (TestEnum)i;
         res = (TestEnum)l;
+    }
+}
+");
+    }
+
+    [Fact]
+    public async Task CastingIntegralTypeToNullableEnumShouldUseExplicitCastAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Enum TestEnum
+    None = 0
+End Enum
+Enum TestEnum2
+    None = 1
+End Enum
+Class Class1
+    Private Sub TestIntegrals(b as Byte, s as Short, i as Integer, l as Long, e as TestEnum2)
+        Dim res = CType(b, TestEnum?)
+        res = CType(s, TestEnum?)
+        res = CType(i, TestEnum?)
+        res = CType(l, TestEnum?)
+        res = CType(e, TestEnum?)
+    End Sub
+
+    Private Sub TestNullableIntegrals(b as Byte?, s as Short?, i as Integer?, l as Long?, e as TestEnum2?)
+        Dim res = CType(b, TestEnum?)
+        res = CType(s, TestEnum?)
+        res = CType(i, TestEnum?)
+        res = CType(l, TestEnum?)
+        res = CType(e, TestEnum?)
+    End Sub
+
+    Private Sub TestUnsignedIntegrals(b as SByte, s as UShort, i as UInteger, l as ULong)
+        Dim res = CType(b, TestEnum?)
+        res = CType(s, TestEnum?)
+        res = CType(i, TestEnum?)
+        res = CType(l, TestEnum?)
+    End Sub
+
+    Private Sub TestNullableUnsignedIntegrals(b as SByte?, s as UShort?, i as UInteger?, l as ULong?)
+        Dim res = CType(b, TestEnum?)
+        res = CType(s, TestEnum?)
+        res = CType(i, TestEnum?)
+        res = CType(l, TestEnum?)
+    End Sub
+End Class",
+                @"
+internal enum TestEnum
+{
+    None = 0
+}
+
+internal enum TestEnum2
+{
+    None = 1
+}
+
+internal partial class Class1
+{
+    private void TestIntegrals(byte b, short s, int i, long l, TestEnum2 e)
+    {
+        TestEnum? res = (TestEnum?)b;
+        res = (TestEnum?)s;
+        res = (TestEnum?)i;
+        res = (TestEnum?)l;
+        res = (TestEnum?)e;
+    }
+
+    private void TestNullableIntegrals(byte? b, short? s, int? i, long? l, TestEnum2? e)
+    {
+        TestEnum? res = (TestEnum?)b;
+        res = (TestEnum?)s;
+        res = (TestEnum?)i;
+        res = (TestEnum?)l;
+        res = (TestEnum?)e;
+    }
+
+    private void TestUnsignedIntegrals(sbyte b, ushort s, uint i, ulong l)
+    {
+        TestEnum? res = (TestEnum?)b;
+        res = (TestEnum?)s;
+        res = (TestEnum?)i;
+        res = (TestEnum?)l;
+    }
+
+    private void TestNullableUnsignedIntegrals(sbyte? b, ushort? s, uint? i, ulong? l)
+    {
+        TestEnum? res = (TestEnum?)b;
+        res = (TestEnum?)s;
+        res = (TestEnum?)i;
+        res = (TestEnum?)l;
     }
 }
 ");

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -777,6 +777,342 @@ internal partial class Class1
     }
 
     [Fact]
+    public async Task TestNullableBoolConversionsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class Class1
+    Private Function Test1(a as Boolean?) As Boolean
+        Return a
+    End Function
+    Private Function Test2(a as Boolean?) As Boolean?
+        Return a
+    End Function
+    Private Function Test3(a as Boolean) As Boolean?
+        Return a
+    End Function
+
+    Private Function Test4(a as Integer?) As Boolean
+        Return a
+    End Function
+    Private Function Test5(a as Integer?) As Boolean?
+        Return a
+    End Function
+    Private Function Test6(a as Integer) As Boolean?
+        Return a
+    End Function
+
+    Private Function Test4(a as Boolean?) As Integer
+        Return a
+    End Function
+    Private Function Test5(a as Boolean?) As Integer?
+        Return a
+    End Function
+    Private Function Test6(a as Boolean) As Integer?
+        Return a
+    End Function
+
+    Private Function Test7(a as Boolean?) As String
+        Return a
+    End Function
+    Private Function Test8(a as Boolean?) As String
+        Return a
+    End Function
+
+    Private Function Test9(a as String) As Boolean?
+        Return a
+    End Function
+    Private Function Test10(a as String) As Boolean
+        Return a
+    End Function
+End Class",
+            @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal partial class Class1
+{
+    private bool Test1(bool? a)
+    {
+        return (bool)a;
+    }
+    private bool? Test2(bool? a)
+    {
+        return a;
+    }
+    private bool? Test3(bool a)
+    {
+        return a;
+    }
+
+    private bool Test4(int? a)
+    {
+        return Conversions.ToBoolean(a.Value);
+    }
+    private bool? Test5(int? a)
+    {
+        return a is { } arg1 ? (bool?)Conversions.ToBoolean(arg1) : null;
+    }
+    private bool? Test6(int a)
+    {
+        return Conversions.ToBoolean(a);
+    }
+
+    private int Test4(bool? a)
+    {
+        return Conversions.ToInteger(a.Value);
+    }
+    private int? Test5(bool? a)
+    {
+        return a is { } arg2 ? (int?)Conversions.ToInteger(arg2) : null;
+    }
+    private int? Test6(bool a)
+    {
+        return Conversions.ToInteger(a);
+    }
+
+    private string Test7(bool? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+    private string Test8(bool? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+
+    private bool? Test9(string a)
+    {
+        return Conversions.ToBoolean(a);
+    }
+    private bool Test10(string a)
+    {
+        return Conversions.ToBoolean(a);
+    }
+}");
+    }
+
+    [Fact]
+    public async Task TestNullableEnumConversionsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Enum TestEnum
+    None = 1
+End Enum
+Class Class1
+    Private Function Test1(a as Integer) As TestEnum?
+        Return a
+    End Function
+    Private Function Test2(a as Integer?) As TestEnum?
+        Return a
+    End Function
+    Private Function Test3(a as Integer?) As TestEnum
+        Return a
+    End Function
+
+    Private Function Test4(a as TestEnum) As Integer?
+        Return a
+    End Function
+    Private Function Test5(a as TestEnum?) As Integer?
+        Return a
+    End Function
+    Private Function Test6(a as TestEnum?) As TestEnum?
+        Return a
+    End Function
+    Private Function Test7(a as TestEnum?) As Integer
+        Return a
+    End Function
+
+    Private Function Test8(a as TestEnum?) As String
+        Return a
+    End Function
+    Private Function Test9(a as TestEnum?) As String
+        Return a
+    End Function
+    
+    Private Function Test10(a as String) As TestEnum?
+        Return a
+    End Function
+    Private Function Test11(a as String) As TestEnum
+        Return a
+    End Function
+End Class",
+            @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal enum TestEnum
+{
+    None = 1
+}
+
+internal partial class Class1
+{
+    private TestEnum? Test1(int a)
+    {
+        return (TestEnum?)a;
+    }
+    private TestEnum? Test2(int? a)
+    {
+        return (TestEnum?)a;
+    }
+    private TestEnum Test3(int? a)
+    {
+        return (TestEnum)a;
+    }
+
+    private int? Test4(TestEnum a)
+    {
+        return Conversions.ToInteger(a);
+    }
+    private int? Test5(TestEnum? a)
+    {
+        return (int?)a;
+    }
+    private TestEnum? Test6(TestEnum? a)
+    {
+        return a;
+    }
+    private int Test7(TestEnum? a)
+    {
+        return (int)a;
+    }
+
+    private string Test8(TestEnum? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+    private string Test9(TestEnum? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+
+    private TestEnum? Test10(string a)
+    {
+        return (TestEnum?)Conversions.ToInteger(a);
+    }
+    private TestEnum Test11(string a)
+    {
+        return (TestEnum)Conversions.ToInteger(a);
+    }
+}");
+    }
+
+    [Fact]
+    public async Task TestNumbersNullableConversionsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Class Class1
+    Private Function Test1(a as Integer) As Integer?
+        Return a
+    End Function
+    Private Function Test2(a as Integer?) As Integer?
+        Return a
+    End Function
+    Private Function Test3(a as Integer?) As Integer
+        Return a
+    End Function
+    Private Function Test4(a as Single) As Integer?
+        Return a
+    End Function
+    Private Function Test5(a as Single?) As Integer?
+        Return a
+    End Function
+
+    Private Function Test6(a as Single) As Single?
+        Return a
+    End Function
+    Private Function Test7(a as Single?) As Single?
+        Return a
+    End Function
+    Private Function Test8(a as Single?) As Single
+        Return a
+    End Function
+    Private Function Test9(a as Integer) As Single?
+        Return a
+    End Function
+    Private Function Test10(a as Integer?) As Single?
+        Return a
+    End Function
+
+   Private Function Test11(a as Integer?) As String
+        Return a
+    End Function
+    Private Function Test12(a as Integer?) As String
+        Return a
+    End Function
+
+    Private Function Test13(a as String) As Integer?
+        Return a
+    End Function
+    Private Function Test14(a as String) As Integer
+        Return a
+    End Function
+End Class",
+            @"using System;
+using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal partial class Class1
+{
+    private int? Test1(int a)
+    {
+        return a;
+    }
+    private int? Test2(int? a)
+    {
+        return a;
+    }
+    private int Test3(int? a)
+    {
+        return (int)a;
+    }
+    private int? Test4(float a)
+    {
+        return (int?)Math.Round(a);
+    }
+    private int? Test5(float? a)
+    {
+        return a is { } arg1 ? (int?)Math.Round(arg1) : null;
+    }
+
+    private float? Test6(float a)
+    {
+        return a;
+    }
+    private float? Test7(float? a)
+    {
+        return a;
+    }
+    private float Test8(float? a)
+    {
+        return (float)a;
+    }
+    private float? Test9(int a)
+    {
+        return a;
+    }
+    private float? Test10(int? a)
+    {
+        return a;
+    }
+
+    private string Test11(int? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+    private string Test12(int? a)
+    {
+        return Conversions.ToString(a.Value);
+    }
+
+    private int? Test13(string a)
+    {
+        return Conversions.ToInteger(a);
+    }
+    private int Test14(string a)
+    {
+        return Conversions.ToInteger(a);
+    }
+}");
+    }
+
+    [Fact]
     public async Task CastConstantNumberToLongAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/TestConstants.cs
+++ b/Tests/TestConstants.cs
@@ -14,7 +14,7 @@ public static class TestConstants
     ///  Set to false
     ///  Commit
     /// </summary>
-    public static bool RecharacterizeByWritingExpectedOverActual { get; } = false;
+    public static bool RecharacterizeByWritingExpectedOverActual => false;
 
     public static string GetTestDataDirectory()
     {

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -41,7 +40,7 @@ namespace VbLibrary.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -55,7 +54,7 @@ namespace VbLibrary.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/My Project/Settings.Designer.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using Microsoft.VisualBasic;
 
+
 namespace VbLibrary.My
 {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/My Project/MyNamespace.Static.2.Designer.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -41,7 +40,7 @@ namespace ConsoleApp1.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -55,7 +54,7 @@ namespace ConsoleApp1.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/My Project/Settings.Designer.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using Microsoft.VisualBasic;
 
+
 namespace ConsoleApp1.My
 {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp4/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp4/My Project/MyNamespace.Static.2.Designer.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -40,7 +39,7 @@ namespace ConsoleApp4.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -54,7 +53,7 @@ namespace ConsoleApp4.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -41,7 +40,7 @@ namespace Prefix.VbLibrary.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -55,7 +54,7 @@ namespace Prefix.VbLibrary.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/My Project/Settings.Designer.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using Microsoft.VisualBasic;
 
+
 namespace Prefix.VbLibrary.My
 {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/MyNamespace.Static.2.Designer.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -41,7 +40,7 @@ namespace VbLibrary.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -55,7 +54,7 @@ namespace VbLibrary.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/My Project/Settings.Designer.cs
@@ -11,6 +11,7 @@
 using System.Diagnostics;
 using Microsoft.VisualBasic;
 
+
 namespace VbLibrary.My
 {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/My Project/MyNamespace.Static.3.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/My Project/MyNamespace.Static.3.Designer.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -40,7 +39,7 @@ namespace VbNetStandardLib.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -54,7 +53,7 @@ namespace VbNetStandardLib.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/Folder/FolderForm.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/Folder/FolderForm.Designer.cs
@@ -2,11 +2,10 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
-using Microsoft.VisualBasic.CompilerServices;
 
 namespace WindowsAppVb
 {
-    [DesignerGenerated()]
+    [Microsoft.VisualBasic.CompilerServices.DesignerGenerated()]
     public partial class FolderForm : Form
     {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/My Project/MyNamespace.Static.2.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/My Project/MyNamespace.Static.2.Designer.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualBasic;
-using Microsoft.VisualBasic.CompilerServices;
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
@@ -41,7 +40,7 @@ namespace WindowsAppVb.My
         public static string get_AttributeValue(IEnumerable<XElement> source, XName name)
         {
             foreach (XElement item in source)
-                return Conversions.ToString(item.Attribute(name));
+                return (string)item.Attribute(name);
             return null;
         }
 
@@ -55,7 +54,7 @@ namespace WindowsAppVb.My
         }
         public static string get_AttributeValue(XElement source, XName name)
         {
-            return Conversions.ToString(source.Attribute(name));
+            return (string)source.Attribute(name);
         }
 
         public static void set_AttributeValue(XElement source, XName name, string value)

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/My Project/Settings.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/My Project/Settings.Designer.cs
@@ -12,6 +12,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.VisualBasic;
 
+
 namespace WindowsAppVb.My
 {
 

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WinformsDesignerTest.Designer.cs
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WinformsDesignerTest.Designer.cs
@@ -3,11 +3,10 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using Microsoft.VisualBasic.CompilerServices;
 
 namespace WindowsAppVb
 {
-    [DesignerGenerated()]
+    [Microsoft.VisualBasic.CompilerServices.DesignerGenerated()]
     public partial class WinformsDesignerTest : Form
     {
 


### PR DESCRIPTION
Fixes #865 

It fixes most problems with casts around integrals/fractional/enum types including nullables.