### PR TITLE
Fix mapping for error trivia added by converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix casting Object to nullable types [#904](https://github.com/icsharpcode/CodeConverter/issues/904)
 * Fix converting Omitted/Optional parameters which could result in wrong method overload being called. [#906](https://github.com/icsharpcode/CodeConverter/issues/906)
 * Fix variable declaration being incorrectly pulled before the loop when it's initialized explicitly with default value. [#911](https://github.com/icsharpcode/CodeConverter/issues/911)
+* Fix mapping for error trivia added by converter. [#917](https://github.com/icsharpcode/CodeConverter/issues/917)
 
 ### C# -> VB
 

--- a/CodeConverter/Common/LineTriviaMapper.cs
+++ b/CodeConverter/Common/LineTriviaMapper.cs
@@ -182,6 +182,15 @@ internal class LineTriviaMapper
     {
         if (!_targetTokenToTrivia.TryGetValue(toReplace, out var targetTrivia)) {
             targetTrivia = (new List<IReadOnlyCollection<SyntaxTrivia>>(), new List<IReadOnlyCollection<SyntaxTrivia>>());
+            var errorTrivia = toReplace.TrailingTrivia.Where(t => t.HasAnnotations(AnnotationConstants.ConversionErrorAnnotationKind)).ToArray();
+            if (errorTrivia.Any()) {
+                targetTrivia.Trailing.Add(errorTrivia);
+            }
+            errorTrivia = toReplace.LeadingTrivia.Where(t => t.HasAnnotations(AnnotationConstants.ConversionErrorAnnotationKind)).ToArray();
+            if (errorTrivia.Any()) {
+                targetTrivia.Leading.Add(errorTrivia);
+            }
+
             _targetTokenToTrivia[toReplace] = targetTrivia;
         }
 

--- a/CodeConverter/Common/ProjectConversion.cs
+++ b/CodeConverter/Common/ProjectConversion.cs
@@ -282,7 +282,7 @@ public class ProjectConversion
 
     private static string[] GetErrorsFromAnnotations(SyntaxNode convertedNode)
     {
-        var errorAnnotations = convertedNode.GetAnnotations(AnnotationConstants.ConversionErrorAnnotationKind).ToList();
+        var errorAnnotations = convertedNode.DescendantNodesAndSelf().SelectMany(t => t.GetAnnotations(AnnotationConstants.ConversionErrorAnnotationKind)).ToList();
         string[] errors = errorAnnotations.Select(a => a.Data).ToArray();
         return errors;
     }


### PR DESCRIPTION
Fix #917 

> You'd probably need to change them to be converted before going into the collection for consistency.

@GrahamTheCoder I'm not sure if I understand this correctly. What do you mean by "change trivia to be converted for consistency"? Isn't the error trivia already created in target language?