### PR TITLE
Fix enum conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### VB -> C#
 
+* Fix converting non-integral types to enums [#888](https://github.com/icsharpcode/CodeConverter/issues/888)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/TypeConversionAnalyzer.cs
+++ b/CodeConverter/CSharp/TypeConversionAnalyzer.cs
@@ -161,6 +161,12 @@ internal class TypeConversionAnalyzer
             return TypeConversionKind.Conversion;
         }
 
+        vbType.IsNullable(out var underlyingType);
+        var nullableVbType = underlyingType ?? vbType;
+        if (vbConvertedType.IsEnumType() && !(nullableVbType.IsIntegralOrEnumType() || nullableVbType.IsFractionalNumericType())) {
+            return TypeConversionKind.EnumConversionThenCast;
+        }
+
         var vbCompilation = (VBasic.VisualBasicCompilation) _semanticModel.Compilation;
         var vbConversion = vbCompilation.ClassifyConversion(vbType, vbConvertedType);
         var csType = GetCSType(vbType, vbNode);

--- a/Tests/CSharp/StatementTests/StatementTests.cs
+++ b/Tests/CSharp/StatementTests/StatementTests.cs
@@ -73,6 +73,7 @@ Class TestClass
         b = MyEnum.Parse(GetType(MyEnum), v)
     End Sub
 End Class", @"using System;
+using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
 
 internal enum MyEnum
 {
@@ -83,8 +84,8 @@ internal partial class TestClass
 {
     private void TestMethod(string v)
     {
-        MyEnum b = (MyEnum)Enum.Parse(typeof(MyEnum), v);
-        b = (MyEnum)Enum.Parse(typeof(MyEnum), v);
+        MyEnum b = (MyEnum)Conversions.ToInteger(Enum.Parse(typeof(MyEnum), v));
+        b = (MyEnum)Conversions.ToInteger(Enum.Parse(typeof(MyEnum), v));
     }
 }");
     }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -519,6 +519,99 @@ internal partial class Class1
     }
 
     [Fact]
+    public async Task CastingToEnumRightSideShouldBeForcedToBeIntegralAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Public Class C
+    Public Enum OrderStatus
+        Pending = 0
+        Fullfilled = 1
+    End Enum
+ 
+    Sub Test1()
+        Dim val As Object = ""1""
+        Dim os1 = CType(val, OrderStatus)
+        Dim os2 As OrderStatus = val
+
+        Dim null1 = CType(val, OrderStatus?)
+        Dim null2 As OrderStatus? = val
+    End Sub
+    Sub Test2()
+        Dim val As String = ""1""
+        Dim os1 = CType(val, OrderStatus)
+        Dim os2 As OrderStatus = val
+
+        Dim null1 = CType(val, OrderStatus?)
+        Dim null2 As OrderStatus? = val
+    End Sub
+    Sub Test3()
+        Dim val As Object = 1
+        Dim os1 = CType(val, OrderStatus)
+        Dim os2 As OrderStatus = val
+
+        Dim null1 = CType(val, OrderStatus?)
+        Dim null2 As OrderStatus? = val
+    End Sub
+    Sub Test4()
+        Dim val = CType(1.5D, Object)
+        Dim os1 = CType(val, OrderStatus)
+        Dim os2 As OrderStatus = val
+
+        Dim null1 = CType(val, OrderStatus?)
+        Dim null2 As OrderStatus? = val
+    End Sub
+End Class",
+            @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+public partial class C
+{
+    public enum OrderStatus
+    {
+        Pending = 0,
+        Fullfilled = 1
+    }
+
+    public void Test1()
+    {
+        object val = ""1"";
+        OrderStatus os1 = (OrderStatus)Conversions.ToInteger(val);
+        OrderStatus os2 = (OrderStatus)Conversions.ToInteger(val);
+
+        OrderStatus? null1 = (OrderStatus?)val;
+        OrderStatus? null2 = (OrderStatus?)val;
+    }
+    public void Test2()
+    {
+        string val = ""1"";
+        OrderStatus os1 = (OrderStatus)Conversions.ToInteger(val);
+        OrderStatus os2 = (OrderStatus)Conversions.ToInteger(val);
+
+        OrderStatus? null1 = (OrderStatus?)Conversions.ToInteger(val);
+        OrderStatus? null2 = (OrderStatus?)Conversions.ToInteger(val);
+    }
+    public void Test3()
+    {
+        object val = 1;
+        OrderStatus os1 = (OrderStatus)Conversions.ToInteger(val);
+        OrderStatus os2 = (OrderStatus)Conversions.ToInteger(val);
+
+        OrderStatus? null1 = (OrderStatus?)val;
+        OrderStatus? null2 = (OrderStatus?)val;
+    }
+    public void Test4()
+    {
+        object val = 1.5m;
+        OrderStatus os1 = (OrderStatus)Conversions.ToInteger(val);
+        OrderStatus os2 = (OrderStatus)Conversions.ToInteger(val);
+
+        OrderStatus? null1 = (OrderStatus?)val;
+        OrderStatus? null2 = (OrderStatus?)val;
+    }
+}");
+    }
+
+    [Fact]
     public async Task CTypeObjectToIntegerAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/EnumTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/EnumTests.vb
@@ -17,19 +17,49 @@ Public Class EnumTests
     End Class
 
     <Fact>
-    Sub TestEnumCast()
+    Sub TestEnumCType()
         Dim eEnum = RankEnum.Second
         Dim sEnum = "2" 'Has to be an integer within the string, CType doesn't parse enums
         Dim iEnum = 2
-        Dim enumToString As String = CType(eEnum, String)
-        Dim enumToInt As Integer = CType(eEnum, Integer)
-        Dim stringToEnum As RankEnum = CType(sEnum, RankEnum)
-        Dim intToEnum As RankEnum = CType(iEnum, RankEnum)
+        Dim boxedString = CType(sEnum, Object)
+        Dim boxedInt = CType(iEnum, Object)
+
+        Dim enumToString = CType(eEnum, String)
+        Dim enumToInt = CType(eEnum, Integer)
+        Dim stringToEnum = CType(sEnum, RankEnum)
+        Dim intToEnum = CType(iEnum, RankEnum)
+        Dim boxedStringToEnum = CType(boxedString, RankEnum)
+        Dim boxedIntToEnum = CType(boxedInt, RankEnum)
 
         Assert.Equal(sEnum, enumToString)
         Assert.Equal(iEnum, enumToInt)
         Assert.Equal(eEnum, stringToEnum)
         Assert.Equal(eEnum, intToEnum)
+        Assert.Equal(eEnum, boxedStringToEnum)
+        Assert.Equal(eEnum, boxedIntToEnum)
+    End Sub
+
+    <Fact>
+    Sub TestEnumConversions()
+        Dim eEnum = RankEnum.Second
+        Dim sEnum = "2" 'Has to be an integer within the string, CType doesn't parse enums
+        Dim iEnum = 2
+        Dim boxedString = CType(sEnum, Object)
+        Dim boxedInt = CType(iEnum, Object)
+
+        Dim enumToString As String = eEnum
+        Dim enumToInt As Integer = iEnum
+        Dim stringToEnum As RankEnum = sEnum
+        Dim intToEnum As RankEnum = iEnum
+        Dim boxedStringToEnum As RankEnum = boxedString
+        Dim boxedIntToEnum As RankEnum = boxedInt
+
+        Assert.Equal(sEnum, enumToString)
+        Assert.Equal(iEnum, enumToInt)
+        Assert.Equal(eEnum, stringToEnum)
+        Assert.Equal(eEnum, intToEnum)
+        Assert.Equal(eEnum, boxedStringToEnum)
+        Assert.Equal(eEnum, boxedIntToEnum)
     End Sub
 
     <Fact>


### PR DESCRIPTION
Fixes #888 

BTW I wanted to write some more advanced self-verifying tests for the conversion logic but found out that their Compilation object has errors: missing xunit references.
Because of that, the logic in ```TryAnalyzeCsConversion``` is not triggered. ```csConvertedType``` is null (for some reason Roslyn doesn't see C# view of vb types in our case).
https://github.com/icsharpcode/CodeConverter/blob/1f81cc89ea9024b472c07ece067c5dc0c53fc562/CodeConverter/CSharp/TypeConversionAnalyzer.cs#L166-L172

The fix is easy but maybe it's intended to test how non-compiling code is converting?