### PR TITLE
Add support for builtin xml namespaces

### DIFF
--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -178,8 +178,6 @@ internal partial class TestClass
 }");
     }
 
-
-
     [Fact]
     public async Task AssignmentStatementWithXmlElementAndEmbeddedExpressionAsync()
     {
@@ -199,8 +197,6 @@ internal partial class TestClass
     }
 }");
     }
-
-
 
     [Fact]
     public async Task SelfClosingXmlTagAsync()
@@ -260,7 +256,7 @@ Module Module1
     Dim inner = <innerElement/>
 
     ' Create element by using both the default global XML namespace and the namespace identified with the ""ns"" prefix.
-    Dim outer = <ns:outer><ns:innerElement></ns:innerElement><siblingElement></siblingElement><%= inner %></ns:outer>
+    Dim outer = <ns:outer><ns:innerElement attr=""value""></ns:innerElement><siblingElement></siblingElement><%= inner %></ns:outer>
 
     ' Display element to see its final form. 
     Console.WriteLine(outer)
@@ -313,12 +309,31 @@ internal static partial class Module1
         var inner = XmlImports.Apply(new XElement(XmlImports.Default + ""innerElement""));
 
         // Create element by using both the default global XML namespace and the namespace identified with the ""ns"" prefix.
-        var outer = XmlImports.Apply(new XElement(XmlImports.ns + ""outer"", new XElement(XmlImports.ns + ""innerElement""), new XElement(XmlImports.Default + ""siblingElement""), inner));
+        var outer = XmlImports.Apply(new XElement(XmlImports.ns + ""outer"", new XElement(XmlImports.ns + ""innerElement"", new XAttribute(""attr"", ""value"")), new XElement(XmlImports.Default + ""siblingElement""), inner));
 
         // Display element to see its final form. 
         Console.WriteLine(outer);
     }
 
 }");
+    }
+
+    [Fact]
+    public async Task XmlBuiltinNamespaceAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()       
+        Dim xElement = <Name xml:lang=""de"">Beispiel</Name>
+    End Sub
+End Class", @"using System.Xml.Linq;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        var xElement = new XElement(""Name"", new XAttribute(XNamespace.Xml + ""lang"", ""de""), ""Beispiel"");
+    }
+}");
+
     }
 }

--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -324,6 +324,7 @@ internal static partial class Module1
         await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
     Private Sub TestMethod()       
         Dim xElement = <Name xml:lang=""de"">Beispiel</Name>
+        Dim xElement2 = <Name xmlns:ns1=""http://www.example.com/namespace/1"">Beispiel</Name>
     End Sub
 End Class", @"using System.Xml.Linq;
 
@@ -332,6 +333,7 @@ internal partial class TestClass
     private void TestMethod()
     {
         var xElement = new XElement(""Name"", new XAttribute(XNamespace.Xml + ""lang"", ""de""), ""Beispiel"");
+        var xElement2 = new XElement(""Name"", new XAttribute(XNamespace.Xmlns + ""ns1"", ""http://www.example.com/namespace/1""), ""Beispiel"");
     }
 }");
 


### PR DESCRIPTION
This is another incremental improvement to the conversion of XML literals. The Namespace prefixes `xml:` and `xmlns:` are special, in that they don't need to be explicitly imported. A common use case is the `xml:lang` attribute, for which a test has been added. Formerly this led to an error at runtime, because just specifying `"xml:lang"` as the attribute name does not work, since `:` is not a valid character for an attribute name.

Instead, when converting XNames using these prefixes, the constants from XNamespace are now used. To achieve this, the handling of XNames has been applied to attributes as well. Care has been taken, and an existing test has been extended, to ensure that default xml namespaces don't get added to attributes, as per [this](https://stackoverflow.com/a/55484882/959045).