### PR TITLE
Pass CancellationToken

### DIFF
--- a/CodeConverter/CodeConverter.cs
+++ b/CodeConverter/CodeConverter.cs
@@ -8,7 +8,7 @@ public static class CodeConverter
     private const string VbLanguage = "Visual Basic";
     private const string CsLanguage = "C#";
 
-    private record SupportedConversion(string From, string To, Func<CodeWithOptions, Task<ConversionResult>> ConvertAsync)
+    private record SupportedConversion(string From, string To, Func<CodeWithOptions, CancellationToken, Task<ConversionResult>> ConvertAsync)
     {
         public override string ToString() => $"{From}->{To}";
     }
@@ -18,18 +18,17 @@ public static class CodeConverter
         new(CsLanguage, VbLanguage, ConvertFromCodeWithOptionsAsync<CSToVBConversion>)
     };
 
-    private static Task<ConversionResult> ConvertFromCodeWithOptionsAsync<TLanguageConversion>(CodeWithOptions code) where TLanguageConversion : ILanguageConversion, new() =>
-        ProjectConversion.ConvertTextAsync<TLanguageConversion>(code.Text, new TextConversionOptions(code.References));
+    private static Task<ConversionResult> ConvertFromCodeWithOptionsAsync<TLanguageConversion>(CodeWithOptions code, CancellationToken ct) where TLanguageConversion : ILanguageConversion, new() =>
+        ProjectConversion.ConvertTextAsync<TLanguageConversion>(code.Text, new TextConversionOptions(code.References), cancellationToken: ct);
 
-    public static async Task<ConversionResult> ConvertAsync(CodeWithOptions code)
+    public static async Task<ConversionResult> ConvertAsync(CodeWithOptions code, CancellationToken ct = default)
     {
-        if (SupportedConversions.SingleOrDefault(c => c.From == code.FromLanguage && c.To == code.ToLanguage) is {} supportedConversion) {
-            return await supportedConversion.ConvertAsync(code);
+        if (SupportedConversions.SingleOrDefault(c => c.From == code.FromLanguage && c.To == code.ToLanguage) is { } supportedConversion) {
+            return await supportedConversion.ConvertAsync(code, ct);
         }
 
         string supportedConversions = string.Join<SupportedConversion>(", ", SupportedConversions);
         var exception = new NotSupportedException($"Conversion {code.FromLanguage} to {code.ToLanguage} is not supported, please specify one of the following: {supportedConversions}");
         return new ConversionResult(exception);
-
     }
 }

--- a/Func/Convert.cs
+++ b/Func/Convert.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Web;
 using Microsoft.AspNetCore.Http;
@@ -10,20 +11,31 @@ using Newtonsoft.Json;
 
 namespace ICSharpCode.CodeConverter.Func;
 
-public static class Convert
+public class Convert
 {
+    private readonly ILoggerFactory _loggerFactory;
+
+    public Convert(ILoggerFactory loggerFactory)
+    {
+        _loggerFactory = loggerFactory;
+    }
+
     //
     // Sample data: {"code":"Public Class VisualBasicClass\r\n\r\nEnd Class","requestedConversion":"vbnet2cs"}
     //
     [FunctionName("Convert")]
 #pragma warning disable VSTHRD200 // Use "Async" suffix for async methods - Name must be "Run" for this to work AFAIK
-    public static async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req, ILogger log)
+    public async Task<IActionResult> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
+        CancellationToken hostCancellationToken)
 #pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
     {
+        var logger = _loggerFactory.CreateLogger<Convert>();
         string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
         var data = JsonConvert.DeserializeObject<ConvertRequest>(requestBody);
 
-        var response = await WebConverter.ConvertAsync(data);
+        using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(hostCancellationToken, req.HttpContext.RequestAborted);
+        var response = await WebConverter.ConvertAsync(data, cancellationSource.Token);
 
         return new OkObjectResult(response);
     }

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -13,6 +13,7 @@
     <None Include="local.settings.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />

--- a/Func/GlobalSuppressions.cs
+++ b/Func/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0161:Convert to file-scoped namespace", Justification = "<Pending>", Scope = "namespace", Target = "~N:ICSharpCode.CodeConverter.Func")]

--- a/Func/Startup.cs
+++ b/Func/Startup.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+[assembly: FunctionsStartup(typeof(ICSharpCode.CodeConverter.Func.Startup))]
+
+namespace ICSharpCode.CodeConverter.Func
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            //builder.Services.AddHttpClient();
+
+            //builder.Services.AddSingleton<IMyService>((s) => {
+            //    return new MyService();
+            //});
+
+            //builder.Services.AddSingleton<ILoggerProvider, MyLoggerProvider>();
+        }
+    }
+}

--- a/Func/host.json
+++ b/Func/host.json
@@ -2,9 +2,9 @@
     "version": "2.0",
     "logging": {
         "applicationInsights": {
-            "samplingExcludedTypes": "Request",
             "samplingSettings": {
-                "isEnabled": true
+                "isEnabled": true,
+                "excludedTypes": "Request"
             }
         }
     }

--- a/Func/local.settings.json
+++ b/Func/local.settings.json
@@ -1,4 +1,9 @@
 ﻿{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    },
     "Host": {
         "CORS": "*"
     }

--- a/Web/WebConverter.cs
+++ b/Web/WebConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.Common;
 using Microsoft.CodeAnalysis;
@@ -10,7 +11,7 @@ public record ConvertResponse(bool conversionOk, string convertedCode, string er
 
 public static class WebConverter
 {
-    public static async Task<ConvertResponse> ConvertAsync(ConvertRequest todo)
+    public static async Task<ConvertResponse> ConvertAsync(ConvertRequest todo, CancellationToken ct = default)
     {
         var languages = todo.requestedConversion.Split('2');
 
@@ -27,7 +28,7 @@ public static class WebConverter
             .SetFromLanguage(fromLanguage)
             .SetToLanguage(toLanguage);
 
-        var result = await CodeConverter.ConvertAsync(codeWithOptions);
+        var result = await CodeConverter.ConvertAsync(codeWithOptions, ct);
 
         return new ConvertResponse(result.Success, result.ConvertedCode, result.GetExceptionsAsString());
     }


### PR DESCRIPTION
As an extension, I'd like to suggest passing ILoggerFactory? into the call chain so we can create logger instances (when non-null) to log errors and information (that can be surfaced in case of the Azure Functions deployment using Application Insights). 