### PR TITLE
Benchmark various parallel async IAsyncEnumerable approaches

### DIFF
--- a/Benchmarks/AsyncParallelExtensions.cs
+++ b/Benchmarks/AsyncParallelExtensions.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using BenchmarkDotNet.Attributes;
+
+namespace CodeConverter.Tests
+{
+
+    public static partial class AsyncParallelExtensions
+    {
+
+        public static IAsyncEnumerable<TResult> DataFlowParallelSelectAsync<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            return DataFlowParallelSelectAsync(source, selector, maxDop, default);
+        }
+
+        private static async IAsyncEnumerable<TResult> DataFlowParallelSelectAsync<TArg, TResult>(IEnumerable<TArg> source, Func<TArg, Task<TResult>> selector, int maxDop, [EnumeratorCancellation] CancellationToken token)
+        {
+            var transform = new TransformBlock<TArg, TResult>(selector, new ExecutionDataflowBlockOptions {
+                MaxDegreeOfParallelism = maxDop,
+                CancellationToken = token
+            });
+
+            var unused = source.Select(f => transform.Post(f)).ToArray();
+            transform.Complete();
+
+            await foreach (var item in transform.AsObservable().ToAsyncEnumerable().WithCancellation(token)) {
+                yield return item;
+            }
+        }
+
+        /// <summary>
+        /// https://stackoverflow.com/a/58564740/1128762
+        /// </summary>
+        public static IAsyncEnumerable<TResult> DataFlowLazyParallelSelectAsync<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            return DataFlowLazyParallelSelectAsync(source, selector, maxDop, default);
+        }
+
+        public static async IAsyncEnumerable<TResult> DataFlowLazyParallelSelectAsync<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop, [EnumeratorCancellation] CancellationToken token)
+        {
+            var processor = new TransformBlock<TArg, TResult>(selector, new ExecutionDataflowBlockOptions {
+                MaxDegreeOfParallelism = maxDop,
+                BoundedCapacity = (maxDop * 5) / 4,
+                CancellationToken = token
+            });
+
+            foreach (var item in source) {
+                while (!processor.Post(item)) {
+                    yield return await WaitNextResultAsync();
+                }
+                if (processor.TryReceive(out var result)) {
+                    yield return result;
+                }
+            }
+            processor.Complete();
+
+            while (await processor.OutputAvailableAsync(token)) {
+                yield return Receive();
+            }
+
+            async Task<TResult> WaitNextResultAsync()
+            {
+                if (!await processor.OutputAvailableAsync()) throw new InvalidOperationException("No output available after posting output and waiting");
+                return Receive();
+            }
+
+            TResult Receive()
+            {
+                if (!processor.TryReceive(out var result)) throw new InvalidOperationException("Nothing received even though output available");
+                token.ThrowIfCancellationRequested();
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// https://stackoverflow.com/a/58564740/1128762
+        /// </summary>
+        public static async IAsyncEnumerable<TResult> DataFlowLazyParallelSelectAsync_PostThread<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            var processor = new TransformBlock<TArg, TResult>(selector, new ExecutionDataflowBlockOptions {
+                MaxDegreeOfParallelism = maxDop
+            });
+
+            var postTask = Task.Run(() => {
+                try {
+                    foreach (var item in source) processor.Post(item);
+                } finally {
+                    processor.Complete();
+                }
+            });
+
+            await foreach (var result in processor.AsObservable().ToAsyncEnumerable()) {
+                yield return result;
+            }
+
+            await postTask; // Observe any exceptions from posting
+        }
+
+        public static async IAsyncEnumerable<TResult> AsParallelSelect<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            foreach (var task in source.AsParallel().AsOrdered().WithDegreeOfParallelism(maxDop).Select(selector).Select(r => r.Result)) {
+                yield return task;
+            }
+        }
+
+        public static IAsyncEnumerable<TResult> SingleThreadAsync<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            return source.ToAsyncEnumerable().SelectAwait(async x => await selector(x));
+        }
+
+        public static async Task<IEnumerable<int>> TaskPerItem_IgnoresMaxDop_NoValuesUntilEnd(this IEnumerable<int[]> inputs, Func<int[], Task<int>> work, int ignoredMaxDop)
+        {
+            return await Task.WhenAll(inputs.Select(work).ToArray());
+        }
+
+        public static IAsyncEnumerable<TResult> ExplicitPartition_Lazy<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            return Partitioner.Create(source).GetPartitions(maxDop).AsParallel()
+                .Select(partition => AsAsyncEnumerable(partition).SelectAwait(async r => await selector(r)))
+                .ToAsyncEnumerable().SelectMany(x => x);
+        }
+
+        public static async IAsyncEnumerable<TResult> ExplicitPartitions_Eager_NoValuesUntilEnd<TArg, TResult>(this IEnumerable<TArg> source,
+            Func<TArg, Task<TResult>> selector, int maxDop)
+        {
+            var partitionTasks = Partitioner.Create(source).GetPartitions(maxDop)
+                .AsParallel().WithDegreeOfParallelism(maxDop).Select(partition => SelectAsync(AsEnumerable(partition), selector));
+            var partionedResults = await Task.WhenAll(partitionTasks);
+            var results = partionedResults.SelectMany(x => x).ToAsyncEnumerable();
+            await foreach (var result in results) yield return result;
+
+            static async Task<TResult[]> SelectAsync(IEnumerable<TArg> source,
+                Func<TArg, Task<TResult>> selector)
+            {
+                var partitionResults = new List<TResult>();
+                foreach (var partitionMember in source) {
+                    var result = await selector(partitionMember);
+                    partitionResults.Add(result);
+                }
+
+                return partitionResults.ToArray();
+            }
+        }
+
+        private static IEnumerable<T> AsEnumerable<T>(this IEnumerator<T> enumerator)
+        {
+            using (enumerator) {
+                while (enumerator.MoveNext()) {
+                    yield return enumerator.Current;
+                }
+            }
+        }
+
+        private static async IAsyncEnumerable<T> AsAsyncEnumerable<T>(this IEnumerator<T> enumerator)
+        {
+            using (enumerator) {
+                while (enumerator.MoveNext()) {
+                    yield return enumerator.Current;
+                }
+            }
+        }
+    }
+}

--- a/Benchmarks/Benchmarks.cs
+++ b/Benchmarks/Benchmarks.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace CodeConverter.Tests
+{
+
+    //[SimpleJob(RuntimeMoniker.CoreRt31, warmupCount: 1, targetCount: 2)]
+    [SimpleJob(RuntimeMoniker.Net472, warmupCount: 1, targetCount: 5)]
+    [MemoryDiagnoser]
+    [MarkdownExporterAttribute.GitHub]
+    public class Benchmarks
+    {
+        private static IConfig _config =
+#if DEBUG
+            new DebugInProcessConfig();
+#else
+            DefaultConfig.Instance;
+#endif
+
+        public static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(Benchmarks).Assembly).Run(args, _config);
+
+        private int[][] _inputs = null;
+
+        [Params(8, 16)]
+        public int MaxDop { get; set; }
+
+        [Params(80)]
+        public byte PiecesOfWork { get; set; }
+
+        [Params(500)]
+        public int MinWorkSize { get; set; }
+
+        [Params(10000)]
+        public int MaxWorkSize { get; set; }
+
+        [Params(4378)]
+        public int RandomSeed { get; set; }
+
+        /// <summary>
+        /// The idea is to ensure low latency for the first result.
+        /// A successful algorith must take less than half the time taking 1 as taking all.
+        /// A cancellation token isn't currently part of the test, so extra work may be ongoing after the first one is returned and stop the benchmark process exiting.
+        /// </summary>
+        [Params(1, byte.MaxValue)]
+        public byte TakeN { get; set; }
+
+        private int? ExpectedAnswer;
+
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var rnd = new Random(RandomSeed);
+            _inputs = Enumerable.Range(1, PiecesOfWork).Select(_ =>
+                Enumerable.Range(1, rnd.Next(MinWorkSize, MaxWorkSize)).Select(__ => rnd.Next(1000)).ToArray()
+            ).ToArray();
+            ExpectedAnswer = SingleThread().GetAwaiter().GetResult();
+        }
+
+        [Benchmark(Baseline = true)]
+        public Task<int> SingleThread()
+        {
+            return Run(AsyncParallelExtensions.SingleThreadAsync);
+        }
+
+        [Benchmark, BenchmarkCategory("GoodThroughput")]
+        public Task<int> AsParallelSelect()
+        {
+            return Run(AsyncParallelExtensions.AsParallelSelect);
+        }
+
+        [Benchmark, BenchmarkCategory("GoodLatency")]
+        public Task<int> ExplicitPartition_Lazy()
+        {
+            return Run(AsyncParallelExtensions.ExplicitPartition_Lazy);
+        }
+
+        [Benchmark, BenchmarkCategory("Candidate", "GoodLatency", "GoodThroughput")]
+        public Task<int> DataFlowLazyParallelSelectAsync()
+        {
+            return Run(AsyncParallelExtensions.DataFlowLazyParallelSelectAsync);
+        }
+
+        [Benchmark, BenchmarkCategory("Variant", "GoodThroughput")]
+        public Task<int> DataFlowParallelSelectAsync()
+        {
+            return Run(AsyncParallelExtensions.DataFlowParallelSelectAsync);
+        }
+
+        [Benchmark, BenchmarkCategory("Variant")]
+        public Task<int> DataFlowLazyParallelSelectAsync_PostThread()
+        {
+            return Run(AsyncParallelExtensions.DataFlowLazyParallelSelectAsync_PostThread);
+        }
+
+        [Benchmark, BenchmarkCategory("NoValuesUntilEnd")]
+        public Task<int> ExplicitPartitions_Eager_NoValuesUntilEnd()
+        {
+            return Run(AsyncParallelExtensions.ExplicitPartitions_Eager_NoValuesUntilEnd);
+        }
+
+        private async Task<int> Run(Func<IEnumerable<int[]>, Func<int[], Task<int>>, int, IAsyncEnumerable<int>> method)
+        {
+            await new SynchronizationContextRemover();
+            var array = method(_inputs, DoDeterministicVariableCpuBoundWork, MaxDop);
+            int max = await array.Take(TakeN).MaxAsync();
+            return ThrowIfIncorrect(max);
+        }
+
+        private int ThrowIfIncorrect(int max)
+        {
+            return !ExpectedAnswer.HasValue || max == ExpectedAnswer ? max : throw new Exception($"Expected {ExpectedAnswer} but got {max}");
+        }
+
+        private async Task<int> DoDeterministicVariableCpuBoundWork(int[] input)
+        {
+            unchecked {
+                int output = 1;
+                for (int i = 0; i < input.Length; i++) {
+                    for (int j = 0; j < input.Length; j++) {
+                        output += 31 * input[i] - 11 * input[j];
+                    }
+                    if (i == input.Length / 2) await Task.Delay(1); //Simulate the task being half synchronous
+                }
+                return output;
+            }
+        }
+    }
+}

--- a/Benchmarks/Benchmarks.csproj
+++ b/Benchmarks/Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>CodeConverter.Benchmarks</AssemblyName>
+    <RootNamespace>CodeConverter.Benchmarks</RootNamespace>
+    <LangVersion>8.0</LangVersion>
+    <NoWarn>$(NoWarn);1998</NoWarn>
+    <StartupObject>CodeConverter.Tests.Benchmarks</StartupObject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.11.0" />
+  </ItemGroup>
+</Project>

--- a/Benchmarks/PartitionParallelExtensions.cs
+++ b/Benchmarks/PartitionParallelExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace CodeConverter.Tests
+{
+
+    internal static class AsyncEnumerableTaskExtensions
+    {
+    }
+}

--- a/Benchmarks/SynchronizationContextRemover.cs
+++ b/Benchmarks/SynchronizationContextRemover.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+
+namespace CodeConverter.Tests
+{
+    /// <summary>
+    /// https://putridparrot.com/blog/replacing-multiple-configureawait-with-the-synchronizationcontextremover/
+    /// </summary>
+    internal struct SynchronizationContextRemover : INotifyCompletion
+    {
+        public bool IsCompleted => SynchronizationContext.Current == null;
+
+        public void OnCompleted(Action continuation)
+        {
+            var prev = SynchronizationContext.Current;
+            try {
+                SynchronizationContext.SetSynchronizationContext(null);
+                continuation();
+            } finally {
+                SynchronizationContext.SetSynchronizationContext(prev);
+            }
+        }
+
+        public SynchronizationContextRemover GetAwaiter()
+        {
+            return this;
+        }
+
+        public void GetResult()
+        {
+        }
+    }
+}

--- a/CodeConverter.sln
+++ b/CodeConverter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29721.120
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ICSharpCode.CodeConverter", "ICSharpCode.CodeConverter\ICSharpCode.CodeConverter.csproj", "{7EA075C6-6406-445C-AB77-6C47AFF88D58}"
 EndProject
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CodeConverter.Web", "CodeConverter.Web\CodeConverter.Web.csproj", "{08A20D4F-6310-43BB-B339-6317ACF3B52E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "Benchmarks\Benchmarks.csproj", "{12A9B86B-789C-4AC1-AF74-2E524EC0F5B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,6 +40,10 @@ Global
 		{08A20D4F-6310-43BB-B339-6317ACF3B52E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08A20D4F-6310-43BB-B339-6317ACF3B52E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08A20D4F-6310-43BB-B339-6317ACF3B52E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12A9B86B-789C-4AC1-AF74-2E524EC0F5B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12A9B86B-789C-4AC1-AF74-2E524EC0F5B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12A9B86B-789C-4AC1-AF74-2E524EC0F5B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12A9B86B-789C-4AC1-AF74-2E524EC0F5B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
|                          Method | MaxDop | PiecesOfWork | MinWorkSize | MaxWorkSize | RandomSeed | TakeN |        Mean |       Error |    StdDev | Ratio | MannWhitney(5%) | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |------- |------------- |------------ |------------ |----------- |------ |------------:|------------:|----------:|------:|---------------- |--------:|------:|------:|------:|----------:|
|                    **SingleThread** |      **8** |           **80** |         **500** |       **10000** |       **4378** |     **1** |    **224.1 ms** |    **16.86 ms** |   **4.38 ms** |  **1.00** |            **Base** |    **0.00** |     **-** |     **-** |     **-** |    **5461 B** |
|                AsParallelSelect |      8 |           80 |         500 |       10000 |       4378 |     1 |  2,935.1 ms | 1,667.14 ms | 432.95 ms | 13.10 |          Slower |    1.93 |     - |     - |     - |  131072 B |
|          ExplicitPartition_Lazy |      8 |           80 |         500 |       10000 |       4378 |     1 |    237.3 ms |    28.33 ms |   7.36 ms |  1.06 |            Same |    0.04 |     - |     - |     - |   73728 B |
| DataFlowLazyParallelSelectAsync |      8 |           80 |         500 |       10000 |       4378 |     1 |    356.4 ms |    46.06 ms |  11.96 ms |  1.59 |          Slower |    0.05 |     - |     - |     - |   81920 B |
|                                 |        |              |             |             |            |       |             |             |           |       |                 |         |       |       |       |           |
|                    **SingleThread** |      **8** |           **80** |         **500** |       **10000** |       **4378** |   **255** |  **7,106.4 ms** |   **630.46 ms** | **163.73 ms** |  **1.00** |            **Base** |    **0.00** |     **-** |     **-** |     **-** |  **172032 B** |
|                AsParallelSelect |      8 |           80 |         500 |       10000 |       4378 |   255 |  2,642.7 ms | 1,320.38 ms | 342.90 ms |  0.37 |          Faster |    0.04 |     - |     - |     - |  139264 B |
|          ExplicitPartition_Lazy |      8 |           80 |         500 |       10000 |       4378 |   255 |  7,209.1 ms |   229.68 ms |  59.65 ms |  1.01 |            Same |    0.02 |     - |     - |     - |  294912 B |
|                                 |        |              |             |             |            |       |             |             |           |       |                 |         |       |       |       |           |
|                    **SingleThread** |     **16** |           **80** |         **500** |       **10000** |       **4378** |     **1** |    **232.6 ms** |     **8.53 ms** |   **2.22 ms** |  **1.00** |            **Base** |    **0.00** |     **-** |     **-** |     **-** |    **5461 B** |
|                AsParallelSelect |     16 |           80 |         500 |       10000 |       4378 |     1 |  2,934.8 ms | 2,665.44 ms | 692.21 ms | 12.62 |          Slower |    2.96 |     - |     - |     - |  172032 B |
|          ExplicitPartition_Lazy |     16 |           80 |         500 |       10000 |       4378 |     1 |    427.7 ms |   109.00 ms |  28.31 ms |  1.84 |          Slower |    0.11 |     - |     - |     - |  114688 B |
| DataFlowLazyParallelSelectAsync |     16 |           80 |         500 |       10000 |       4378 |     1 |    654.9 ms |   145.95 ms |  37.90 ms |  2.82 |          Slower |    0.17 |     - |     - |     - |   81920 B |
|                                 |        |              |             |             |            |       |             |             |           |       |                 |         |       |       |       |           |
|                    **SingleThread** |     **16** |           **80** |         **500** |       **10000** |       **4378** |   **255** | **14,772.7 ms** |   **429.85 ms** | **111.63 ms** |  **1.00** |            **Base** |    **0.00** |     **-** |     **-** |     **-** |  **172032 B** |
|                AsParallelSelect |     16 |           80 |         500 |       10000 |       4378 |   255 |  2,984.5 ms | 1,650.40 ms | 428.60 ms |  0.20 |          Faster |    0.03 |     - |     - |     - |  163840 B |
|          ExplicitPartition_Lazy |     16 |           80 |         500 |       10000 |       4378 |   255 |  7,414.7 ms |   591.19 ms | 153.53 ms |  0.50 |          Faster |    0.01 |     - |     - |     - |  294912 B |

|                          Method | MaxDop | PiecesOfWork | MinWorkSize | MaxWorkSize | RandomSeed | TakeN |       Mean |     Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |------- |------------- |------------ |------------ |----------- |------ |-----------:|----------:|---------:|------:|------:|------:|----------:|
| **DataFlowLazyParallelSelectAsync** |      **8** |           **80** |         **500** |       **10000** |       **4378** |     **1** |   **352.7 ms** |  **81.64 ms** | **21.20 ms** |     **-** |     **-** |     **-** |     **80 KB** |
| **DataFlowLazyParallelSelectAsync** |      **8** |           **80** |         **500** |       **10000** |       **4378** |   **255** | **2,459.2 ms** | **276.57 ms** | **71.82 ms** |     **-** |     **-** |     **-** |    **192 KB** |
| **DataFlowLazyParallelSelectAsync** |     **16** |           **80** |         **500** |       **10000** |       **4378** |     **1** |   **567.9 ms** | **149.19 ms** | **38.75 ms** |     **-** |     **-** |     **-** |     **80 KB** |
| **DataFlowLazyParallelSelectAsync** |     **16** |           **80** |         **500** |       **10000** |       **4378** |   **255** | **2,330.9 ms** | **130.79 ms** | **33.97 ms** |     **-** |     **-** |     **-** |    **184 KB** |
