### PR TITLE
fix for VB -> C#: wrong conversion of generic function with CType #893

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### VB -> C#
 
 * Fix converting non-integral types to enums [#888](https://github.com/icsharpcode/CodeConverter/issues/888)
+* Fix types conversion for generic functions [#893](https://github.com/icsharpcode/CodeConverter/issues/893)
 
 ### C# -> VB
 

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -1427,4 +1427,27 @@ public partial class CopiedFromTheSelfVerifyingBooleanTests
     }
 }");
     }
+
+    [Fact]
+    public async Task TestGenericCastAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class TestGenericCast
+    Private Shared Function GenericFunctionWithCast(Of T)() As T
+        Const result = 1
+        Dim resultObj As Object = result
+        Return CType(resultObj, T)
+    End Function
+End Class", @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+internal partial class TestGenericCast
+{
+    private static T GenericFunctionWithCast<T>()
+    {
+        const int result = 1;
+        object resultObj = result;
+        return Conversions.ToGenericParameter<T>(resultObj);
+    }
+}");
+    }
 }

--- a/Tests/CSharp/TypeCastTests.cs
+++ b/Tests/CSharp/TypeCastTests.cs
@@ -1433,20 +1433,38 @@ public partial class CopiedFromTheSelfVerifyingBooleanTests
     {
         await TestConversionVisualBasicToCSharpAsync(
             @"Class TestGenericCast
-    Private Shared Function GenericFunctionWithCast(Of T)() As T
+    Private Shared Function GenericFunctionWithCTypeCast(Of T)() As T
         Const result = 1
         Dim resultObj As Object = result
         Return CType(resultObj, T)
+    End Function
+    Private Shared Function GenericFunctionWithCast(Of T)() As T
+        Const result = 1
+        Dim resultObj As Object = result
+        Return resultObj
+    End Function
+    Private Shared Function GenericFunctionWithCastThatExistsInCsharp(Of T As {TestGenericCast})() As T
+        Return New TestGenericCast
     End Function
 End Class", @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
 
 internal partial class TestGenericCast
 {
+    private static T GenericFunctionWithCTypeCast<T>()
+    {
+        const int result = 1;
+        object resultObj = result;
+        return Conversions.ToGenericParameter<T>(resultObj);
+    }
     private static T GenericFunctionWithCast<T>()
     {
         const int result = 1;
         object resultObj = result;
         return Conversions.ToGenericParameter<T>(resultObj);
+    }
+    private static T GenericFunctionWithCastThatExistsInCsharp<T>() where T : TestGenericCast
+    {
+        return (T)new TestGenericCast();
     }
 }");
     }

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/CastTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/CastTests.vb
@@ -2334,4 +2334,16 @@ Public Class CastTests
         Dim vStringIntDivString = vString \ vString
         Assert.Equal(vStringIntDivString.GetType(), GetType(Long))
     End Sub
+
+    <Fact>
+    Sub TestGenericCast()
+        Assert.Equal(1I, GenericFunctionWithCast(Of Integer)())
+        Assert.Equal(1S, GenericFunctionWithCast(Of Short)())
+    End Sub
+
+    Private Shared Function GenericFunctionWithCast(Of T)() As T
+        Const result = 1
+        Dim resultObj As Object = result
+        Return CType(resultObj, T)
+    End Function
 End Class


### PR DESCRIPTION
[ VB -> C#: wrong conversion of generic function with CType #893](https://github.com/icsharpcode/CodeConverter/issues/893)

### Problem
When casting to a generic type in VB, the converted C# code can fail at runtime where VB doesn't.
`return (T)resultObj;     // run time error when T is short`

### Solution
* Use Call to `Microsoft.VisualBasic.CompilerServices.ToGenericParameter<>` instead of simple cast
* [x] At least one test covering the code changed

