### PR TITLE
Fix Issue #897 (VB -> C#: variable is initialized inside loop)

### DIFF
--- a/CodeConverter/CSharp/HoistedDefaultInitializedLoopVariable.cs
+++ b/CodeConverter/CSharp/HoistedDefaultInitializedLoopVariable.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.CSharp;
+
+internal class HoistedDefaultInitializedLoopVariable : IHoistedNode
+{
+    public string OriginalVariableName { get; }
+    public string Id { get; }
+    public ExpressionSyntax Initializer { get; }
+    public TypeSyntax Type { get; }
+    public bool Nested { get; }
+
+    public HoistedDefaultInitializedLoopVariable(string originalVariableName, ExpressionSyntax initializer, TypeSyntax type, bool nested)
+    {
+        Debug.Assert(initializer is DefaultExpressionSyntax);
+        OriginalVariableName = originalVariableName;
+        Id = $"ph{Guid.NewGuid():N}";
+        Initializer = initializer;
+        Type = type;
+        Nested = nested;
+    }
+
+}

--- a/Tests/CSharp/StatementTests/LoopStatementTests.cs
+++ b/Tests/CSharp/StatementTests/LoopStatementTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Tests.TestRunners;
 using Xunit;
 
@@ -416,6 +417,102 @@ internal partial class GotoTest1
         Console.WriteLine(""End of search."");
         Console.WriteLine(""Press any key to exit."");
         Console.ReadKey();
+    }
+}");
+    }
+    
+    [Fact]
+    public async Task ForWithVariableDeclarationIssue897Async()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        For i = 1 To 2
+            Dim b As Boolean
+            Console.WriteLine(b)
+            b = True
+        Next
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        var b = default(bool);
+        for (int i = 1; i <= 2; i++)
+        {
+            Console.WriteLine(b);
+            b = true;
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task NestedLoopsWithVariableDeclarationIssue897Async()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        Dim i=1
+        Do
+            Dim b As Integer
+            b  +=1
+            Console.WriteLine(""b={0}"", b)
+            For j = 1 To 3
+                Dim c As Integer
+                c  +=1
+                Console.WriteLine(""c1={0}"", c)
+            Next
+            For j = 1 To 3
+                Dim c As Integer
+                c +=1
+                Console.WriteLine(""c2={0}"", c)
+            Next
+            Dim k=1
+            Do while k <= 3
+                Dim c As Integer
+                c +=1
+                Console.WriteLine(""c3={0}"", c)
+                k+=1
+            Loop
+        i += 1
+        Loop Until i > 3
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        int i = 1;
+        var b = default(int);
+        var c1 = default(int);
+        var c2 = default(int);
+        var c3 = default(int);
+        do
+        {
+            b += 1;
+            Console.WriteLine(""b={0}"", b);
+            for (int j = 1; j <= 3; j++)
+            {
+                c1 += 1;
+                Console.WriteLine(""c1={0}"", c1);
+            }
+            for (int j = 1; j <= 3; j++)
+            {
+                c2 += 1;
+                Console.WriteLine(""c2={0}"", c2);
+            }
+            int k = 1;
+            while (k <= 3)
+            {
+                c3 += 1;
+                Console.WriteLine(""c3={0}"", c3);
+                k += 1;
+            }
+            i += 1;
+        }
+        while (i <= 3);
     }
 }");
     }

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
@@ -1,0 +1,57 @@
+﻿Imports System
+Imports System.Linq
+Imports System.Xml.Linq
+Imports Xunit
+
+Public Class VariableScopeTests
+
+    <Fact>
+    Sub TestDeclarationInsideForLoop()
+        For i = 1 To 2
+            Dim b As Boolean
+            If i = 1 Then
+                Assert.False(b)
+            Else
+                Assert.True(b)
+            End If
+
+            b = True
+            Assert.True(b)
+        Next
+    End Sub
+
+    <Fact>
+    Sub TestDeclarationsInsideNestedLoops()
+        Dim results As New List(Of String)
+        Dim i = 1
+        Do
+            Dim b As Integer
+            b += 1
+            results.Add("b=" & b)
+            For j = 1 To 3
+                Dim c As Integer
+                c += 1
+                results.Add("c1=" & c)
+            Next
+            For j = 1 To 3
+                Dim c As Integer
+                c += 1
+                results.Add("c2=" & c)
+            Next
+            Dim k = 1
+            Do While k <= 3
+                Dim c As Integer
+                c += 1
+                results.Add("c3=" & c)
+                k += 1
+            Loop
+            i += 1
+        Loop Until i > 3
+        Assert.Equal(
+            "b=1, c1=1, c1=2, c1=3, c2=1, c2=2, c2=3, c3=1, c3=2, c3=3, " &
+            "b=2, c1=4, c1=5, c1=6, c2=4, c2=5, c2=6, c3=4, c3=5, c3=6, " &
+            "b=3, c1=7, c1=8, c1=9, c2=7, c2=8, c2=9, c3=7, c3=8, c3=9",
+            String.Join(", ", results))
+    End Sub
+
+End Class


### PR DESCRIPTION
[Link to issue this covers](https://github.com/icsharpcode/CodeConverter/issues/897)

### Problem
Uninitialized variables are implicitly set to the default value in VB. The converter needs to add the initialization explicitly. However, in VB the initialization only happens once, even when the variable declaration is inside a loop. Therefore the converted code behaves differently.

### Solution
* Pull default initialized variables out of the loop to ensure they are only initialized once.
* This also applies to nested loops: variables are pulled all the way out to ensure the same behavior as in VB.
* Nested loops in VB can lead to different variables with the same name that end up in the same scope after conversion. These have their names changed.
* [x] At least one test covering the code changed -> I have added a simple case as described in the issue, as well as a complicated one with all loop types and nested clashing variable names. Both cases have a self-verifying test as well as a normal one.