### PR TITLE
Apply timeout to simplification

### DIFF
--- a/CodeConverter/CSharp/VBToCSConversion.cs
+++ b/CodeConverter/CSharp/VBToCSConversion.cs
@@ -202,7 +202,7 @@ End Class";
 
     public async Task<Document> SingleSecondPassAsync(Document doc)
     {
-        var simplifiedDocument = await doc.SimplifyStatementsAsync<UsingDirectiveSyntax>(UnresolvedNamespaceDiagnosticId, _cancellationToken);
+        var simplifiedDocument = await _vbToCsProjectContentsConverter.OptionalOperations.SimplifyStatementsAsync<UsingDirectiveSyntax>(doc, UnresolvedNamespaceDiagnosticId);
 
         // Can't add a reference to Microsoft.VisualBasic if there's no project file, so hint to install the package
         if (_vbToCsProjectContentsConverter.SourceProject.AssemblyName == FabricatedAssemblyName) {

--- a/CodeConverter/VB/CSToVBConversion.cs
+++ b/CodeConverter/VB/CSToVBConversion.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using ICSharpCode.CodeConverter.CSharp;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
@@ -28,7 +29,7 @@ public class CSToVBConversion : ILanguageConversion
     }
     public async Task<Document> SingleSecondPassAsync(Document doc)
     {
-        return await doc.SimplifyStatementsAsync<ImportsStatementSyntax>(UnresolvedNamespaceDiagnosticId, _cancellationToken);
+        return await _csToVbProjectContentsConverter.OptionalOperations.SimplifyStatementsAsync<ImportsStatementSyntax>(doc, UnresolvedNamespaceDiagnosticId);
     }
 
     public SyntaxNode GetSurroundedNode(IEnumerable<SyntaxNode> descendantNodes,


### PR DESCRIPTION
### Problem
#877
A deeply nested single expression seemed to cause this issue. 

### Solution
Currently just skips simplification when it takes longer than the configurable timeout. This at least allows the conversion to proceed.

* [x] Get a benchmark test set up for this and experiment with different approaches:
    * [ ] Simplify leaf nodes first and work up.
    * [x] Skip simplifying subparts of a name, just the outer one may be enough
    * Try adding new lines
    * Try extracting sub expressions into their own field

### Notes
* Even simplifying with the simplify annotation only on the namespace node takes 48.5s
* All the time seems to be in GetOriginalSymbol info. I believe that for each identifier, it essentially rebinds the entire expression in order to get the original symbol.
* Very similar sort of issue here: https://lightrun.com/answers/omnisharp-omnisharp-vscode-omnisharp-gets-stuck-at-100-cpu-when-analyzing-complex-automapper-profiles