### PR TITLE
Fix variable declaration incorrectly pulled before the loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix types conversion for generic functions [#893](https://github.com/icsharpcode/CodeConverter/issues/893)
 * Fix casting Object to nullable types [#904](https://github.com/icsharpcode/CodeConverter/issues/904)
 * Fix converting Omitted/Optional parameters which could result in wrong method overload being called. [#906](https://github.com/icsharpcode/CodeConverter/issues/906)
+* Fix variable declaration being incorrectly pulled before the loop when it's initialized explicitly with default value. [#911](https://github.com/icsharpcode/CodeConverter/issues/911)
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -124,10 +124,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                 }
             } else {
                 foreach (var decl in localDeclarationStatementSyntaxs) {
-                    if (_perScopeState.IsInsideLoop() &&
-                        decl.Declaration.Variables.All(
-                            x => x.Initializer?.Value is DefaultExpressionSyntax
-                        )) {
+                    if (_perScopeState.IsInsideLoop() && declarator.Initializer is null && declarator.AsClause is not VBSyntax.AsNewClauseSyntax) {
                         foreach (var variable in decl.Declaration.Variables) {
                             _perScopeState.Hoist(new HoistedDefaultInitializedLoopVariable(
                                 variable.Identifier.Text, 

--- a/Tests/CSharp/StatementTests/LoopStatementTests.cs
+++ b/Tests/CSharp/StatementTests/LoopStatementTests.cs
@@ -420,6 +420,56 @@ internal partial class GotoTest1
     }
 }");
     }
+
+    [Fact]
+    public async Task LoopWithVariableDeclarationInitializedWithDefault_ShouldNotBePulledOutOfTheLoopAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        For i = 1 To 2
+            Dim a As Boolean? = Nothing
+            Console.WriteLine(a)
+        Next
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        for (int i = 1; i <= 2; i++)
+        {
+            bool? a = default;
+            Console.WriteLine(a);
+        }
+    }
+}");
+    }
+
+    [Fact]
+    public async Task LoopWithVariableDeclarationInitializedWithAsNewClause_ShouldNotBePulledOutOfTheLoopAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        For i = 1 To 2
+            Dim a As New Integer()
+            Console.WriteLine(a)
+        Next
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        for (int i = 1; i <= 2; i++)
+        {
+            int a = new int();
+            Console.WriteLine(a);
+        }
+    }
+}");
+    }
     
     [Fact]
     public async Task ForWithVariableDeclarationIssue897Async()

--- a/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
+++ b/Tests/TestData/SelfVerifyingTests/VBToCS/VariableScopeTests.vb
@@ -53,4 +53,27 @@ Public Class VariableScopeTests
             String.Join(", ", results))
     End Sub
 
+    <Fact>
+    Sub TestMultipleVariablesDefinedInOneDeclarationStatement()
+        For i = 1 To 2
+            Dim a = True, b As Boolean, c As Integer? = Nothing, d = 4, e As New Integer(), f As Integer?
+            a = Not a
+            b = Not b
+            c = If(Not c.HasValue, 0, c + 1)
+            d += 1
+            e += 1
+            f = If(Not f.HasValue, 0, f + 1)
+
+            If i = 2 Then
+                Assert.Equal(False, a)
+                Assert.Equal(False, b)
+                Assert.Equal(0, c)
+                Assert.Equal(5, d)
+                Assert.Equal(1, e)
+                Assert.Equal(1, f)
+            End If
+        Next
+    End Sub
+
+
 End Class


### PR DESCRIPTION
Fixes #911 

### Problem
You can explicitly initialize variables with default values. In these cases, the declarations shouldn't be pulled before the loop.

### Solution
* Any comments on the approach taken, its consistency with surrounding code, etc.
* Which part of this PR is most in need of attention/improvement?
* [x] At least one test covering the code changed

