### PR TITLE
Push to github pages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -78,6 +78,7 @@ jobs:
         path: Func/bin/${{ env.BuildTarget }}/publish/
         
  deploy:
+     if: ${{ github.ref == 'refs/heads/master' }}
      concurrency: ci-${{ github.ref }}
      needs: [build] # The second job must depend on the first one to complete before running and uses ubuntu-latest instead of windows.
      runs-on: ubuntu-latest
@@ -94,5 +95,6 @@ jobs:
        - name: Deploy 🚀
          uses: JamesIves/github-pages-deploy-action@v4
          with:
-           folder: 'site/wwwroot' # The deployment folder should match the name of the artifact. Even though our project builds into the 'build' folder the artifact name of 'site' must be placed here.
+           branch: 'autoupdated/gh-pages'
+           folder: 'site/wwwroot'
           

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,12 +5,14 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
- 
+
+env:
+  BuildVersion: '9.0.2'
+  
 jobs:
  build:
     runs-on: windows-2022
     env:
-      BuildVersion: '9.0.2'
       BuildPlatform: Any CPU
       BuildTarget: Release
 
@@ -79,8 +81,6 @@ jobs:
      concurrency: ci-${{ github.ref }}
      needs: [build] # The second job must depend on the first one to complete before running and uses ubuntu-latest instead of windows.
      runs-on: ubuntu-latest
-     env:
-       BuildVersion: '9.0.2'
      steps:
        - name: Checkout 🛎️
          uses: actions/checkout@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,8 +49,10 @@ jobs:
       env:
         Tests1: Tests/bin/${{ env.BuildTarget }}/ICSharpCode.CodeConverter.Tests.dll
 
+
+
     - name: Deploy to github pages
-      uses: JamesIves/github-pages-deploy-action@4.4.0
+      uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: autoupdated/gh-pages

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -52,6 +52,7 @@ jobs:
 
 
     - name: Deploy to github pages
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: JamesIves/github-pages-deploy-action@v4.4.0
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,16 +49,6 @@ jobs:
       env:
         Tests1: Tests/bin/${{ env.BuildTarget }}/ICSharpCode.CodeConverter.Tests.dll
 
-
-
-    - name: Deploy to github pages
-      if: ${{ github.ref == 'refs/heads/master' }}
-      uses: JamesIves/github-pages-deploy-action@v4.4.0
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH: autoupdated/gh-pages
-        FOLDER: Web/bin/${{ env.BuildTarget }}/publish/wwwroot
-
     - name: Upload NuGet package
       uses: actions/upload-artifact@v2
       with:
@@ -84,3 +74,23 @@ jobs:
       with:
         name: ICSharpCode.CodeConverter.Func.${{ env.BuildVersion }}.zip
         path: Func/bin/${{ env.BuildTarget }}/publish/
+        
+ deploy:
+     concurrency: ci-${{ github.ref }}
+     needs: [build] # The second job must depend on the first one to complete before running and uses ubuntu-latest instead of windows.
+     runs-on: ubuntu-latest
+     steps:
+       - name: Checkout 🛎️
+         uses: actions/checkout@v3
+ 
+       - name: Download Artifacts 🔻 # The built project is downloaded into the 'site' folder.
+         uses: actions/download-artifact@v1
+         with:
+           name: ICSharpCode.CodeConverter.Web.${{ env.BuildVersion }}.zip
+           path: site
+ 
+       - name: Deploy 🚀
+         uses: JamesIves/github-pages-deploy-action@v4
+         with:
+           folder: 'site/wwwroot' # The deployment folder should match the name of the artifact. Even though our project builds into the 'build' folder the artifact name of 'site' must be placed here.
+          

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,6 +79,8 @@ jobs:
      concurrency: ci-${{ github.ref }}
      needs: [build] # The second job must depend on the first one to complete before running and uses ubuntu-latest instead of windows.
      runs-on: ubuntu-latest
+     env:
+       BuildVersion: '9.0.2'
      steps:
        - name: Checkout 🛎️
          uses: actions/checkout@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,6 +49,13 @@ jobs:
       env:
         Tests1: Tests/bin/${{ env.BuildTarget }}/ICSharpCode.CodeConverter.Tests.dll
 
+    - name: Deploy to github pages
+      uses: JamesIves/github-pages-deploy-action@4.4.0
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: autoupdated/gh-pages
+        FOLDER: Web/bin/${{ env.BuildTarget }}/publish/wwwroot
+
     - name: Upload NuGet package
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Part of https://github.com/icsharpcode/CodeConverter/issues/795

Irritatingly the action I'm using only runs on ubuntu so it has to be a totally separate job. IIRC we need to build on windows for some legacy msbuild related stuff to work

TODO
* [x] Once this works first time, restrict to master
`if: ${{ github.ref == 'refs/heads/master' }}`

@christophwille You'll need to setup the repo settings something like this:
![image](https://user-images.githubusercontent.com/2490482/181788981-53148571-34a4-4499-8998-3dcb16554e6f.png)
