### PR TITLE
Bugfixes for XML Import Helper code

### DIFF
--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -275,14 +275,14 @@ internal static class XmlImportsCodeToConvert
     // Place Imports statements at the top of your program.  
     internal static readonly XNamespace Default = ""http://DefaultNamespace"";
     internal static readonly XNamespace ns = ""http://NewNamespace"";
-    private static XAttribute[] namespaceAttributes = {
+    private static readonly XAttribute[] namespaceAttributes = {
         new XAttribute(""xmlns"", Default.NamespaceName),
         new XAttribute(XNamespace.Xmlns + ""ns"", ns.NamespaceName)
     };
 
-    internal static TContainer Apply<TContainer>(TContainer x) where TContainer : XContainer
+    internal static XElement Apply(XElement x)
     {
-        foreach (var d in x.Descendants())
+        foreach (var d in x.DescendantsAndSelf())
         {
             foreach (var n in namespaceAttributes)
             {
@@ -294,6 +294,12 @@ internal static class XmlImportsCodeToConvert
             }
         }
         x.Add(namespaceAttributes);
+        return x;
+    }
+
+    internal static XDocument Apply(XDocument x)
+    {
+        Apply(x.Root);
         return x;
     }
 }

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/XmlTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/XmlTests.vb
@@ -1,0 +1,39 @@
+﻿Imports System
+Imports System.Linq
+Imports System.Xml.Linq
+Imports Xunit
+
+Imports <xmlns:t="http://example.com/test">
+Imports <xmlns="http://example.com/">
+
+Public Class XmlTests
+
+    <Fact>
+    Sub TestXDocumentWithXmlNamespaceImports()
+        Dim document As XDocument =
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <books>
+                    <t:book/>
+                </books>
+
+        Assert.Equal("<books xmlns:t=""http://example.com/test"" xmlns=""http://example.com/"">
+  <t:book />
+</books>", document.ToString())
+    End Sub
+
+
+    <Fact>
+    Sub TestXDocumentWithXmlNamespaceImportsFromExistingElement()
+        Dim body As XElement = <books>
+                                   <t:book/>
+                               </books>
+        Dim document As XDocument =
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <%= body %>
+
+        Assert.Equal("<books xmlns:t=""http://example.com/test"" xmlns=""http://example.com/"">
+  <t:book />
+</books>", document.ToString())
+    End Sub
+
+End Class


### PR DESCRIPTION
These changes to the boilerplate template fix run-time errors in some special cases:

- Generating an XDocument with imported XML namespaces: This used to throw an Exception because the xmlns attributes cannot be added to the Document itself. Add to the root instead.
- Make Apply idempotent by including the main element in the scan for duplicate attributes, so that no "Duplicate Attribute" error can occur, even when Apply happens to be called twice on the same element.
- Add readonly attribute to make linter happy
