### PR TITLE
Enable arm64 vsix

### DIFF
--- a/Vsix/Vsix.csproj
+++ b/Vsix/Vsix.csproj
@@ -56,7 +56,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <!-- Avoids needing the VSSDK MSI installed. Version is the VS version used during compilation, not where the VSIX will be installed -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4065">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Vsix/source.extension.vsixmanifest
+++ b/Vsix/source.extension.vsixmanifest
@@ -19,6 +19,9 @@
       <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
         <ProductArchitecture>amd64</ProductArchitecture>
       </InstallationTarget>
+      <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+        <ProductArchitecture>arm64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />


### PR DESCRIPTION
Potentially fixes #989 

This should make the extension installable on VS2022 on arm. I don't have a device to test it with, and even if it installs it may not work. Any feedback would be appreciated

[ICSharpCode.CodeConverter.VsExtension.zip](https://github.com/icsharpcode/CodeConverter/files/10962282/ICSharpCode.CodeConverter.VsExtension.zip)
