### PR TITLE
Update to CodeAnalysis 4.2.0 (drop 2017 support)

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -232,7 +232,7 @@ internal class CommonConversions
     private async Task<CSharpSyntaxNode> GetInitializerFromNameAndTypeAsync(ITypeSymbol typeSymbol,
         VBSyntax.ModifiedIdentifierSyntax name, CSharpSyntaxNode initializer)
     {
-        if (!SyntaxTokenExtensions.IsKind(name.Nullable, SyntaxKind.None))
+        if (!name.Nullable.IsKind(SyntaxKind.None))
         {
             if (typeSymbol.IsArrayType())
             {
@@ -347,8 +347,8 @@ internal class CommonConversions
         if (implicitVisibility && !isPartial) declaredAccessibility = Accessibility.NotApplicable;
         var modifierSyntaxs = ConvertModifiersCore(declaredAccessibility, modifiers, context)
             .Concat(extraCsModifierKinds.Select(SyntaxFactory.Token))
-            .Where(t => t.Kind() != CSSyntaxKind.None)
-            .OrderBy(m => SyntaxTokenExtensions.IsKind(m, CSSyntaxKind.PartialKeyword));
+            .Where(t => !t.IsKind(CSSyntaxKind.None))
+            .OrderBy(m => m.IsKind(CSSyntaxKind.PartialKeyword));
         return SyntaxFactory.TokenList(modifierSyntaxs);
     }
 
@@ -399,7 +399,7 @@ internal class CommonConversions
             if (m.HasValue) yield return m.Value;
         }
         if (context == TokenContext.MemberInModule &&
-            !remainingModifiers.Any(a => VisualBasicExtensions.Kind(a) == SyntaxKind.ConstKeyword ))
+            !remainingModifiers.Any(a => a.IsKind(SyntaxKind.ConstKeyword)))
             yield return SyntaxFactory.Token(CSSyntaxKind.StaticKeyword);
     }
 
@@ -617,7 +617,7 @@ internal class CommonConversions
 
     public static bool IsDefaultIndexer(SyntaxNode node)
     {
-        return node is VBSyntax.PropertyStatementSyntax pss && pss.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, SyntaxKind.DefaultKeyword));
+        return node is VBSyntax.PropertyStatementSyntax pss && pss.Modifiers.Any(m => m.IsKind(SyntaxKind.DefaultKeyword));
     }
 
 

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -553,7 +553,7 @@ internal class CommonConversions
     {
         if (operation is IPropertyReferenceOperation pro && pro.Arguments.Any() &&
             !VisualBasicExtensions.IsDefault(pro.Property)) {
-            var isSetter = pro.Parent.Kind == OperationKind.SimpleAssignment && pro.Parent.ChildOperations.First() == pro;
+            var isSetter = pro.Parent.Kind == OperationKind.SimpleAssignment && pro.Parent.Children.First() == pro;
             var extraArg = isSetter
                 ? await GetParameterizedSetterArgAsync(operation)
                 : null;

--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -553,7 +553,7 @@ internal class CommonConversions
     {
         if (operation is IPropertyReferenceOperation pro && pro.Arguments.Any() &&
             !VisualBasicExtensions.IsDefault(pro.Property)) {
-            var isSetter = pro.Parent.Kind == OperationKind.SimpleAssignment && pro.Parent.Children.First() == pro;
+            var isSetter = pro.Parent.Kind == OperationKind.SimpleAssignment && pro.Parent.ChildOperations.First() == pro;
             var extraArg = isSetter
                 ? await GetParameterizedSetterArgAsync(operation)
                 : null;

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -495,8 +495,8 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
     {
         var attributes = (await node.AttributeLists.SelectManyAsync(CommonConversions.ConvertAttributeAsync)).ToList();
         var convertableModifiers =
-            node.Modifiers.Where(m => !SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
-        var isWithEvents = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WithEventsKeyword));
+            node.Modifiers.Where(m => !m.IsKind(VBasic.SyntaxKind.WithEventsKeyword));
+        var isWithEvents = node.Modifiers.Any(m => m.IsKind(VBasic.SyntaxKind.WithEventsKeyword));
         var convertedModifiers =
             CommonConversions.ConvertModifiers(node.Declarators[0].Names[0], convertableModifiers.ToList(), GetMemberContext(node));
         var declarations = new List<MemberDeclarationSyntax>(node.Declarators.Count);
@@ -635,8 +635,8 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
     public override async Task<CSharpSyntaxNode> VisitPropertyStatement(VBSyntax.PropertyStatementSyntax node)
     {
         var attributes = SyntaxFactory.List(await node.AttributeLists.SelectManyAsync(CommonConversions.ConvertAttributeAsync));
-        var isReadonly = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.ReadOnlyKeyword));
-        var isWriteOnly = node.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, VBasic.SyntaxKind.WriteOnlyKeyword));
+        var isReadonly = node.Modifiers.Any(m => m.IsKind(VBasic.SyntaxKind.ReadOnlyKeyword));
+        var isWriteOnly = node.Modifiers.Any(m => m.IsKind(VBasic.SyntaxKind.WriteOnlyKeyword));
         var convertibleModifiers = node.Modifiers.Where(m => !m.IsKind(VBasic.SyntaxKind.ReadOnlyKeyword, VBasic.SyntaxKind.WriteOnlyKeyword, VBasic.SyntaxKind.DefaultKeyword));
         var modifiers = CommonConversions.ConvertModifiers(node, convertibleModifiers.ToList(), GetMemberContext(node));
         var isIndexer = CommonConversions.IsDefaultIndexer(node);
@@ -650,7 +650,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         var additionalInterfaceImplements = propSymbol.ExplicitInterfaceImplementations;
         directlyConvertedCsIdentifier = hasExplicitInterfaceImplementation ? directlyConvertedCsIdentifier : CommonConversions.ConvertIdentifier(node.Identifier);
 
-        var explicitInterfaceModifiers = modifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword, CSSyntaxKind.AbstractKeyword, CSSyntaxKind.OverrideKeyword, CSSyntaxKind.NewKeyword));
+        var explicitInterfaceModifiers = modifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword, CSSyntaxKind.AbstractKeyword) || m.IsKind(CSSyntaxKind.OverrideKeyword, CSSyntaxKind.NewKeyword));
         var shouldConvertToMethods = ShouldConvertAsParameterizedProperty(node);
         var (initializer, vbType) = await GetVbReturnTypeAsync(node);
 
@@ -1127,7 +1127,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         bool hasBody = node.Parent is VBSyntax.MethodBlockBaseSyntax;
 
         if ("Finalize".Equals(node.Identifier.ValueText, StringComparison.OrdinalIgnoreCase) && 
-            node.Modifiers.Any(m => VBasic.VisualBasicExtensions.Kind(m) == VBasic.SyntaxKind.OverridesKeyword)) 
+            node.Modifiers.Any(m => m.IsKind(VBasic.SyntaxKind.OverridesKeyword)))
         {
             var declaration = SyntaxFactory.
                 DestructorDeclaration(CommonConversions.ConvertIdentifier(node.GetAncestor<VBSyntax.TypeBlockSyntax>().BlockStatement.Identifier)).
@@ -1168,7 +1168,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
 
             var requiredParameterList = MakeOptionalParametersRequired(parameterList);
             var delegatingClause = GetDelegatingClause(directlyConvertedCsIdentifier, requiredParameterList, false);
-            var explicitInterfaceModifiers = convertedModifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword, CSSyntaxKind.AbstractKeyword, CSSyntaxKind.OverrideKeyword, CSSyntaxKind.NewKeyword));
+            var explicitInterfaceModifiers = convertedModifiers.RemoveWhere(m => m.IsCsMemberVisibility() || m.IsKind(CSSyntaxKind.VirtualKeyword, CSSyntaxKind.AbstractKeyword) || m.IsKind(CSSyntaxKind.OverrideKeyword, CSSyntaxKind.NewKeyword));
 
             var interfaceDeclParams = new MethodDeclarationParameters(attributes, explicitInterfaceModifiers, returnType, typeParameters, requiredParameterList, constraints, delegatingClause);
             AddInterfaceMemberDeclarations(declaredSymbol.ExplicitInterfaceImplementations, additionalDeclarations, interfaceDeclParams);
@@ -1571,8 +1571,8 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
     public override async Task<CSharpSyntaxNode> VisitTypeParameter(VBSyntax.TypeParameterSyntax node)
     {
         SyntaxToken variance = default(SyntaxToken);
-        if (!SyntaxTokenExtensions.IsKind(node.VarianceKeyword, VBasic.SyntaxKind.None)) {
-            variance = SyntaxFactory.Token(SyntaxTokenExtensions.IsKind(node.VarianceKeyword, VBasic.SyntaxKind.InKeyword) ? CSSyntaxKind.InKeyword : CSSyntaxKind.OutKeyword);
+        if (!node.VarianceKeyword.IsKind(VBasic.SyntaxKind.None)) {
+            variance = SyntaxFactory.Token(node.VarianceKeyword.IsKind(VBasic.SyntaxKind.InKeyword) ? CSSyntaxKind.InKeyword : CSSyntaxKind.OutKeyword);
         }
         return SyntaxFactory.TypeParameter(SyntaxFactory.List<AttributeListSyntax>(), variance, CommonConversions.ConvertIdentifier(node.Identifier));
     }
@@ -1592,7 +1592,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
 
     public override async Task<CSharpSyntaxNode> VisitSpecialConstraint(VBSyntax.SpecialConstraintSyntax node)
     {
-        if (SyntaxTokenExtensions.IsKind(node.ConstraintKeyword, VBasic.SyntaxKind.NewKeyword))
+        if (node.ConstraintKeyword.IsKind(VBasic.SyntaxKind.NewKeyword))
             return SyntaxFactory.ConstructorConstraint();
         return SyntaxFactory.ClassOrStructConstraint(node.IsKind(VBasic.SyntaxKind.ClassConstraint) ? CSSyntaxKind.ClassConstraint : CSSyntaxKind.StructConstraint);
     }

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -313,7 +313,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         if (simplifiedOrNull != null) return simplifiedOrNull;
 
         var expressionSyntax = await node.Expression.AcceptAsync<ExpressionSyntax>(TriviaConvertingExpressionVisitor);
-        if (SyntaxTokenExtensions.IsKind(node.Keyword, VBasic.SyntaxKind.CDateKeyword)) {
+        if (node.Keyword.IsKind(VBasic.SyntaxKind.CDateKeyword)) {
 
             _extraUsingDirectives.Add("Microsoft.VisualBasic.CompilerServices");
             return SyntaxFactory.InvocationExpression(SyntaxFactory.ParseExpression("Conversions.ToDate"), SyntaxFactory.ArgumentList(
@@ -1352,7 +1352,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             syntaxParamType = SyntaxFactory.ArrayType(syntaxParamType, rankSpecifiers);
         }
 
-        if (!SyntaxTokenExtensions.IsKind(node.Identifier.Nullable, SyntaxKind.None)) {
+        if (!node.Identifier.Nullable.IsKind(SyntaxKind.None)) {
             var arrayType = syntaxParamType as ArrayTypeSyntax;
             if (arrayType == null) {
                 syntaxParamType = SyntaxFactory.NullableType(syntaxParamType);
@@ -1398,7 +1398,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
 
     public override async Task<CSharpSyntaxNode> VisitPredefinedType(VBasic.Syntax.PredefinedTypeSyntax node)
     {
-        if (SyntaxTokenExtensions.IsKind(node.Keyword, VBasic.SyntaxKind.DateKeyword)) {
+        if (node.Keyword.IsKind(VBasic.SyntaxKind.DateKeyword)) {
             return SyntaxFactory.IdentifierName(nameof(DateTime));
         }
         return SyntaxFactory.PredefinedType(node.Keyword.ConvertToken());

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -89,7 +89,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
     public override async Task<SyntaxList<StatementSyntax>> VisitLocalDeclarationStatement(VBSyntax.LocalDeclarationStatementSyntax node)
     {  
         var modifiers = CommonConversions.ConvertModifiers(node.Declarators[0].Names[0], node.Modifiers, TokenContext.Local);
-        var isConst = modifiers.Any(a => a.Kind() == SyntaxKind.ConstKeyword);
+        var isConst = modifiers.Any(a => a.IsKind(SyntaxKind.ConstKeyword));
         var isVBStatic = node.Modifiers.Any(a => a.IsKind(VBasic.SyntaxKind.StaticKeyword));
 
         var declarations = new List<StatementSyntax>();
@@ -1002,7 +1002,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
 
         if (node.DoStatement.WhileOrUntilClause != null) {
             var stmt = node.DoStatement.WhileOrUntilClause;
-            if (SyntaxTokenExtensions.IsKind(stmt.WhileOrUntilKeyword, VBasic.SyntaxKind.WhileKeyword))
+            if (stmt.WhileOrUntilKeyword.IsKind(VBasic.SyntaxKind.WhileKeyword))
                 return SingleStatement(SyntaxFactory.WhileStatement(
                     await stmt.Condition.AcceptAsync<ExpressionSyntax>(_expressionVisitor),
                     statements
@@ -1018,7 +1018,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
         bool isUntilStmt;
         if (whileOrUntilStmt != null) {
             conditionExpression = await whileOrUntilStmt.Condition.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-            isUntilStmt = SyntaxTokenExtensions.IsKind(whileOrUntilStmt.WhileOrUntilKeyword, VBasic.SyntaxKind.UntilKeyword);
+            isUntilStmt = whileOrUntilStmt.WhileOrUntilKeyword.IsKind(VBasic.SyntaxKind.UntilKeyword);
         } else {
             conditionExpression = SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression);
             isUntilStmt = false;

--- a/CodeConverter/CSharp/PerScopeStateVisitorDecorator.cs
+++ b/CodeConverter/CSharp/PerScopeStateVisitorDecorator.cs
@@ -79,7 +79,7 @@ internal class PerScopeStateVisitorDecorator : VBasic.VisualBasicSyntaxVisitor<T
     public override Task<SyntaxList<StatementSyntax>> VisitThrowStatement(VBSyntax.ThrowStatementSyntax node) => AddLocalVariablesAsync(node);
     public override Task<SyntaxList<StatementSyntax>> VisitTryBlock(VBSyntax.TryBlockSyntax node)
     {
-        var isExited = node.DescendantNodes(n => n == node || n is not VBSyntax.TryBlockSyntax).OfType<VBSyntax.ExitStatementSyntax>().Any(e => VBasic.VisualBasicExtensions.Kind(e.BlockKeyword) == VBasic.SyntaxKind.TryKeyword);
+        var isExited = node.DescendantNodes(n => n == node || n is not VBSyntax.TryBlockSyntax).OfType<VBSyntax.ExitStatementSyntax>().Any(e => e.BlockKeyword.IsKind(VBasic.SyntaxKind.TryKeyword));
         return AddLocalVariablesAsync(node, VBasic.SyntaxKind.TryKeyword, isExited);
     }
 

--- a/CodeConverter/CSharp/ProjectMergedDeclarationExtensions.cs
+++ b/CodeConverter/CSharp/ProjectMergedDeclarationExtensions.cs
@@ -164,7 +164,7 @@ End Namespace";
         for (var symbolToRename = await GetElementToRename(project); symbolToRename != null; symbolToRename = await GetElementToRename(project, toSkip)) {
             string newName = symbolToRename.Name.Replace(oldNamePrefix, newNamePrefix);
             try {
-                var renamedSolution = await Renamer.RenameSymbolAsync(project.Solution, symbolToRename, newName, project.Solution.Workspace.Options, cancellationToken);
+                var renamedSolution = await Renamer.RenameSymbolAsync(project.Solution, symbolToRename, new SymbolRenameOptions(), newName, cancellationToken);
                 project = renamedSolution.GetProject(project.Id);
             } catch (Exception e) {
                 toSkip++;

--- a/CodeConverter/CSharp/ProjectMergedDeclarationExtensions.cs
+++ b/CodeConverter/CSharp/ProjectMergedDeclarationExtensions.cs
@@ -164,7 +164,7 @@ End Namespace";
         for (var symbolToRename = await GetElementToRename(project); symbolToRename != null; symbolToRename = await GetElementToRename(project, toSkip)) {
             string newName = symbolToRename.Name.Replace(oldNamePrefix, newNamePrefix);
             try {
-                var renamedSolution = await Renamer.RenameSymbolAsync(project.Solution, symbolToRename, new SymbolRenameOptions(), newName, cancellationToken);
+                var renamedSolution = await Renamer.RenameSymbolAsync(project.Solution, symbolToRename, newName, project.Solution.Workspace.Options, cancellationToken);
                 project = renamedSolution.GetProject(project.Id);
             } catch (Exception e) {
                 toSkip++;

--- a/CodeConverter/CSharp/VBToCSConversion.cs
+++ b/CodeConverter/CSharp/VBToCSConversion.cs
@@ -161,7 +161,7 @@ public class VBToCSConversion : ILanguageConversion
     private static bool IsNonTypeEndBlock(SyntaxNode node)
     {
         return node is VBSyntax.EndBlockStatementSyntax ebs &&
-               !ebs.BlockKeyword.IsKind(SyntaxKind.ClassKeyword, SyntaxKind.StructureKeyword, SyntaxKind.InterfaceKeyword, SyntaxKind.ModuleKeyword);
+               !ebs.BlockKeyword.IsKind(SyntaxKind.ClassKeyword, SyntaxKind.StructureKeyword) && !ebs.BlockKeyword.IsKind(SyntaxKind.InterfaceKeyword, SyntaxKind.ModuleKeyword);
     }
 
     public bool MustBeContainedByClass(SyntaxNode node)

--- a/CodeConverter/CSharp/VbMethodSyntaxExtensions.cs
+++ b/CodeConverter/CSharp/VbMethodSyntaxExtensions.cs
@@ -18,7 +18,7 @@ internal static class VbMethodSyntaxExtensions
 
     public static bool HasModifier(this VBSyntax.MethodBaseSyntax d, VBasic.SyntaxKind modifierKind)
     {
-        return d.Modifiers.Any(m => SyntaxTokenExtensions.IsKind(m, modifierKind));
+        return d.Modifiers.Any(m => m.IsKind(modifierKind));
     }
 
     private static VBSyntax.MethodBaseSyntax GetMethodBlock(VBSyntax.MethodBlockBaseSyntax node)

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -31,28 +31,28 @@
     <EmbeddedResource Include="Common\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
-    <PackageReference Include="Nullable" Version="1.3.0">
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
+    <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0">
+    <PackageReference Include="System.IO.Abstractions" Version="19.1.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <!-- The InternalVisibleTo fails when building with signing -->
   <ItemGroup Condition="'$(SignAssembly)'=='True'">

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -49,7 +49,7 @@
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
     <PackageReference Include="System.IO.Abstractions" Version="19.1.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0">
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
     <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -31,28 +31,28 @@
     <EmbeddedResource Include="Common\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
-    <PackageReference Include="Nullable" Version="1.3.1">
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.1.1" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0">
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
   <!-- The InternalVisibleTo fails when building with signing -->
   <ItemGroup Condition="'$(SignAssembly)'=='True'">

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -31,28 +31,28 @@
     <EmbeddedResource Include="Common\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
-    <PackageReference Include="Nullable" Version="1.3.0">
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="17.2.41" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Globalization.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.33" />
-    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="5.0.0">
+    <PackageReference Include="System.IO.Abstractions" Version="19.1.1" />
+    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="7.0.0">
       <IncludeAssets>all</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <!-- The InternalVisibleTo fails when building with signing -->
   <ItemGroup Condition="'$(SignAssembly)'=='True'">

--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -31,8 +31,8 @@
     <EmbeddedResource Include="Common\DefaultReferences.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/CodeConverter/Common/SymbolRenamer.cs
+++ b/CodeConverter/Common/SymbolRenamer.cs
@@ -33,7 +33,7 @@ internal static class SymbolRenamer
             ISymbol currentDeclaration = SymbolFinder.FindSimilarSymbols(originalSymbol, compilation).FirstOrDefault();
             if (currentDeclaration == null)
                 continue; //Must have already renamed this symbol for a different reason
-            solution = await Renamer.RenameSymbolAsync(solution, currentDeclaration, new SymbolRenameOptions(), newName);
+            solution = await Renamer.RenameSymbolAsync(solution, currentDeclaration, newName, solution.Workspace.Options);
         }
 
         return solution.GetProject(project.Id);

--- a/CodeConverter/Common/SymbolRenamer.cs
+++ b/CodeConverter/Common/SymbolRenamer.cs
@@ -33,7 +33,7 @@ internal static class SymbolRenamer
             ISymbol currentDeclaration = SymbolFinder.FindSimilarSymbols(originalSymbol, compilation).FirstOrDefault();
             if (currentDeclaration == null)
                 continue; //Must have already renamed this symbol for a different reason
-            solution = await Renamer.RenameSymbolAsync(solution, currentDeclaration, newName, solution.Workspace.Options);
+            solution = await Renamer.RenameSymbolAsync(solution, currentDeclaration, new SymbolRenameOptions(), newName);
         }
 
         return solution.GetProject(project.Id);

--- a/CodeConverter/Util/SyntaxTokenExtensions.cs
+++ b/CodeConverter/Util/SyntaxTokenExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using VisualBasicExtensions = Microsoft.CodeAnalysis.VisualBasic.VisualBasicExtensions;
 
@@ -17,7 +18,7 @@ internal static class SyntaxTokenExtensions
 
     public static bool IsKindOrHasMatchingText(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind)
     {
-        return VisualBasicExtensions.Kind(token) == kind || token.HasMatchingText(kind);
+        return token.IsKind(kind) || token.HasMatchingText(kind);
     }
 
     public static bool HasMatchingText(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind)
@@ -27,43 +28,27 @@ internal static class SyntaxTokenExtensions
 
     public static bool IsKind(this SyntaxToken token, SyntaxKind kind1, SyntaxKind kind2)
     {
-        return token.Kind() == kind1
-               || token.Kind() == kind2;
+        return token.IsKind(kind1) || token.IsKind(kind2);
     }
 
     public static bool IsKind(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind1, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind2)
     {
-        return VisualBasicExtensions.Kind(token) == kind1
-               || VisualBasicExtensions.Kind(token) == kind2;
+        return token.IsKind(kind1) || token.IsKind(kind2);
     }
 
     public static bool IsKind(this SyntaxToken token, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3)
     {
-        return token.Kind() == kind1
-               || token.Kind() == kind2
-               || token.Kind() == kind3;
+        return token.IsKind(kind1) || token.IsKind(kind2) || token.IsKind(kind3);
     }
 
     public static bool IsKind(this SyntaxToken token, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind1, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind2, Microsoft.CodeAnalysis.VisualBasic.SyntaxKind kind3)
     {
-        return VisualBasicExtensions.Kind(token) == kind1
-               || VisualBasicExtensions.Kind(token) == kind2
-               || VisualBasicExtensions.Kind(token) == kind3;
-    }
-
-    public static bool IsKind(this SyntaxToken token, params SyntaxKind[] kinds)
-    {
-        return kinds.Contains(token.Kind());
-    }
-
-    public static bool IsKind(this SyntaxToken token, params Microsoft.CodeAnalysis.VisualBasic.SyntaxKind[] kinds)
-    {
-        return kinds.Contains(VisualBasicExtensions.Kind(token));
+        return token.IsKind(kind1) || token.IsKind(kind2) || token.IsKind(kind3);
     }
 
     public static bool IsVbVisibility(this SyntaxToken token, bool isVariableOrConst, bool isConstructor)
     {
-        return token.IsKind(VBasic.SyntaxKind.PublicKeyword, VBasic.SyntaxKind.FriendKeyword, VBasic.SyntaxKind.ProtectedKeyword, VBasic.SyntaxKind.PrivateKeyword)
+        return token.IsKind(VBasic.SyntaxKind.PublicKeyword, VBasic.SyntaxKind.FriendKeyword, VBasic.SyntaxKind.ProtectedKeyword) || token.IsKind(VBasic.SyntaxKind.PrivateKeyword)
                || isVariableOrConst && token.IsKind(VBasic.SyntaxKind.ConstKeyword)
                || isConstructor && token.IsKind(VBasic.SyntaxKind.SharedKeyword);
     }
@@ -77,7 +62,7 @@ internal static class SyntaxTokenExtensions
 
     public static bool IsCsMemberVisibility(this SyntaxToken token)
     {
-        return token.IsKind(SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.PrivateKeyword);
+        return token.IsKind(SyntaxKind.PublicKeyword, SyntaxKind.InternalKeyword, SyntaxKind.ProtectedKeyword) || token.IsKind(SyntaxKind.PrivateKeyword);
     }
 
     public static SyntaxToken WithSourceMappingFrom(this SyntaxToken converted, SyntaxNodeOrToken fromToken)

--- a/CodeConverter/Util/SyntaxTriviaExtensions.cs
+++ b/CodeConverter/Util/SyntaxTriviaExtensions.cs
@@ -45,7 +45,7 @@ internal static class SyntaxTriviaExtensions
             }
 
             return commentText.TrimStart(null);
-        } else if (CS.CSharpExtensions.Kind(trivia) == CS.SyntaxKind.MultiLineCommentTrivia) {
+        } else if (trivia.IsKind(CS.SyntaxKind.MultiLineCommentTrivia)) {
             var textBuilder = new StringBuilder();
 
             if (commentText.EndsWith("*/", StringComparison.InvariantCulture)) {
@@ -66,7 +66,7 @@ internal static class SyntaxTriviaExtensions
 
             // remove trailing line breaks
             return textBuilder.ToString().TrimEnd();
-        } else if (trivia.IsKind(VBasic.SyntaxKind.DocumentationCommentTrivia) || CS.CSharpExtensions.Kind(trivia) == CS.SyntaxKind.SingleLineDocumentationCommentTrivia) {
+        } else if (trivia.IsKind(VBasic.SyntaxKind.DocumentationCommentTrivia) || trivia.IsKind(CS.SyntaxKind.SingleLineDocumentationCommentTrivia)) {
             var textBuilder = new StringBuilder();
 
             var lines = commentText.Replace("\r\n", "\n").Split('\n');

--- a/CodeConverter/VB/CommonConversions.cs
+++ b/CodeConverter/VB/CommonConversions.cs
@@ -22,6 +22,7 @@ using VariableDeclaratorSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.Varia
 using YieldStatementSyntax = Microsoft.CodeAnalysis.VisualBasic.Syntax.YieldStatementSyntax;
 using ICSharpCode.CodeConverter.CSharp;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
+using System.Linq;
 
 namespace ICSharpCode.CodeConverter.VB;
 
@@ -556,7 +557,7 @@ internal class CommonConversions
             return true;
 
         // List of the kinds that end in declaration and can have names attached
-        return id.IsKind(CSSyntaxKind.CatchDeclaration,
+        var syntaxKinds = new[]{CSSyntaxKind.CatchDeclaration,
             CSSyntaxKind.ClassDeclaration,
             CSSyntaxKind.DelegateDeclaration,
             CSSyntaxKind.EnumDeclaration,
@@ -569,7 +570,8 @@ internal class CommonConversions
             CSSyntaxKind.PropertyDeclaration,
             CSSyntaxKind.NamespaceDeclaration,
             CSSyntaxKind.StructDeclaration,
-            CSSyntaxKind.VariableDeclaration);
+            CSSyntaxKind.VariableDeclaration};
+        return syntaxKinds.Any(x => id.IsKind(x));
     }
 
 

--- a/CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/VB/MethodBodyExecutableStatementVisitor.cs
@@ -328,7 +328,7 @@ internal class MethodBodyExecutableStatementVisitor : CS.CSharpSyntaxVisitor<Syn
         if (stepExpression == null || !(stepExpression.Token.Value is int))
             return false;
         int step = (int)stepExpression.Token.Value;
-        if (SyntaxTokenExtensions.IsKind(iterator.OperatorToken, SyntaxKind.MinusEqualsToken))
+        if (iterator.OperatorToken.IsKind(SyntaxKind.MinusEqualsToken))
             step = -step;
 
         var condition = node.Condition as CSSyntax.BinaryExpressionSyntax;
@@ -467,7 +467,7 @@ internal class MethodBodyExecutableStatementVisitor : CS.CSharpSyntaxVisitor<Syn
             simpleTypeName = type.ToString();
         return SyntaxFactory.CatchBlock(
             SyntaxFactory.CatchStatement(
-                SyntaxFactory.IdentifierName(SyntaxTokenExtensions.IsKind(catchClause.Declaration.Identifier, CS.SyntaxKind.None) ? SyntaxFactory.Identifier($"__unused{simpleTypeName}{index + 1}__") : _commonConversions.ConvertIdentifier(catchClause.Declaration.Identifier)),
+                SyntaxFactory.IdentifierName(catchClause.Declaration.Identifier.IsKind(CS.SyntaxKind.None) ? SyntaxFactory.Identifier($"__unused{simpleTypeName}{index + 1}__") : _commonConversions.ConvertIdentifier(catchClause.Declaration.Identifier)),
                 SyntaxFactory.SimpleAsClause(type),
                 catchClause.Filter == null ? null : SyntaxFactory.CatchFilterClause((ExpressionSyntax)catchClause.Filter.FilterExpression.Accept(_nodesVisitor))
             ), statements

--- a/CodeConverter/VB/NodesVisitor.cs
+++ b/CodeConverter/VB/NodesVisitor.cs
@@ -505,7 +505,7 @@ internal class NodesVisitor : CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode>
     {
         var id = _commonConversions.ConvertIdentifier(node.ThisKeyword);
         var modifiers = CommonConversions.ConvertModifiers(node.Modifiers, GetMemberContext(node));
-        if (modifiers.Any(x => x.Kind() == SyntaxKind.PrivateKeyword)) {
+        if (modifiers.Any(x => x.IsKind(SyntaxKind.PrivateKeyword))) {
         } else {
             modifiers = modifiers.Insert(0, SyntaxFactory.Token(SyntaxKind.DefaultKeyword));
         }
@@ -700,7 +700,7 @@ internal class NodesVisitor : CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode>
 
         foreach (var attrList in attributeLists) {
             var targetIdentifier = attrList.Target?.Identifier;
-            if (targetIdentifier != null && SyntaxTokenExtensions.IsKind((SyntaxToken)targetIdentifier, CS.SyntaxKind.ReturnKeyword))
+            if (targetIdentifier is {} ti && ti.IsKind(CS.SyntaxKind.ReturnKeyword))
                 retAttr.Add((AttributeListSyntax)attrList.Accept(TriviaConvertingVisitor));
             else
                 attr.Add((AttributeListSyntax)attrList.Accept(TriviaConvertingVisitor));
@@ -979,10 +979,10 @@ internal class NodesVisitor : CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode>
                         return SyntaxFactory.SimpleAssignmentStatement(left, invokeDelegateMethod);
                     }
                 } else {
-                    if (SyntaxTokenExtensions.IsKind(node.OperatorToken, CS.SyntaxKind.PlusEqualsToken)) {
+                    if (node.OperatorToken.IsKind(CS.SyntaxKind.PlusEqualsToken)) {
                         return SyntaxFactory.AddHandlerStatement(left, right);
                     }
-                    if (SyntaxTokenExtensions.IsKind(node.OperatorToken, CS.SyntaxKind.MinusEqualsToken)) {
+                    if (node.OperatorToken.IsKind(CS.SyntaxKind.MinusEqualsToken)) {
                         return SyntaxFactory.RemoveHandlerStatement(left, right);
                     }
                 }
@@ -1258,8 +1258,8 @@ internal class NodesVisitor : CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode>
         var leftType = _semanticModel.GetTypeInfo(node.Left).ConvertedType;
         var rightType = _semanticModel.GetTypeInfo(node.Right).ConvertedType;
 
-        bool isEquals = SyntaxTokenExtensions.IsKind(node.OperatorToken, CS.SyntaxKind.EqualsEqualsToken);
-        bool isNotEquals = SyntaxTokenExtensions.IsKind(node.OperatorToken, CS.SyntaxKind.ExclamationEqualsToken);
+        bool isEquals = node.OperatorToken.IsKind(CS.SyntaxKind.EqualsEqualsToken);
+        bool isNotEquals = node.OperatorToken.IsKind(CS.SyntaxKind.ExclamationEqualsToken);
 
         if (leftType.SpecialType == SpecialType.System_String && rightType.SpecialType == SpecialType.System_String && (isEquals || isNotEquals)) {
             var opEquality = SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName(nameof(Equals)), ExpressionSyntaxExtensions.CreateArgList(vbLeft, vbRight));
@@ -1673,8 +1673,8 @@ internal class NodesVisitor : CS.CSharpSyntaxVisitor<VisualBasicSyntaxNode>
     public override VisualBasicSyntaxNode VisitTypeParameter(CSSyntax.TypeParameterSyntax node)
     {
         SyntaxToken variance = default(SyntaxToken);
-        if (!SyntaxTokenExtensions.IsKind(node.VarianceKeyword, CS.SyntaxKind.None)) {
-            variance = SyntaxFactory.Token(SyntaxTokenExtensions.IsKind(node.VarianceKeyword, CS.SyntaxKind.InKeyword) ? SyntaxKind.InKeyword : SyntaxKind.OutKeyword);
+        if (!node.VarianceKeyword.IsKind(CS.SyntaxKind.None)) {
+            variance = SyntaxFactory.Token(node.VarianceKeyword.IsKind(CS.SyntaxKind.InKeyword) ? SyntaxKind.InKeyword : SyntaxKind.OutKeyword);
         }
         // copy generic constraints
         var clause = FindClauseForParameter(node);

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -10,18 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.11.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="5.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
     <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -10,19 +10,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="5.4.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -12,9 +12,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
     <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NuGet.Build.Tasks" Version="5.4.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />

--- a/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
+++ b/CommandLine/CodeConv.NetFramework/CodeConv.NetFramework.csproj
@@ -10,18 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="5.4.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv.Shared/MSBuildWorkspaceConverter.cs
+++ b/CommandLine/CodeConv.Shared/MSBuildWorkspaceConverter.cs
@@ -30,7 +30,7 @@ public sealed class MSBuildWorkspaceConverter : IDisposable
     private readonly AsyncLazy<MSBuildWorkspace> _workspace; //Cached to avoid NullRef from OptionsService when initialized concurrently (e.g. in our tests)
     private AsyncLazy<Solution>? _cachedSolution; //Cached for performance of tests
     private readonly bool _isNetCore;
-    private Version _versionUsed;
+    private Version? _versionUsed;
 
     public MSBuildWorkspaceConverter(string solutionFilePath, bool isNetCore, JoinableTaskFactory joinableTaskFactory, bool bestEffortConversion = false, Dictionary<string, string>? buildProps = null)
     {
@@ -94,7 +94,10 @@ public sealed class MSBuildWorkspaceConverter : IDisposable
         }
         return solution;
 
-        static ValidationException CreateException(string mainMessage, string fullDetail) => new ValidationException($"{mainMessage}:{Environment.NewLine}Used MSBuild {_versionUsed}.{Environment.NewLine}{fullDetail}{Environment.NewLine}{mainMessage}");
+        ValidationException CreateException(string mainMessage, string fullDetail) {
+            var versionUsedString = _versionUsed != null ? $"Used MSBuild {_versionUsed}.{Environment.NewLine}" : "";
+            return new ValidationException($"{mainMessage}:{Environment.NewLine}{versionUsedString}{fullDetail}{Environment.NewLine}{mainMessage}");
+        }
     }
 
     private async Task<string> GetCompilationErrorsAsync(
@@ -115,16 +118,17 @@ public sealed class MSBuildWorkspaceConverter : IDisposable
         if (restoreExitCode != 0) throw new ValidationException("dotnet restore had a non-zero exit code.");
     }
 
-    private static async Task<MSBuildWorkspace> CreateWorkspaceAsync(Dictionary<string, string> buildProps)
+    private async Task<MSBuildWorkspace> CreateWorkspaceAsync(Dictionary<string, string> buildProps)
     {
         if (MSBuildLocator.CanRegister) {
             var instances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
             var instance = instances.OrderByDescending(x => x.Version).FirstOrDefault()
                            ?? throw new ValidationException("No Visual Studio instance available");
             MSBuildLocator.RegisterInstance(instance);
-            _instanceUsed = instance.Version;
+            _versionUsed = instance.Version;
             AppDomain.CurrentDomain.UseVersionAgnosticAssemblyResolution();
         }
+
         var hostServices = await ThreadSafeWorkspaceHelper.CreateHostServicesAsync(MSBuildMefHostServices.DefaultAssemblies);
         return MSBuildWorkspace.Create(buildProps, hostServices);
     }

--- a/CommandLine/CodeConv.Shared/Util/ProcessRunner.cs
+++ b/CommandLine/CodeConv.Shared/Util/ProcessRunner.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace ICSharpCode.CodeConverter.DotNetTool.Util;
 
-internal static class ProcessRunner
+public static class ProcessRunner
 {
 
     public static Task<int> ConnectConsoleGetExitCodeAsync(string command, params string[] args) =>

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -43,6 +43,7 @@ For a nugetted dll, web converter or visual studio extension, see https://github
     <PackageReference Include="System.CodeDom" Version="6.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -28,25 +28,25 @@ For a nugetted dll, web converter or visual studio extension, see https://github
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="6.1.0" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
     <PackageReference Include="System.CodeDom" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -28,24 +28,24 @@ For a nugetted dll, web converter or visual studio extension, see https://github
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="6.1.0" />
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
+    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -28,24 +28,24 @@ For a nugetted dll, web converter or visual studio extension, see https://github
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.10.56" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
+    <PackageReference Include="NuGet.Build.Tasks" Version="6.1.0" />
     <PackageReference Include="System.CodeDom" Version="6.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -28,7 +28,7 @@ For a nugetted dll, web converter or visual studio extension, see https://github
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
@@ -37,11 +37,11 @@ For a nugetted dll, web converter or visual studio extension, see https://github
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.4.27" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.2.32" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="NuGet.Build.Tasks" Version="6.4.0" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
 

--- a/CommandLine/CodeConv/CodeConv.csproj
+++ b/CommandLine/CodeConv/CodeConv.csproj
@@ -30,9 +30,9 @@ For a nugetted dll, web converter or visual studio extension, see https://github
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeConverter\CodeConverter.csproj" />

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -17,11 +17,11 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeConverter\CodeConverter.csproj" />

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeConverter\CodeConverter.csproj" />

--- a/Func/Func.csproj
+++ b/Func/Func.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeConverter\CodeConverter.csproj" />

--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -116,32 +116,34 @@ internal partial class TestClass
     {
         var catalog = new XDocument(
 new XElement(""Catalog"",
-    new XElement(""Book"", new XAttribute(""id"", ""bk101""),
-        new XElement(""Author"", ""Garghentini, Davide""),
-        new XElement(""Title"", ""XML Developer's Guide""),
-        new XElement(""Price"", ""44.95""),
-        new XElement(""Description"", ""\r\n          An in-depth look at creating applications\r\n          with "", new XElement(""technology"", ""XML""), "". For\r\n          "", new XElement(""audience"", ""beginners""), "" or\r\n          "", new XElement(""audience"", ""advanced""), "" developers.\r\n        "")
-    ),
-    new XElement(""Book"", new XAttribute(""id"", ""bk331""),
-        new XElement(""Author"", ""Spencer, Phil""),
-        new XElement(""Title"", ""Developing Applications with Visual Basic .NET""),
-        new XElement(""Price"", ""45.95""),
-        new XElement(""Description"", ""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with "", new XElement(""technology"", ""Visual\r\n          Basic .NET""), "".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top "", new XElement(""audience"", ""developers""), "".\r\n        "")
-    )
+new XElement(""Book"", new XAttribute(""id"", ""bk101""),
+new XElement(""Author"", ""Garghentini, Davide""),
+new XElement(""Title"", ""XML Developer's Guide""),
+new XElement(""Price"", ""44.95""),
+new XElement(""Description"", ""\r\n          An in-depth look at creating applications\r\n          with "", new XElement(""technology"", ""XML""), "". For\r\n          "", new XElement(""audience"", ""beginners""), "" or\r\n          "", new XElement(""audience"", ""advanced""), "" developers.\r\n        "")
+),
+new XElement(""Book"", new XAttribute(""id"", ""bk331""),
+new XElement(""Author"", ""Spencer, Phil""),
+new XElement(""Title"", ""Developing Applications with Visual Basic .NET""),
+new XElement(""Price"", ""45.95""),
+new XElement(""Description"", ""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with "", new XElement(""technology"", ""Visual\r\n          Basic .NET""), "".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top "", new XElement(""audience"", ""developers""), "".\r\n        "")
+)
 )
 
 );
         var htmlOutput = new XElement(""html"",
+
                   new XElement(""body"", from book in catalog.Elements(""Catalog"").Elements(""Book"")
                                        select new XElement(""div"",
-                                                  new XElement(""h1"", book.Elements(""Title"").Value),
-                                                  new XElement(""h3"", ""By "" + book.Elements(""Author"").Value),
-                                                  new XElement(""h3"", ""Price = "" + book.Elements(""Price"").Value),
+                 new XElement(""h1"", book.Elements(""Title"").Value),
+                 new XElement(""h3"", ""By "" + book.Elements(""Author"").Value),
+                 new XElement(""h3"", ""Price = "" + book.Elements(""Price"").Value),
+
 
                                                   new XElement(""h2"", ""Description""), TransformDescription((string)book.Elements(""Description"").ElementAtOrDefault(0)), new XElement(""hr"")
-                                              )
-              )
-          );
+                 )
+                    )
+                );
     }
 
     public string TransformDescription(string s)

--- a/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/XmlExpressionTests.cs
@@ -116,34 +116,32 @@ internal partial class TestClass
     {
         var catalog = new XDocument(
 new XElement(""Catalog"",
-new XElement(""Book"", new XAttribute(""id"", ""bk101""),
-new XElement(""Author"", ""Garghentini, Davide""),
-new XElement(""Title"", ""XML Developer's Guide""),
-new XElement(""Price"", ""44.95""),
-new XElement(""Description"", ""\r\n          An in-depth look at creating applications\r\n          with "", new XElement(""technology"", ""XML""), "". For\r\n          "", new XElement(""audience"", ""beginners""), "" or\r\n          "", new XElement(""audience"", ""advanced""), "" developers.\r\n        "")
-),
-new XElement(""Book"", new XAttribute(""id"", ""bk331""),
-new XElement(""Author"", ""Spencer, Phil""),
-new XElement(""Title"", ""Developing Applications with Visual Basic .NET""),
-new XElement(""Price"", ""45.95""),
-new XElement(""Description"", ""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with "", new XElement(""technology"", ""Visual\r\n          Basic .NET""), "".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top "", new XElement(""audience"", ""developers""), "".\r\n        "")
-)
+    new XElement(""Book"", new XAttribute(""id"", ""bk101""),
+        new XElement(""Author"", ""Garghentini, Davide""),
+        new XElement(""Title"", ""XML Developer's Guide""),
+        new XElement(""Price"", ""44.95""),
+        new XElement(""Description"", ""\r\n          An in-depth look at creating applications\r\n          with "", new XElement(""technology"", ""XML""), "". For\r\n          "", new XElement(""audience"", ""beginners""), "" or\r\n          "", new XElement(""audience"", ""advanced""), "" developers.\r\n        "")
+    ),
+    new XElement(""Book"", new XAttribute(""id"", ""bk331""),
+        new XElement(""Author"", ""Spencer, Phil""),
+        new XElement(""Title"", ""Developing Applications with Visual Basic .NET""),
+        new XElement(""Price"", ""45.95""),
+        new XElement(""Description"", ""\r\n          Get the expert insights, practical code samples,\r\n          and best practices you need\r\n          to advance your expertise with "", new XElement(""technology"", ""Visual\r\n          Basic .NET""), "".\r\n          Learn how to create faster, more reliable applications\r\n          based on professional,\r\n          pragmatic guidance by today's top "", new XElement(""audience"", ""developers""), "".\r\n        "")
+    )
 )
 
 );
         var htmlOutput = new XElement(""html"",
-
                   new XElement(""body"", from book in catalog.Elements(""Catalog"").Elements(""Book"")
                                        select new XElement(""div"",
-                 new XElement(""h1"", book.Elements(""Title"").Value),
-                 new XElement(""h3"", ""By "" + book.Elements(""Author"").Value),
-                 new XElement(""h3"", ""Price = "" + book.Elements(""Price"").Value),
-
+                                                  new XElement(""h1"", book.Elements(""Title"").Value),
+                                                  new XElement(""h3"", ""By "" + book.Elements(""Author"").Value),
+                                                  new XElement(""h3"", ""Price = "" + book.Elements(""Price"").Value),
 
                                                   new XElement(""h2"", ""Description""), TransformDescription((string)book.Elements(""Description"").ElementAtOrDefault(0)), new XElement(""hr"")
-                 )
-                    )
-                );
+                                              )
+              )
+          );
     }
 
     public string TransformDescription(string s)

--- a/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
+++ b/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
@@ -18,14 +18,14 @@ public class MultiFileSolutionAndProjectTests
         _multiFileTestFixture = multiFileTestFixture;
     }
 
-    [Fact] /* enable for executing locally */
+    //[Fact] /* enable for executing locally */
     public async Task ConvertWholeSolutionAsync()
     {
 
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => true, Language.CS);
     }
 
-    [Fact] /* enable for executing locally */
+    //[Fact] /* enable for executing locally */
     public async Task ConvertVbLibraryOnlyAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => p.Name == "VbLibrary", Language.CS);

--- a/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
+++ b/Tests/CSharp/MultiFileSolutionAndProjectTests.cs
@@ -18,14 +18,14 @@ public class MultiFileSolutionAndProjectTests
         _multiFileTestFixture = multiFileTestFixture;
     }
 
-    //[Fact] /* enable for executing locally */
+    [Fact] /* enable for executing locally */
     public async Task ConvertWholeSolutionAsync()
     {
 
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => true, Language.CS);
     }
 
-    //[Fact] /* enable for executing locally */
+    [Fact] /* enable for executing locally */
     public async Task ConvertVbLibraryOnlyAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => p.Name == "VbLibrary", Language.CS);

--- a/Tests/TestRunners/MultiFileTestFixture.cs
+++ b/Tests/TestRunners/MultiFileTestFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -7,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.CommandLine;
 using ICSharpCode.CodeConverter.Common;
+using ICSharpCode.CodeConverter.DotNetTool.Util;
 using Microsoft.CodeAnalysis;
 using Xunit;
 
@@ -47,22 +49,24 @@ public sealed class MultiFileTestFixture : ICollectionFixture<MultiFileTestFixtu
     {
         bool recharacterizeByWritingExpectedOverActual = TestConstants.RecharacterizeByWritingExpectedOverActual;
 
-        var results = await _msBuildWorkspaceConverter.ConvertProjectsWhereAsync(shouldConvertProject, targetLanguage, new Progress<ConversionProgress>(), default).ToArrayAsync();
-        var conversionResults = results.ToDictionary(c => c.TargetPathOrNull, StringComparer.OrdinalIgnoreCase);
         var expectedResultDirectory = GetExpectedResultDirectory(expectedResultsDirectory, targetLanguage);
+        var exePath = Path.GetFullPath("../../../CommandLine/CodeConv/bin/Debug/net6.0/ICSharpCode.CodeConverter.CodeConv.exe");
+        var out1 = await new ProcessStartInfo(exePath, McMaster.Extensions.CommandLineUtils.ArgumentEscaper.EscapeAndConcatenate(new[] {SolutionFile, "-o", expectedResultDirectory.FullName, "--force"})).GetOutputAsync();
+        //var results = await _msBuildWorkspaceConverter.ConvertProjectsWhereAsync(shouldConvertProject, targetLanguage, new Progress<ConversionProgress>(), default).ToArrayAsync();
+        //var conversionResults = results.ToDictionary(c => c.TargetPathOrNull, StringComparer.OrdinalIgnoreCase);
 
-        try {
-            if (!expectedResultDirectory.Exists) expectedResultDirectory.Create();
-            var expectedFiles = expectedResultDirectory.GetFiles("*", SearchOption.AllDirectories)
-                .Where(f => !f.FullName.Contains(@"\obj\") && !f.FullName.Contains(@"\bin\")).ToArray();
-            AssertAllExpectedFilesAreEqual(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
-            AssertAllConvertedFilesWereExpected(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
-            AssertNoConversionErrors(conversionResults);
-        } finally {
-            if (recharacterizeByWritingExpectedOverActual) {
-                await ConversionResultWriter.WriteConvertedAsync(results.ToAsyncEnumerable(), SolutionFile, expectedResultDirectory, true, WriteAllFilesForManualTesting, new Progress<string>(), default);
-            }
-        }
+        //try {
+        //    if (!expectedResultDirectory.Exists) expectedResultDirectory.Create();
+        //    var expectedFiles = expectedResultDirectory.GetFiles("*", SearchOption.AllDirectories)
+        //        .Where(f => !f.FullName.Contains(@"\obj\") && !f.FullName.Contains(@"\bin\")).ToArray();
+        //    AssertAllExpectedFilesAreEqual(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
+        //    AssertAllConvertedFilesWereExpected(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
+        //    AssertNoConversionErrors(conversionResults);
+        //} finally {
+        //    if (recharacterizeByWritingExpectedOverActual) {
+        //        await ConversionResultWriter.WriteConvertedAsync(results.ToAsyncEnumerable(), SolutionFile, expectedResultDirectory, true, WriteAllFilesForManualTesting, new Progress<string>(), default);
+        //    }
+        //}
 
         Assert.False(recharacterizeByWritingExpectedOverActual, $"Test setup issue: Set {nameof(recharacterizeByWritingExpectedOverActual)} to false after using it");
     }

--- a/Tests/TestRunners/MultiFileTestFixture.cs
+++ b/Tests/TestRunners/MultiFileTestFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -8,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 using ICSharpCode.CodeConverter.CommandLine;
 using ICSharpCode.CodeConverter.Common;
-using ICSharpCode.CodeConverter.DotNetTool.Util;
 using Microsoft.CodeAnalysis;
 using Xunit;
 
@@ -49,24 +47,22 @@ public sealed class MultiFileTestFixture : ICollectionFixture<MultiFileTestFixtu
     {
         bool recharacterizeByWritingExpectedOverActual = TestConstants.RecharacterizeByWritingExpectedOverActual;
 
+        var results = await _msBuildWorkspaceConverter.ConvertProjectsWhereAsync(shouldConvertProject, targetLanguage, new Progress<ConversionProgress>(), default).ToArrayAsync();
+        var conversionResults = results.ToDictionary(c => c.TargetPathOrNull, StringComparer.OrdinalIgnoreCase);
         var expectedResultDirectory = GetExpectedResultDirectory(expectedResultsDirectory, targetLanguage);
-        var exePath = Path.GetFullPath("../../../CommandLine/CodeConv/bin/Debug/net6.0/ICSharpCode.CodeConverter.CodeConv.exe");
-        var out1 = await new ProcessStartInfo(exePath, McMaster.Extensions.CommandLineUtils.ArgumentEscaper.EscapeAndConcatenate(new[] {SolutionFile, "-o", expectedResultDirectory.FullName, "--force"})).GetOutputAsync();
-        //var results = await _msBuildWorkspaceConverter.ConvertProjectsWhereAsync(shouldConvertProject, targetLanguage, new Progress<ConversionProgress>(), default).ToArrayAsync();
-        //var conversionResults = results.ToDictionary(c => c.TargetPathOrNull, StringComparer.OrdinalIgnoreCase);
 
-        //try {
-        //    if (!expectedResultDirectory.Exists) expectedResultDirectory.Create();
-        //    var expectedFiles = expectedResultDirectory.GetFiles("*", SearchOption.AllDirectories)
-        //        .Where(f => !f.FullName.Contains(@"\obj\") && !f.FullName.Contains(@"\bin\")).ToArray();
-        //    AssertAllExpectedFilesAreEqual(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
-        //    AssertAllConvertedFilesWereExpected(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
-        //    AssertNoConversionErrors(conversionResults);
-        //} finally {
-        //    if (recharacterizeByWritingExpectedOverActual) {
-        //        await ConversionResultWriter.WriteConvertedAsync(results.ToAsyncEnumerable(), SolutionFile, expectedResultDirectory, true, WriteAllFilesForManualTesting, new Progress<string>(), default);
-        //    }
-        //}
+        try {
+            if (!expectedResultDirectory.Exists) expectedResultDirectory.Create();
+            var expectedFiles = expectedResultDirectory.GetFiles("*", SearchOption.AllDirectories)
+                .Where(f => !f.FullName.Contains(@"\obj\") && !f.FullName.Contains(@"\bin\")).ToArray();
+            AssertAllExpectedFilesAreEqual(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
+            AssertAllConvertedFilesWereExpected(expectedFiles, conversionResults, expectedResultDirectory, OriginalSolutionDir);
+            AssertNoConversionErrors(conversionResults);
+        } finally {
+            if (recharacterizeByWritingExpectedOverActual) {
+                await ConversionResultWriter.WriteConvertedAsync(results.ToAsyncEnumerable(), SolutionFile, expectedResultDirectory, true, WriteAllFilesForManualTesting, new Progress<string>(), default);
+            }
+        }
 
         Assert.False(recharacterizeByWritingExpectedOverActual, $"Test setup issue: Set {nameof(recharacterizeByWritingExpectedOverActual)} to false after using it");
     }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,9 +9,12 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
@@ -27,12 +30,12 @@
     <ProjectReference Include="..\CommandLine\CodeConv.NetFramework\CodeConv.NetFramework.csproj" />
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements - test against latest Visual Studio version">
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,10 +30,10 @@
     <ProjectReference Include="..\CommandLine\CodeConv.NetFramework\CodeConv.NetFramework.csproj" />
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements - test against latest Visual Studio version">
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.Build" Version="17.4.0" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.4.0" />
   </ItemGroup>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,12 +9,9 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.18.3" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
@@ -30,12 +27,12 @@
     <ProjectReference Include="..\CommandLine\CodeConv.NetFramework\CodeConv.NetFramework.csproj" />
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements - test against latest Visual Studio version">
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.4.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,9 +9,12 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
@@ -27,12 +30,12 @@
     <ProjectReference Include="..\CommandLine\CodeConv.NetFramework\CodeConv.NetFramework.csproj" />
   </ItemGroup>
   <ItemGroup Label="ReSharper test runner requirements - test against latest Visual Studio version">
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.4.0" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />

--- a/Tests/VB/MultiFileSolutionAndProjectTests.cs
+++ b/Tests/VB/MultiFileSolutionAndProjectTests.cs
@@ -18,13 +18,13 @@ public class MultiFileSolutionAndProjectTests
         _multiFileTestFixture = multiFileTestFixture;
     }
 
-    //[Fact] /* enable for executing locally */
+    [Fact] /* enable for executing locally */
     public async Task ConvertWholeSolutionAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => true, Language.VB);
     }
 
-    //[Fact] /* enable for executing locally */
+    [Fact] /* enable for executing locally */
     public async Task ConvertCSharpConsoleAppOnlyAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => p.Name == "CSharpConsoleApp", Language.VB);

--- a/Tests/VB/MultiFileSolutionAndProjectTests.cs
+++ b/Tests/VB/MultiFileSolutionAndProjectTests.cs
@@ -18,13 +18,13 @@ public class MultiFileSolutionAndProjectTests
         _multiFileTestFixture = multiFileTestFixture;
     }
 
-    [Fact] /* enable for executing locally */
+    //[Fact] /* enable for executing locally */
     public async Task ConvertWholeSolutionAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => true, Language.VB);
     }
 
-    [Fact] /* enable for executing locally */
+    //[Fact] /* enable for executing locally */
     public async Task ConvertCSharpConsoleAppOnlyAsync()
     {
         await _multiFileTestFixture.ConvertProjectsWhereAsync(p => p.Name == "CSharpConsoleApp", Language.VB);

--- a/Vsix/OutputWindow.cs
+++ b/Vsix/OutputWindow.cs
@@ -55,11 +55,11 @@ internal class OutputWindow
 
     private void SignUpToSolutionOpened()
     {
+        ThreadHelper.ThrowIfNotOnUIThread();
         try {
             SignUpToSolutionOpenedPriorToVs2022();
         } catch (MissingMethodException) {
         }
-
         // When attempting to call this function, it throws an MissingMethodException in VS2022 onwards.
         // I don't know another way to get this behaviour that was available in VS2017, so we'll forego this until we can drop VS2017 support and use a more recent interface
         void SignUpToSolutionOpenedPriorToVs2022() => _solutionEvents.Opened += () => OnSolutionOpenedAsync().Forget();

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -50,13 +50,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Build against VS 16.10 -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <!-- Build against VS 17.2+ API -->
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.32505.173" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -51,12 +51,12 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Build against VS 16.10 -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.4.33103.184" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -50,9 +50,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Build against VS 16.10 -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.4.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.4.33103.184" ExcludeAssets="runtime">
+    <!-- Build against VS 17.2+ API -->
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.2.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.32505.173" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->

--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -50,13 +50,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Build against VS 17.2+ API -->
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.32505.173" ExcludeAssets="runtime">
+    <!-- Build against VS 16.10 -->
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.11.0" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.10.31321.278" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2119">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -13,10 +13,7 @@
         <Tags>code converter vb csharp visual basic csharp net translate</Tags>
     </Metadata>
     <Installation>
-      <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community">
-        <ProductArchitecture>x86</ProductArchitecture>
-      </InstallationTarget>
-      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+      <InstallationTarget Version="[17.2,18.0)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>amd64</ProductArchitecture>
       </InstallationTarget>
     </Installation>
@@ -28,6 +25,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.2,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -13,7 +13,10 @@
         <Tags>code converter vb csharp visual basic csharp net translate</Tags>
     </Metadata>
     <Installation>
-      <InstallationTarget Version="[17.2,18.0)" Id="Microsoft.VisualStudio.Community">
+      <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>x86</ProductArchitecture>
+      </InstallationTarget>
+      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>amd64</ProductArchitecture>
       </InstallationTarget>
     </Installation>
@@ -25,6 +28,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.2,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 

--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestMinor"
-  }
-}


### PR DESCRIPTION
Needed codeanalysis >3.11 to avoid https://github.com/dotnet/msbuild/issues/7873
Needed codeanalysis< 4.3 to avoid https://github.com/dotnet/roslyn/issues/63780

Current (working) solution here just sets the minimum version to VS2022 17.2.
It's been available since May 17, 2022, hopefully this won't be too disruptive to most people.

I found another way by forcing a later version of the system memory library. VS2019 support survives...for now.

