### PR TITLE
Fix converting Omitted/Optional parameters which could result in wrong method overload being called.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix converting non-integral types to enums [#888](https://github.com/icsharpcode/CodeConverter/issues/888)
 * Fix types conversion for generic functions [#893](https://github.com/icsharpcode/CodeConverter/issues/893)
 * Fix casting Object to nullable types [#904](https://github.com/icsharpcode/CodeConverter/issues/904)
+* Fix converting Omitted/Optional parameters which could result in wrong method overload being called. [#906](https://github.com/icsharpcode/CodeConverter/issues/906)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1613,7 +1613,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
     private IEnumerable<ArgumentSyntax> GetAdditionalRequiredArgs(
         ISet<IParameterSymbol> processedParameters,
         ISymbol invocationSymbol,
-        bool hadOmittedArgs = false)
+        bool invocationHasOmittedArgs = false)
     {
         if (invocationSymbol is null) {
             yield break;
@@ -1623,14 +1623,14 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var requiresCompareMethod = _visualBasicEqualityComparison.OptionCompareTextCaseInsensitive && RequiresStringCompareMethodToBeAppended(invocationSymbol);
 
         foreach (var parameterSymbol in missingArgs) {
-            var extraArg = CreateExtraArgOrNull(parameterSymbol, requiresCompareMethod, hadOmittedArgs);
+            var extraArg = CreateExtraArgOrNull(parameterSymbol, requiresCompareMethod, invocationHasOmittedArgs);
             if (extraArg != null) {
                 yield return extraArg;
             }
         }
     }
 
-    private ArgumentSyntax CreateExtraArgOrNull(IParameterSymbol p, bool requiresCompareMethod, bool hadOmittedArgs)
+    private ArgumentSyntax CreateExtraArgOrNull(IParameterSymbol p, bool requiresCompareMethod, bool invocationHasOmittedArgs)
     {
         var csRefKind = CommonConversions.GetCsRefKind(p);
         if (csRefKind != RefKind.None) {
@@ -1641,7 +1641,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             return (ArgumentSyntax)CommonConversions.CsSyntaxGenerator.Argument(p.Name, RefKind.None, _visualBasicEqualityComparison.CompareMethodExpression);
         }
 
-        if (hadOmittedArgs && p.HasExplicitDefaultValue) {
+        if (invocationHasOmittedArgs && p.HasExplicitDefaultValue) {
             return (ArgumentSyntax)CommonConversions.CsSyntaxGenerator.Argument(p.Name, RefKind.None, CommonConversions.Literal(p.ExplicitDefaultValue));
         }
 

--- a/CodeConverter/Util/SymbolExtensions.cs
+++ b/CodeConverter/Util/SymbolExtensions.cs
@@ -256,6 +256,19 @@ internal static class SymbolExtensions
         return (symbol as IMethodSymbol)?.MethodKind == MethodKind.Ordinary;
     }
 
+    public static bool HasOverloads(this ISymbol invocationSymbol)
+    {
+        if (invocationSymbol?.ContainingType is null) {
+            return false;
+        }
+
+        return invocationSymbol.ContainingType
+            .GetMembers()
+            .Where(it => string.Equals(it.Name, invocationSymbol.Name, StringComparison.OrdinalIgnoreCase))
+            .Take(2)
+            .Count() > 1;
+    }
+
     public static bool IsNormalAnonymousType(this ISymbol symbol)
     {
         return symbol.IsAnonymousType() && !symbol.IsDelegateType();

--- a/CodeConverter/Util/SymbolExtensions.cs
+++ b/CodeConverter/Util/SymbolExtensions.cs
@@ -11,17 +11,21 @@ internal static class SymbolExtensions
     {
         if (symbol == null)
             throw new ArgumentNullException(nameof(symbol));
-        var method = symbol as IMethodSymbol;
-        if (method != null)
+        if (symbol is IMethodSymbol method)
             return method.Parameters;
-        var property = symbol as IPropertySymbol;
-        if (property != null)
+        if (symbol is IPropertySymbol property)
             return property.Parameters;
-        var ev = symbol as IEventSymbol;
-        if (ev != null)
+        if (symbol is IEventSymbol ev)
             return ev.Type.GetDelegateInvokeMethod().Parameters;
         return ImmutableArray<IParameterSymbol>.Empty;
     }
+
+    public static IParameterSymbol GetArgument(this ImmutableArray<IParameterSymbol> args, string name, int ordinal) => 
+        name is not null ? GetArgument(args, name) : GetArgument(args, ordinal);
+
+    public static IParameterSymbol GetArgument(this ImmutableArray<IParameterSymbol> args, string name) => args.FirstOrDefault(argSymbol => argSymbol.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+    public static IParameterSymbol GetArgument(this ImmutableArray<IParameterSymbol> args, int ordinal) => ordinal < args.Length ? args[ordinal] : null;
 
     public static bool IsConstructor(this ISymbol symbol)
     {

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -964,9 +964,9 @@ public static partial class MyExtensions
     public static void CallNewColumn()
     {
         NewColumn(typeof(MyExtensions));
-        NewColumn(null, null, ""otherCode"", argInt: 1);
+        NewColumn(null, code: ""otherCode"");
         NewColumn(null, ""fred"");
-        NewColumn(null, null, argInt: 2, code: ""code"");
+        NewColumn(null, argInt: 2);
     }
 }");
     }
@@ -979,7 +979,6 @@ public static partial class MyExtensions
         Call mySuperFunction(7, , New Object())
     End Sub
 
-
     Private Sub mySuperFunction(intSomething As Integer, Optional p As Object = Nothing, Optional optionalSomething As Object = Nothing)
         Throw New NotImplementedException()
     End Sub
@@ -989,9 +988,8 @@ public partial class Issue445MissingParameter
 {
     public void First(string a, string b, int c)
     {
-        mySuperFunction(7, null, new object());
+        mySuperFunction(7, optionalSomething: new object());
     }
-
 
     private void mySuperFunction(int intSomething, object p = null, object optionalSomething = null)
     {

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -964,9 +964,9 @@ public static partial class MyExtensions
     public static void CallNewColumn()
     {
         NewColumn(typeof(MyExtensions));
-        NewColumn(null, code: ""otherCode"");
+        NewColumn(null, null, ""otherCode"");
         NewColumn(null, ""fred"");
-        NewColumn(null, argInt: 2);
+        NewColumn(null, null, argInt: 2);
     }
 }");
     }
@@ -989,7 +989,7 @@ public partial class Issue445MissingParameter
 {
     public void First(string a, string b, int c)
     {
-        mySuperFunction(7, optionalSomething: new object());
+        mySuperFunction(7, null, new object());
     }
 
 

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -964,9 +964,9 @@ public static partial class MyExtensions
     public static void CallNewColumn()
     {
         NewColumn(typeof(MyExtensions));
-        NewColumn(null, null, ""otherCode"");
+        NewColumn(null, null, ""otherCode"", argInt: 1);
         NewColumn(null, ""fred"");
-        NewColumn(null, null, argInt: 2);
+        NewColumn(null, null, argInt: 2, code: ""code"");
     }
 }");
     }

--- a/Tests/CSharp/ExpressionTests/ParameterTests.cs
+++ b/Tests/CSharp/ExpressionTests/ParameterTests.cs
@@ -38,12 +38,10 @@ public partial class MyController
     }
 
     [Fact]
-    public async Task OptionalLastParameter_UsesCorrectMethodOverloadAsync()
+    public async Task OptionalLastParameter_ExpandsOptionalOmittedArgAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"
 Public Class TestClass
-     Public Sub M(a As String)
-    End Sub
     Public Sub M(a As String, Optional b as String = ""smth"")
     End Sub
     
@@ -55,9 +53,6 @@ End Class
             @"
 public partial class TestClass
 {
-    public void M(string a)
-    {
-    }
     public void M(string a, string b = ""smth"")
     {
     }
@@ -70,12 +65,10 @@ public partial class TestClass
     }
 
     [Fact]
-    public async Task OptionalFirstParameter_UsesCorrectMethodOverloadAsync()
+    public async Task OptionalFirstParameter_ExpandsOptionalOmittedArgAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"
 Public Class TestClass
-    Public Sub M(b As String)
-    End Sub
     Public Sub M(Optional a As String = ""ss"", Optional b as String = ""smth"")
     End Sub
     
@@ -87,9 +80,6 @@ End Class
             @"
 public partial class TestClass
 {
-    public void M(string b)
-    {
-    }
     public void M(string a = ""ss"", string b = ""smth"")
     {
     }
@@ -97,6 +87,31 @@ public partial class TestClass
     public void Test()
     {
         M(""ss"", ""x"");
+    }
+}");
+    }
+
+    [Fact]
+    public async Task OmittedArgumentAfterNamedArgumentAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Public Class TestClass
+    Public Sub M(Optional a As String = ""1"", Optional b as string = ""2"", optional c as string = ""3"")
+    End Sub
+    Public Sub Test()
+        M(a:=""4"", )
+    End Sub
+End Class
+",
+            @"
+public partial class TestClass
+{
+    public void M(string a = ""1"", string b = ""2"", string c = ""3"")
+    {
+    }
+    public void Test()
+    {
+        M(a: ""4"", ""2"", c: ""3"");
     }
 }");
     }

--- a/Tests/CSharp/ExpressionTests/ParameterTests.cs
+++ b/Tests/CSharp/ExpressionTests/ParameterTests.cs
@@ -42,6 +42,8 @@ public partial class MyController
     {
         await TestConversionVisualBasicToCSharpAsync(@"
 Public Class TestClass
+    Public Sub M(a As String)
+    End Sub
     Public Sub M(a As String, Optional b as String = ""smth"")
     End Sub
     
@@ -53,6 +55,9 @@ End Class
             @"
 public partial class TestClass
 {
+    public void M(string a)
+    {
+    }
     public void M(string a, string b = ""smth"")
     {
     }
@@ -69,6 +74,8 @@ public partial class TestClass
     {
         await TestConversionVisualBasicToCSharpAsync(@"
 Public Class TestClass
+    Public Sub M(a As String)
+    End Sub
     Public Sub M(Optional a As String = ""ss"", Optional b as String = ""smth"")
     End Sub
     
@@ -80,6 +87,9 @@ End Class
             @"
 public partial class TestClass
 {
+    public void M(string a)
+    {
+    }
     public void M(string a = ""ss"", string b = ""smth"")
     {
     }
@@ -92,12 +102,15 @@ public partial class TestClass
     }
 
     [Fact]
-    public async Task OmittedArgumentAfterNamedArgumentAsync()
+    public async Task OmittedArgumentAfterNamedArgument_WhenMethodHasCollidingOverload_ShouldExpandAllOptionalArgsAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"
 Public Class TestClass
-    Public Sub M(Optional a As String = ""1"", Optional b as string = ""2"", optional c as string = ""3"")
+    Public Sub M(a As String, b as string)
     End Sub
+    Public Sub M(Optional a As String = ""1"", Optional b as string = ""2"", Optional c as string = ""3"")
+    End Sub
+
     Public Sub Test()
         M(a:=""4"", )
     End Sub
@@ -106,9 +119,13 @@ End Class
             @"
 public partial class TestClass
 {
+    public void M(string a, string b)
+    {
+    }
     public void M(string a = ""1"", string b = ""2"", string c = ""3"")
     {
     }
+
     public void Test()
     {
         M(a: ""4"", ""2"", c: ""3"");

--- a/Tests/CSharp/ExpressionTests/ParameterTests.cs
+++ b/Tests/CSharp/ExpressionTests/ParameterTests.cs
@@ -36,4 +36,68 @@ public partial class MyController
     }
 }");
     }
+
+    [Fact]
+    public async Task OptionalLastParameter_UsesCorrectMethodOverloadAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Public Class TestClass
+     Public Sub M(a As String)
+    End Sub
+    Public Sub M(a As String, Optional b as String = ""smth"")
+    End Sub
+    
+    Public Sub Test()
+        M(""x"",)
+    End Sub
+End Class
+",
+            @"
+public partial class TestClass
+{
+    public void M(string a)
+    {
+    }
+    public void M(string a, string b = ""smth"")
+    {
+    }
+
+    public void Test()
+    {
+        M(""x"", ""smth"");
+    }
+}");
+    }
+
+    [Fact]
+    public async Task OptionalFirstParameter_UsesCorrectMethodOverloadAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Public Class TestClass
+    Public Sub M(b As String)
+    End Sub
+    Public Sub M(Optional a As String = ""ss"", Optional b as String = ""smth"")
+    End Sub
+    
+    Public Sub Test()
+        M(,""x"")
+    End Sub
+End Class
+",
+            @"
+public partial class TestClass
+{
+    public void M(string b)
+    {
+    }
+    public void M(string a = ""ss"", string b = ""smth"")
+    {
+    }
+
+    public void Test()
+    {
+        M(""ss"", ""x"");
+    }
+}");
+    }
 }

--- a/Tests/CSharp/MemberTests/PropertyMemberTests.cs
+++ b/Tests/CSharp/MemberTests/PropertyMemberTests.cs
@@ -621,24 +621,24 @@ public partial class SomeClass : IFoo
     public void TestGet()
     {
         IFoo foo = this;
-        int a = get_Prop2(1, 2) + get_Prop2(1, 20) + get_Prop2(10, 2) + get_Prop2(1, 20, 3) + get_Prop2(1, 2, 30) + get_Prop2(10, 2, 3) + get_Prop2(1, 2, 3);
-        int b = foo.get_Prop(1, 2) + foo.get_Prop(1, 20) + foo.get_Prop(10, 2) + foo.get_Prop(1, 20, 3) + foo.get_Prop(1, 2, 30) + foo.get_Prop(10, 2, 3) + foo.get_Prop(1, 2, 3);
+        int a = get_Prop2(1, 2, z: 3) + get_Prop2(1, 20, z: 3) + get_Prop2(10, 2, z: 3) + get_Prop2(1, 20, 3) + get_Prop2(1, 2, 30) + get_Prop2(10, 2, 3) + get_Prop2(1, 2, 3);
+        int b = foo.get_Prop(1, 2, z: 3) + foo.get_Prop(1, 20, z: 3) + foo.get_Prop(10, 2, z: 3) + foo.get_Prop(1, 20, 3) + foo.get_Prop(1, 2, 30) + foo.get_Prop(10, 2, 3) + foo.get_Prop(1, 2, 3);
     }
 
     public void TestSet()
     {
-        set_Prop2(1, 2, value: 1);
-        set_Prop2(1, 20, value: 1);
-        set_Prop2(10, 2, value: 1);
+        set_Prop2(1, 2, z: 3, value: 1);
+        set_Prop2(1, 20, z: 3, value: 1);
+        set_Prop2(10, 2, z: 3, value: 1);
         set_Prop2(1, 20, 3, 1);
         set_Prop2(1, 2, 30, 1);
         set_Prop2(10, 2, 3, 1);
         set_Prop2(1, 2, 3, 1);
 
         IFoo foo = this;
-        foo.set_Prop(1, 2, value: 1);
-        foo.set_Prop(1, 20, value: 1);
-        foo.set_Prop(10, 2, value: 1);
+        foo.set_Prop(1, 2, z: 3, value: 1);
+        foo.set_Prop(1, 20, z: 3, value: 1);
+        foo.set_Prop(10, 2, z: 3, value: 1);
         foo.set_Prop(1, 20, 3, 1);
         foo.set_Prop(1, 2, 30, 1);
         foo.set_Prop(10, 2, 3, 1);

--- a/Tests/CSharp/MemberTests/PropertyMemberTests.cs
+++ b/Tests/CSharp/MemberTests/PropertyMemberTests.cs
@@ -621,28 +621,28 @@ public partial class SomeClass : IFoo
     public void TestGet()
     {
         IFoo foo = this;
-        int a = get_Prop2() + get_Prop2(y: 20) + get_Prop2(10) + get_Prop2(y: 20) + get_Prop2(z: 30) + get_Prop2(10) + get_Prop2();
-        int b = foo.get_Prop() + foo.get_Prop(y: 20) + foo.get_Prop(10) + foo.get_Prop(y: 20) + foo.get_Prop(z: 30) + foo.get_Prop(10) + foo.get_Prop();
+        int a = get_Prop2(1, 2) + get_Prop2(1, 20) + get_Prop2(10, 2) + get_Prop2(1, 20, 3) + get_Prop2(1, 2, 30) + get_Prop2(10, 2, 3) + get_Prop2(1, 2, 3);
+        int b = foo.get_Prop(1, 2) + foo.get_Prop(1, 20) + foo.get_Prop(10, 2) + foo.get_Prop(1, 20, 3) + foo.get_Prop(1, 2, 30) + foo.get_Prop(10, 2, 3) + foo.get_Prop(1, 2, 3);
     }
 
     public void TestSet()
     {
-        set_Prop2(value: 1);
-        set_Prop2(y: 20, value: 1);
-        set_Prop2(10, value: 1);
-        set_Prop2(y: 20, value: 1);
-        set_Prop2(z: 30, value: 1);
-        set_Prop2(10, value: 1);
-        set_Prop2(value: 1);
+        set_Prop2(1, 2, value: 1);
+        set_Prop2(1, 20, value: 1);
+        set_Prop2(10, 2, value: 1);
+        set_Prop2(1, 20, 3, 1);
+        set_Prop2(1, 2, 30, 1);
+        set_Prop2(10, 2, 3, 1);
+        set_Prop2(1, 2, 3, 1);
 
         IFoo foo = this;
-        foo.set_Prop(value: 1);
-        foo.set_Prop(y: 20, value: 1);
-        foo.set_Prop(10, value: 1);
-        foo.set_Prop(y: 20, value: 1);
-        foo.set_Prop(z: 30, value: 1);
-        foo.set_Prop(10, value: 1);
-        foo.set_Prop(value: 1);
+        foo.set_Prop(1, 2, value: 1);
+        foo.set_Prop(1, 20, value: 1);
+        foo.set_Prop(10, 2, value: 1);
+        foo.set_Prop(1, 20, 3, 1);
+        foo.set_Prop(1, 2, 30, 1);
+        foo.set_Prop(10, 2, 3, 1);
+        foo.set_Prop(1, 2, 3, 1);
     }
 }");
     }

--- a/Tests/CSharp/MemberTests/PropertyMemberTests.cs
+++ b/Tests/CSharp/MemberTests/PropertyMemberTests.cs
@@ -621,28 +621,28 @@ public partial class SomeClass : IFoo
     public void TestGet()
     {
         IFoo foo = this;
-        int a = get_Prop2(1, 2, z: 3) + get_Prop2(1, 20, z: 3) + get_Prop2(10, 2, z: 3) + get_Prop2(1, 20, 3) + get_Prop2(1, 2, 30) + get_Prop2(10, 2, 3) + get_Prop2(1, 2, 3);
-        int b = foo.get_Prop(1, 2, z: 3) + foo.get_Prop(1, 20, z: 3) + foo.get_Prop(10, 2, z: 3) + foo.get_Prop(1, 20, 3) + foo.get_Prop(1, 2, 30) + foo.get_Prop(10, 2, 3) + foo.get_Prop(1, 2, 3);
+        int a = get_Prop2() + get_Prop2(y: 20) + get_Prop2(10) + get_Prop2(y: 20) + get_Prop2(z: 30) + get_Prop2(10) + get_Prop2();
+        int b = foo.get_Prop() + foo.get_Prop(y: 20) + foo.get_Prop(10) + foo.get_Prop(y: 20) + foo.get_Prop(z: 30) + foo.get_Prop(10) + foo.get_Prop();
     }
 
     public void TestSet()
     {
-        set_Prop2(1, 2, z: 3, value: 1);
-        set_Prop2(1, 20, z: 3, value: 1);
-        set_Prop2(10, 2, z: 3, value: 1);
-        set_Prop2(1, 20, 3, 1);
-        set_Prop2(1, 2, 30, 1);
-        set_Prop2(10, 2, 3, 1);
-        set_Prop2(1, 2, 3, 1);
+        set_Prop2(value: 1);
+        set_Prop2(y: 20, value: 1);
+        set_Prop2(10, value: 1);
+        set_Prop2(y: 20, value: 1);
+        set_Prop2(z: 30, value: 1);
+        set_Prop2(10, value: 1);
+        set_Prop2(value: 1);
 
         IFoo foo = this;
-        foo.set_Prop(1, 2, z: 3, value: 1);
-        foo.set_Prop(1, 20, z: 3, value: 1);
-        foo.set_Prop(10, 2, z: 3, value: 1);
-        foo.set_Prop(1, 20, 3, 1);
-        foo.set_Prop(1, 2, 30, 1);
-        foo.set_Prop(10, 2, 3, 1);
-        foo.set_Prop(1, 2, 3, 1);
+        foo.set_Prop(value: 1);
+        foo.set_Prop(y: 20, value: 1);
+        foo.set_Prop(10, value: 1);
+        foo.set_Prop(y: 20, value: 1);
+        foo.set_Prop(z: 30, value: 1);
+        foo.set_Prop(10, value: 1);
+        foo.set_Prop(value: 1);
     }
 }");
     }

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/OmittedArgumentsTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/OmittedArgumentsTests.vb
@@ -1,0 +1,125 @@
+﻿Imports System
+Imports System.Linq
+Imports Xunit
+
+Public Class TestCase1
+    Public Sub SubA(type As Type, Optional code As String = "code", Optional argInt as Integer = 1)
+    End Sub
+    Public Sub SubA(type As Object , Optional code As String = "code", Optional argInt as Integer = 1)
+        Throw New InvalidOperationException("This overload shouldn't be called")
+    End Sub
+    public Sub Run()
+        SubA(Nothing, , argInt:= 1)
+    End Sub
+End Class
+
+Public Class TestCase2
+    Public Sub SubA(type As Type, Optional code As String = "code", Optional argInt as Integer = 1)
+        Throw New InvalidOperationException("This overload shouldn't be called")
+    End Sub
+    Public Sub SubA(type As Object , Optional code As String = "code", Optional argInt2 as Integer = 1)
+    End Sub
+    public Sub Run()
+        SubA(Nothing, , argInt2:= 1)
+    End Sub
+End Class
+
+Public Class TestCase3
+    Public Function SubA(Optional arg1 As String = "arg1", Optional arg2 As String = "arg2") As String
+        Return arg1 & " " & arg2
+    End Function
+    Public Function SubA(arg1 As String) As String
+        Throw New InvalidOperationException("This overload shouldn't be called")
+    End Function
+    public Sub Run()
+        Assert.Equal("test arg2", SubA("test",))
+        Assert.Equal("arg1 test", SubA(,"test"))
+    End Sub
+End Class
+
+Public Class TestCase4
+    Public Function SubA(Optional arg1 As String = "arg1", Optional arg2 As String = "arg2") As String
+        Return arg1 & " " & arg2
+    End Function
+    Public Function SubA(arg1 As String) As String
+        Return arg1
+    End Function
+    Public Function SubA(arg2 As String, Optional arg1 As Integer = 3) As String
+        Return arg1.ToString() & " " & arg2
+    End Function
+    public Sub Run()
+        Assert.Equal("arg1 test", SubA(,"test"))
+        Assert.Equal("arg1 test", SubA(, arg2:="test"))
+
+        Assert.Equal("test", SubA(arg1:= "test"))
+        Assert.Equal("test 5", SubA(arg1:= "test", "5"))
+        Assert.Equal("test arg2", SubA(arg1:= "test", ))
+        Assert.Equal("5 test", SubA(arg1:="5", arg2:= "test"))
+        Assert.Equal("5 test", SubA(arg1:=5, arg2:= "test"))
+        Assert.Equal("6 test", SubA(arg2:= "test", "6"))
+        Assert.Equal("test 6", SubA(arg1:= "test", "6"))
+        Assert.Equal("3 test", SubA(arg2:= "test", ))
+        Assert.Equal("5 arg2", SubA(arg1:= 5, ))
+        Assert.Equal("3 5", SubA(arg2:= 5, ))
+        Assert.Equal("arg1 5", SubA(,arg2:= 5))
+    End Sub
+End Class
+
+Public Class TestCase5
+    Public Function SubA(Optional ByRef arg1 As String = "arg1", Optional arg2 As String = "arg2") As String
+        arg1 &= "changed"
+        Return arg1 & " " & arg2
+    End Function
+    Public Function SubA(arg1 As String) As String
+        Return arg1
+    End Function
+    public Sub Run()
+        Assert.Equal("arg1changed test", SubA(, "test"))
+        Assert.Equal("testchanged arg2", SubA("test", ))
+        Assert.Equal("test", SubA(arg1:="test"))
+        Assert.Equal("test1changed test2", SubA(arg2:="test2", arg1:="test1"))
+        Assert.Equal("test2changed test1", SubA(arg1:="test2", arg2:="test1"))
+        Assert.Equal("testchanged arg2", SubA(arg1:="test",))
+        Assert.Equal("arg1changed test", SubA(arg2:="test"))
+        Assert.Equal("arg1changed test", SubA(,arg2:="test"))
+
+        Dim arg = "test"
+        Assert.Equal("test", SubA(arg))
+        Assert.Equal("testchanged arg2", SubA(arg,))
+        Assert.Equal("arg1changed testchanged", SubA(,arg))
+    End Sub
+End Class
+
+Public Class OmittedArgumentsTests
+
+    <Fact>
+    Public Sub Test1()
+        Dim test1 As New TestCase1()
+        test1.Run()
+    End Sub
+
+    <Fact>
+    Public Sub Test2()
+        Dim test2 As New TestCase2()
+        test2.Run()
+    End Sub
+
+    <Fact>
+    Public Sub Test3()
+        Dim test3 As New TestCase3()
+        test3.Run()
+    End Sub
+
+    <Fact>
+    Public Sub Test4()
+        Dim test4 As New TestCase4()
+        test4.Run()
+    End Sub
+
+    <Fact>
+    Public Sub Test5()
+        Dim test5 As New TestCase5()
+        test5.Run()
+    End Sub
+
+End Class

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/OmittedArgumentsTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/OmittedArgumentsTests.vb
@@ -8,7 +8,7 @@ Public Class TestCase1
     Public Sub SubA(type As Object , Optional code As String = "code", Optional argInt as Integer = 1)
         Throw New InvalidOperationException("This overload shouldn't be called")
     End Sub
-    public Sub Run()
+    Public Sub Run()
         SubA(Nothing, , argInt:= 1)
     End Sub
 End Class
@@ -19,7 +19,7 @@ Public Class TestCase2
     End Sub
     Public Sub SubA(type As Object , Optional code As String = "code", Optional argInt2 as Integer = 1)
     End Sub
-    public Sub Run()
+    Public Sub Run()
         SubA(Nothing, , argInt2:= 1)
     End Sub
 End Class
@@ -31,7 +31,7 @@ Public Class TestCase3
     Public Function SubA(arg1 As String) As String
         Throw New InvalidOperationException("This overload shouldn't be called")
     End Function
-    public Sub Run()
+    Public Sub Run()
         Assert.Equal("test arg2", SubA("test",))
         Assert.Equal("arg1 test", SubA(,"test"))
     End Sub
@@ -47,7 +47,7 @@ Public Class TestCase4
     Public Function SubA(arg2 As String, Optional arg1 As Integer = 3) As String
         Return arg1.ToString() & " " & arg2
     End Function
-    public Sub Run()
+    Public Sub Run()
         Assert.Equal("arg1 test", SubA(,"test"))
         Assert.Equal("arg1 test", SubA(, arg2:="test"))
 
@@ -73,7 +73,7 @@ Public Class TestCase5
     Public Function SubA(arg1 As String) As String
         Return arg1
     End Function
-    public Sub Run()
+    Public Sub Run()
         Assert.Equal("arg1changed test", SubA(, "test"))
         Assert.Equal("testchanged arg2", SubA("test", ))
         Assert.Equal("test", SubA(arg1:="test"))
@@ -87,6 +87,47 @@ Public Class TestCase5
         Assert.Equal("test", SubA(arg))
         Assert.Equal("testchanged arg2", SubA(arg,))
         Assert.Equal("arg1changed testchanged", SubA(,arg))
+    End Sub
+End Class
+
+Public Class TestCase6
+    Public Function M() As String
+        Return ""
+    End Function
+    Public Function M(a As String, b as string) As String
+        Return $"{a} {b}"
+    End Function
+    Public Function M(Optional a As String = "1", Optional b as string = "2", optional c as string = "3") As String
+        Return $"{a} {b} {c}"
+    End Function
+    Public Sub Run()
+        Assert.Equal("11 2 3", M(a:="11", ))
+        Assert.Equal("11 22", M(a:="11", "22"))
+        Assert.Equal("11 22 3", M(a:="11", "22", ))
+        Assert.Equal("1 2 3", M(,))
+        Assert.Equal("1 22 3", M(,b:="22"))
+        Assert.Equal("1 22 3", M(,b:="22",))
+        Assert.Equal("1 2 33", M(,c:="33"))
+        Assert.Equal("1 2 33", M(,,c:="33"))
+        Assert.Equal("1 2 33", M(,,c:="33"))
+        Assert.Equal("11 22", M(a:="11",b:="22"))
+        Assert.Equal("11 22 3", M(a:="11",b:="22",))
+    End Sub
+End Class
+
+Public Class TestCase7
+    Public Function M() As String
+        Return ""
+    End Function
+    Public Function M(Optional a As String = "3", optional b as string = "4") As String
+        Return $"{a} {b}"
+    End Function
+    Public Function M(Optional a As String = "1", Optional b as string = "2", optional c as string = "3") As String
+        Return $"{a} {b} {c}"
+    End Function
+    Public Sub Run()
+        Assert.Equal("11 2 3", M(a:="11",,))
+        Assert.Equal("11 2 3", M("11",,))
     End Sub
 End Class
 
@@ -120,6 +161,12 @@ Public Class OmittedArgumentsTests
     Public Sub Test5()
         Dim test5 As New TestCase5()
         test5.Run()
+    End Sub
+
+    <Fact>
+    Public Sub Test6()
+        Dim test6 As New TestCase6()
+        test6.Run()
     End Sub
 
 End Class


### PR DESCRIPTION
Fixes #906 

More complicated than I initially thought. The idea of just providing every omitted argument didn't work for all cases. Example:

Input [sharplab.io](https://sharplab.io/#v2:DYLgbgRgNAJiDUAfAkgWwA4HsBOAXAzgAQDKAnvrgKaoCwAUPQAoCuEwAlgMaEDCwAhviIA1dvmb9gAIUFc+g/E1YduxVoQCyACn6EAgkWK5s7AHYBzAJT1Ct3plP5MwSgDoA6iaoAZM5S0AJABEAN78AL5B1nQAoqYwJKxKbFyJEJo6+obGZuZQhOmChBQmFtF29o7Obp7sPn6BoRGEIRCR0XEJahDJKmkZAPLouOwOkoS6BiQ5FoQAvIRBAIxB+UMjY8AFE0QlufOLAEyrhJjDo6bj3EV7swtBAMxRNnY8Dk4uHl6Uvqb+wWFwi02i1OO16J00vReqluoQAErMUxacq2bTLFb5IKHY5QVEZfggOYYk4deJQ2Lk+RCIA===):
```vbnet
Public Sub M(a As String)
    Console.WriteLine($"{a}")
End Sub
Public Sub M(a As String, b as string)
    Console.WriteLine($"{a} {b}")
End Sub
Public Sub M(Optional a As String = "1", Optional b as string = "2", optional c as string = "3")
    Console.WriteLine($"{a} {b} {c}")
End Sub

Public Sub Run()
   M("11", "22",) ' "11 22 3
   M(a:="11", ) ' 11 2 3
End Sub
```

Develop [sharplab.io](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUH1AZgAINiA1ASwGcIBDAGwCE7rKBjAYQderwG88xYaRKpMANlIAWYgFkAFOIAMxOgEohIwbhF7SmAJwKAJACJ+dAL5n1Abi3CreR6INTUsxSrUwDqgCNNXW1XPXFjc0srYn4Am3tXZ3wQ4SJ3GXklTFU6YgBeYjNMMz8fAIKi9FL/YnZKs0JbVx19EQjTC2tY+Nj2BIdU4mTXDHQWsJFFYpK/M3RqxKG9RToQIswSpb1kqyA===)
```csharp
M("11", "22"); // incorrect: 11 22
M(a: "11"); // incorrect: 11
```

Initial idea [sharplab.io](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUH1AZgAINiA1ASwGcIBDAGwCE7rKBjAYQderwG88xYaRKpMANlIAWYgFkAFOIAMxOgEohIwbhF7SmAJwKAJACJ+dAL5n1Abi3CreR6INTUsxSrUwDqgCNNXW1XPXFjc0srYn4Am3tXZ3wQ4SJ3GXklTFU6YgBeYjNMMz8fAIKi9FL/YnZKs0JbVx19EQjTC2tY+Nj2BIdU4mTXDHQWsJFFYpK/M3RquabEob1FOhAizFmq20G9ZKsgA=)
```csharp
M("11", "22", "3"); // correct
M(a: "11", "2"); // incorrect: 11 2
```

Final (?) solution [sharplab.io](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUH1AZgAINiA1ASwGcIBDAGwCE7rKBjAYQderwG88xYaRKpMANlIAWYgFkAFOIAMxOgEohIwbhF7SmAJwKAJACJ+dAL5n1Abi3CreR6INTUsxSrUwDqgCNNXW1XPXFjc0srYn4Am3tXZ3wQ4SJ3GXklTFU6YgBeYjNMMz8fAIKi9FL/YnZKs0JbVx19EQjTC2tY+Nj2BIdU4mTXDHQWsJFFYpK/M3Rqv3YQIqbEob1FOhWZmoCdxbqdtcG9ZKsgA=)
```csharp
M("11", "22", c: "3"); // correct
M(a: "11", b: "2", c: "3"); // correct
```

The solution works more or less like this:
1. Process named/positional args as usual. If the positional arg is omitted then pull ```ExplicitDefaultValue```.  
a) Note that after named arg we can still have omitted args!
b) If the omitted arg is required in C# (ref/out) then do the hoisting.
2. Now ```GetAdditionalRequiredArgs``` will check what parameters we're still missing to match the invoked symbol.
This includes cases where we need to provide ```Microsoft.VisualBasic.CompareMethod``` enum or do the hoisting for (ref/out) arg.

The downside of this approach is that we sometimes pull more arguments than it's necessary but I guess it's better than calling wrong method overload.