### PR TITLE
Fix Issue #895 (VB -> C#: missing where and wrong select in linq with group clause)

### DIFF
--- a/Tests/CSharp/ExpressionTests/LinqExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/LinqExpressionTests.cs
@@ -7,6 +7,40 @@ namespace ICSharpCode.CodeConverter.Tests.CSharp.ExpressionTests;
 public class LinqExpressionTests : ConverterTestBase
 {
     [Fact]
+    public async Task Issue895_LinqWhereAfterGroupAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Imports System.Collections.Generic
+Imports System.Linq
+
+Public Class Issue895
+    Private Shared Sub LinqWithGroup()
+        Dim numbers = New List(Of Integer) From {1, 2, 3, 4, 4}
+        Dim duplicates = From x In numbers
+                         Group By x Into Group
+                         Where Group.Count > 1
+        System.Console.WriteLine(duplicates.Count)
+    End Sub
+End Class",
+            @"using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public partial class Issue895
+{
+    private static void LinqWithGroup()
+    {
+        var numbers = new List<int>() { 1, 2, 3, 4, 4 };
+        var duplicates = from x in numbers
+                         group x by x into Group
+                         where Group.Count() > 1
+                         select Group;
+        Console.WriteLine(duplicates.Count());
+    }
+}");
+    }
+
+    [Fact]
     public async Task Issue736_LinqEarlySelectAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"
@@ -40,6 +74,7 @@ public partial class Issue635
     }
 }");
     }
+
     [Fact]
     public async Task Issue635_LinqDistinctOrderByAsync()
     {

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/LinqExpressionTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/LinqExpressionTests.vb
@@ -1,0 +1,16 @@
+﻿Imports System
+Imports System.Linq
+Imports Xunit
+
+Public Class LinqExpressionTests
+
+    <Fact>
+    Sub TestWhereAfterGroup()
+        Dim numbers = New List(Of Integer) From {1, 2, 3, 4, 4}
+        Dim duplicates = From x In numbers
+                         Group By x Into Group
+                         Where Group.Count > 1
+        Assert.Equal(1, duplicates.Count)
+    End Sub
+
+End Class

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
@@ -1,6 +1,5 @@
 ﻿Imports System
 Imports System.Linq
-Imports System.Xml.Linq
 Imports Xunit
 
 Public Class VariableScopeTests


### PR DESCRIPTION
[Link to issue(s) this covers](https://github.com/icsharpcode/CodeConverter/issues/895)

### Problem
Nested clauses after a group by get dropped, also the wrong default selection is used.

### Solution
* Pass along the nested clauses to CreateGroupByContinuation, so they no longer get lost.
* When building a "group by" continuation, do not use the selection from the nested clause if it is the default selection, select the group itself instead.
* [x] At least one test covering the code changed

