### PR TITLE
Issue/982

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### VB -> C#
 
+* Simplify converted expressions involving nullable value types [#982](https://github.com/icsharpcode/CodeConverter/issues/982)
+
 
 ### C# -> VB
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -52,7 +52,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         _visualBasicEqualityComparison = new VisualBasicEqualityComparison(_semanticModel, _extraUsingDirectives);
         TriviaConvertingDeclarationVisitor = new CommentConvertingVisitorWrapper(this, _semanticModel.SyntaxTree);
         var expressionEvaluator = new ExpressionEvaluator(semanticModel, _visualBasicEqualityComparison);
-        var nullableExpressionsConverter = new VisualBasicNullableExpressionsConverter();
+        var nullableExpressionsConverter = new VisualBasicNullableExpressionsConverter(_semanticModel);
         var typeConversionAnalyzer = new TypeConversionAnalyzer(semanticModel, csCompilation, _extraUsingDirectives, _csSyntaxGenerator, expressionEvaluator, nullableExpressionsConverter);
         CommonConversions = new CommonConversions(document, semanticModel, typeConversionAnalyzer, csSyntaxGenerator, compilation, csCompilation, _typeContext, _visualBasicEqualityComparison);
         var expressionNodeVisitor = new ExpressionNodeVisitor(semanticModel, _visualBasicEqualityComparison, _typeContext, CommonConversions, _extraUsingDirectives, _xmlImportContext, nullableExpressionsConverter);

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -897,8 +897,10 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
                 return _visualBasicEqualityComparison.GetFullExpressionForVbObjectComparison(lhs, rhs, node.IsKind(VBasic.SyntaxKind.NotEqualsExpression));
         }
 
-        omitConversion |= lhsTypeInfo.Type != null && rhsTypeInfo.Type != null &&
-                          lhsTypeInfo.Type.IsEnumType() && SymbolEqualityComparer.IncludeNullability.Equals(lhsTypeInfo.Type, rhsTypeInfo.Type)
+        var lhsTypeIgnoringNullable = lhsTypeInfo.Type.GetNullableUnderlyingType() ?? lhsTypeInfo.Type;
+        var rhsTypeIgnoringNullable = rhsTypeInfo.Type.GetNullableUnderlyingType() ?? rhsTypeInfo.Type;
+        omitConversion |= lhsTypeIgnoringNullable != null && rhsTypeIgnoringNullable != null &&
+                          lhsTypeIgnoringNullable.IsEnumType() && SymbolEqualityComparer.Default.Equals(lhsTypeIgnoringNullable, rhsTypeIgnoringNullable)
                           && !node.IsKind(VBasic.SyntaxKind.AddExpression, VBasic.SyntaxKind.SubtractExpression, VBasic.SyntaxKind.MultiplyExpression, VBasic.SyntaxKind.DivideExpression, VBasic.SyntaxKind.IntegerDivideExpression, VBasic.SyntaxKind.ModuloExpression)
                           && forceLhsTargetType == null;
         lhs = omitConversion ? lhs : CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Left, lhs, forceTargetType: forceLhsTargetType);

--- a/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
+++ b/CodeConverter/CSharp/VisualBasicNullableExpressionsConverter.cs
@@ -252,8 +252,8 @@ internal class VisualBasicNullableExpressionsConverter
                 }
 
                 if (op.IsKind(VBasic.SyntaxKind.OrElseKeyword)) {
-                    // Look inside right knowing it'd be false if we evaluate the right
-                    if (GetNullabilityWithinBooleanExpression(nameText, r, false) is { } knownNullability) {
+                    // Look inside left knowing it'd be false if we evaluate the right
+                    if (GetNullabilityWithinBooleanExpression(nameText, l, false) is { } knownNullability) {
                         return knownNullability;
                     }
                 }

--- a/CodeConverter/Util/SyntaxExtensions.cs
+++ b/CodeConverter/Util/SyntaxExtensions.cs
@@ -11,6 +11,15 @@ internal static class SyntaxExtensions
         }
         return expression;
     }
+    public static bool AnyInParens(this CS.Syntax.ExpressionSyntax expression, Func<CS.Syntax.ExpressionSyntax, bool> predicate)
+    {
+        if (expression == null) return false;
+        while (true) {
+            if (predicate(expression)) return true;
+            if (expression is not CS.Syntax.ParenthesizedExpressionSyntax pes) return false;
+            expression = pes.Expression;
+        }
+    }
 
     public static VBSyntax.ExpressionSyntax SkipIntoParens(this VBSyntax.ExpressionSyntax expression)
     {

--- a/CodeConverter/Util/TypeExtensions.cs
+++ b/CodeConverter/Util/TypeExtensions.cs
@@ -21,8 +21,7 @@ internal static class TypeExtensions
 
     public static bool IsNullableType(this ITypeSymbol type)
     {
-        var original = type.OriginalDefinition;
-        return original.SpecialType == SpecialType.System_Nullable_T;
+        return type?.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T;
     }
 
     public static ITypeSymbol GetNullableUnderlyingType(this ITypeSymbol type)

--- a/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
@@ -397,6 +397,29 @@ internal partial class TestClass
         }
 
         [Fact]
+        public async Task NullableFlowStateOptimizationAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod(newDays As Integer?, oldDays As Integer?)
+        If newDays.HasValue AndAlso oldDays.HasValue AndAlso newDays <> oldDays Then
+            Console.Write(1)
+        End If
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod(int? newDays, int? oldDays)
+    {
+        if (newDays.HasValue && oldDays.HasValue && newDays != oldDays)
+        {
+            Console.Write(1);
+        }
+    }
+}");
+        }
+
+        [Fact]
         public async Task RelationalOperatorsOnNullableTypeInConditionAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(@"Class TestClass

--- a/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/BinaryExpressionTests.cs
@@ -453,7 +453,7 @@ private bool TestMethod(int? newDays, int? oldDays)
     }
 
         [Fact]
-        public async Task CharacterizeDoesNotCurrentlySimplifyComparisonWhenNullableChecksAreUncertainAsync()
+        public async Task DoesNotSimplifyComparisonWhenNullableChecksAreUncertainAsync()
         {
             await TestConversionVisualBasicToCSharpAsync(@"
 Private Function TestMethod(newDays As Integer?, oldDays As Integer?) As Boolean
@@ -463,6 +463,66 @@ End Function
 private bool TestMethod(int? newDays, int? oldDays)
 {
     return (bool)(newDays.HasValue || oldDays.HasValue ? newDays.HasValue && oldDays.HasValue ? newDays != oldDays : null : (bool?)false);
+}");
+        }
+
+        [Fact]
+        public async Task SimplifiesNullableEnumIfEqualityCheckAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"
+Public Enum PasswordStatus
+    Expired
+    Locked    
+End Enum
+Public Class TestForEnums
+    Public Shared Sub WriteStatus(status As PasswordStatus?)
+      If status = PasswordStatus.Locked Then
+          Console.Write(""Locked"")
+      End If
+    End Sub
+End Class
+", @"using System;
+
+public enum PasswordStatus
+{
+    Expired,
+    Locked
+}
+
+public partial class TestForEnums
+{
+    public static void WriteStatus(PasswordStatus? status)
+    {
+        if (status.HasValue && status == PasswordStatus.Locked)
+        {
+            Console.Write(""Locked"");
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public async Task SimplifiesNullableDateIfEqualityCheckAsync()
+        {
+            await TestConversionVisualBasicToCSharpAsync(@"
+Public Class TestForDates
+    Public Shared Sub WriteStatus(adminDate As DateTime?, chartingTimeAllowanceEnd As DateTime)
+        If adminDate Is Nothing OrElse adminDate > chartingTimeAllowanceEnd Then
+            adminDate = DateTime.Now
+        End If
+    End Sub
+End Class
+", @"using System;
+
+public partial class TestForDates
+{
+    public static void WriteStatus(DateTime? adminDate, DateTime chartingTimeAllowanceEnd)
+    {
+        if (adminDate is null || adminDate > chartingTimeAllowanceEnd)
+        {
+            adminDate = DateTime.Now;
+        }
+    }
 }");
         }
 


### PR DESCRIPTION
Try to cover some common cases mentioned in #982

It's a tricky area since I don't want to change the number of evaluations of any expression involved that may have side effects
There are a lot more cases which could be tidied up, see https://github.com/icsharpcode/CodeConverter/issues/982#issuecomment-1407665870 but I think I'll merge just these first steps for now

I've only applied improvements to relational operators. It's likely the same patterns (checking for reusable expressions and using flow analysis) could be applied to the special-cased OrElse and AndAlso cases in future. It's just a case of finding time to do it.