### PR TITLE
OnError GoTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### VB -> C#
 
+* Handle one very simple case of OnError Goto [#999](https://github.com/icsharpcode/CodeConverter/pull/999)
 * Fix StackOverflowException when converting nullable comparisons [#1007](https://github.com/icsharpcode/CodeConverter/pull/1007)
 * Fixes for default-initialized loop variables [#1001](https://github.com/icsharpcode/CodeConverter/pull/1001)
 * Convert DefineDebug and DefineTrace into DefineConstants [#1004](https://github.com/icsharpcode/CodeConverter/pull/1004)

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -37,7 +37,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
     private string _topAncestorNamespace;
 
     private CommonConversions CommonConversions { get; }
-    private Func<VisualBasicSyntaxNode, bool, IdentifierNameSyntax, Task<VisualBasicSyntaxVisitor<Task<SyntaxList<StatementSyntax>>>>> _createMethodBodyVisitorAsync { get; }
+    private Func<VisualBasicSyntaxNode, IReadOnlyCollection<VBSyntax.StatementSyntax>, bool, IdentifierNameSyntax, Task<VisualBasicSyntaxVisitor<Task<SyntaxList<StatementSyntax>>>>> _createMethodBodyVisitorAsync { get; }
 
     internal PerScopeState AdditionalLocals => _typeContext.PerScopeState;
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -1101,10 +1101,6 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
 
     private static async Task<BlockSyntax> ConvertStatementsAsync(SyntaxList<VBSyntax.StatementSyntax> statements, VBasic.VisualBasicSyntaxVisitor<Task<SyntaxList<StatementSyntax>>> methodBodyVisitor)
     {
-        //TODO If this contains "OnError" statments, put the whole thing in a try catch and declare a catchBlockIndex variable
-        //  Add a catch block with a catchBlockIndex for each of the OnError Goto statements and the appropriate goto contained (or do a switch statement in 1, doesn't matter)
-        //  At each OnErrorGoto, increment catchBlockIndex (setting it explicitly might be nicer but more effort)
-        //  For OnErrorResumeNext, just insert a label and increment between every single statement
         return SyntaxFactory.Block(await statements.SelectManyAsync(async s => (IEnumerable<StatementSyntax>) await s.Accept(methodBodyVisitor)));
     }
 

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -994,11 +994,13 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
 
         async Task<CatchFilterClauseSyntax> ConvertCatchFilterClauseAsync(VBasic.Syntax.CatchFilterClauseSyntax node)
         {
+            if (node == null) return null;
             return SyntaxFactory.CatchFilterClause(await node.Filter.AcceptAsync<ExpressionSyntax>(_expressionVisitor));
         }
 
         async Task<FinallyClauseSyntax> ConvertFinallyBlockAsync(VBasic.Syntax.FinallyBlockSyntax node)
         {
+            if (node == null) return null;
             var stmts = await node.Statements.SelectManyAsync(async s => (IEnumerable<StatementSyntax>)await s.Accept(CommentConvertingVisitor));
             return SyntaxFactory.FinallyClause(SyntaxFactory.Block(stmts));
         }

--- a/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
+++ b/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
@@ -15,9 +15,10 @@ Public Function SelfDivisionPossible(x as Integer) As Boolean
         Dim i as Integer = x / x
         Return True
 ErrorHandler:
-    Return False
+    Return Err.Number = 6
 End Function
 End Class", @"using System;
+using Microsoft.VisualBasic; // Install-Package Microsoft.VisualBasic
 
 internal partial class TestClass
 {
@@ -30,10 +31,41 @@ internal partial class TestClass
         }
         catch
         {
-        }
 
-        return false;
+            return Information.Err().Number == 6;
+        }
     }
 }");
+    }
+
+    [Fact]
+    public async Task RemainingScopeIssueCharacterizationAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+Public Function SelfDivisionPossible(x as Integer) As Boolean
+    On Error GoTo ErrorHandler
+        Dim i as Integer = x / x
+ErrorHandler:
+    Return i <> 0
+End Function
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    public bool SelfDivisionPossible(int x)
+    {
+        try
+        {
+            int i = (int)Math.Round(x / (double)x);
+        }
+        catch
+        {
+        }
+
+        return i != 0;
+    }
+}
+1 target compilation errors:
+CS0103: The name 'i' does not exist in the current context");
     }
 }

--- a/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
+++ b/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+using Xunit;
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp.StatementTests;
+
+public class OnErrorStatementTests : ConverterTestBase
+{
+    [Fact]
+    public async Task BasicGotoAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+Public Function Save() As Boolean
+    On Error GoTo ErrorHandler
+
+        Dim zero as Integer = 0
+        Dim i as Integer = zero / zero
+
+    Exit Function
+
+ErrorHandler: 
+    Console.Write(0)
+End Function
+End Class", @"using System;
+          
+internal partial class TestClass
+{
+    public bool Save()
+    {
+        var catchIndex = -1;
+        do
+            try
+            {
+                switch (catchIndex)
+                {
+                    case 0:
+                        catchIndex = -1;
+                        goto ErrorHandler;
+                        break;
+                }
+                catchIndex = 0;
+
+                int zero = 0;
+                int i = (int)Math.Round(zero / (double)zero);
+
+                return default;
+
+            ErrorHandler:
+                ;
+
+                Console.Write(0);
+                catchIndex = -1;
+            }
+            catch
+            {
+            }
+        while (catchIndex != -1);
+    }
+}
+1 target compilation errors:
+CS0161: 'TestClass.Save()': not all code paths return a value");
+    }
+}

--- a/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
+++ b/Tests/CSharp/StatementTests/OnErrorStatementTests.cs
@@ -10,54 +10,30 @@ public class OnErrorStatementTests : ConverterTestBase
     public async Task BasicGotoAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
-Public Function Save() As Boolean
+Public Function SelfDivisionPossible(x as Integer) As Boolean
     On Error GoTo ErrorHandler
-
-        Dim zero as Integer = 0
-        Dim i as Integer = zero / zero
-
-    Exit Function
-
-ErrorHandler: 
-    Console.Write(0)
+        Dim i as Integer = x / x
+        Return True
+ErrorHandler:
+    Return False
 End Function
 End Class", @"using System;
-          
+
 internal partial class TestClass
 {
-    public bool Save()
+    public bool SelfDivisionPossible(int x)
     {
-        var catchIndex = -1;
-        do
-            try
-            {
-                switch (catchIndex)
-                {
-                    case 0:
-                        catchIndex = -1;
-                        goto ErrorHandler;
-                        break;
-                }
-                catchIndex = 0;
+        try
+        {
+            int i = (int)Math.Round(x / (double)x);
+            return true;
+        }
+        catch
+        {
+        }
 
-                int zero = 0;
-                int i = (int)Math.Round(zero / (double)zero);
-
-                return default;
-
-            ErrorHandler:
-                ;
-
-                Console.Write(0);
-                catchIndex = -1;
-            }
-            catch
-            {
-            }
-        while (catchIndex != -1);
+        return false;
     }
-}
-1 target compilation errors:
-CS0161: 'TestClass.Save()': not all code paths return a value");
+}");
     }
 }


### PR DESCRIPTION
Partial (simplest possible case) fix for https://github.com/icsharpcode/CodeConverter/issues/426

Simplest case covered here: A single top level On Error Go To, everything after it could be placed in a try catch and go to the outer label

### May be possible to cover in future

* OnErrorGoTo statement and label in same scope, but not top-level (e.g. nested in an if statment/loop)

* Extend that system to two statements within a scope (e.g. changing the error handler part way through, it would be possible to have a nested try catch block for the second one, and use an filter clause to avoid hitting the outer one

 

### Still no known solution

General solution: The difficulty is that in C# the labels are scoped to the containing block, so it isn't possible to goto a label straight from a catch block. I've therefore created a loop and switch to allow it to re-enter the scope where it's possible to go to the label. I'm still trying to think of a less verbose/ugly way of handling this.



