### PR TITLE
Fix Issue #998 and #1000

### DIFF
--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -148,7 +148,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                 if (!assignedBeforeRead) {
                     _perScopeState.Hoist(new HoistedDefaultInitializedLoopVariable(
                         csVariable.Identifier.Text,
-                        // e.g. "b As Boolean" has no intializer but can turn into "var b = default(bool)"
+                        // e.g. "b As Boolean" has no initializer but can turn into "var b = default(bool)"
                         csVariable.Initializer?.Value,
                         variablesDecl.Decl.Type,
                         _perScopeState.IsInsideNestedLoop()));

--- a/CodeConverter/CSharp/PerScopeState.cs
+++ b/CodeConverter/CSharp/PerScopeState.cs
@@ -46,18 +46,20 @@ internal class PerScopeState
         return additionalLocal;
     }
 
-    private readonly VBasic.SyntaxKind[] loopKinds = {
-        VBasic.SyntaxKind.DoKeyword, 
+    private readonly VBasic.SyntaxKind[] _loopKinds = {
+        VBasic.SyntaxKind.DoKeyword,
         VBasic.SyntaxKind.ForKeyword,
         VBasic.SyntaxKind.WhileKeyword
     };
+
     public bool IsInsideLoop()
     {
-        return _hoistedNodesPerScope.Skip(1).Any(x => loopKinds.Contains(x.ExitableKind));
+        return _hoistedNodesPerScope.Skip(1).Any(x => _loopKinds.Contains(x.ExitableKind));
     }
+
     public bool IsInsideNestedLoop()
     {
-        return _hoistedNodesPerScope.Skip(1).Count(x => loopKinds.Contains(x.ExitableKind)) > 1;
+        return _hoistedNodesPerScope.Skip(1).Count(x => _loopKinds.Contains(x.ExitableKind)) > 1;
     }
 
     public T HoistToTopLevel<T>(T additionalField) where T : IHoistedNode
@@ -113,7 +115,9 @@ internal class PerScopeState
 
         foreach (var variable in GetDefaultInitializedLoopVariables()) {
             if (IsInsideLoop()) {
-                newNames.Add(variable.OriginalVariableName, variable.Id);
+                if (variable.Nested) {
+                    newNames.Add(variable.OriginalVariableName, variable.Id);
+                }
                 HoistToParent(variable);
             } else {
                 string name;

--- a/CodeConverter/CSharp/PerScopeState.cs
+++ b/CodeConverter/CSharp/PerScopeState.cs
@@ -120,15 +120,14 @@ internal class PerScopeState
                 }
                 HoistToParent(variable);
             } else {
-                string name;
+                // The variable comes from the VB scope, only check for conflict with other hoisted definitions
+                string name = NameGenerator.GenerateUniqueVariableName(generatedNames, variable.OriginalVariableName);
                 if (variable.Nested) {
-                    newNames.Add(variable.Id, NameGenerator.GetUniqueVariableNameInScope(semanticModel, generatedNames, vbNode, variable.OriginalVariableName));
-                    name = newNames[variable.Id];
-                } else {
-                    name = variable.OriginalVariableName;
+                    newNames.Add(variable.Id, name);
+                } else if (name != variable.OriginalVariableName) {
+                    newNames.Add(variable.OriginalVariableName, name);
                 }
-                var decl = 
-                    CommonConversions.CreateVariableDeclarationAndAssignment(name,
+                var decl = CommonConversions.CreateVariableDeclarationAndAssignment(name,
                     variable.Initializer, variable.Type);
                 preDeclarations.Add(CS.SyntaxFactory.LocalDeclarationStatement(decl));
             }

--- a/CodeConverter/Common/NameGenerator.cs
+++ b/CodeConverter/Common/NameGenerator.cs
@@ -52,4 +52,11 @@ internal static class NameGenerator
         return node.GetAncestorOrThis<VBSyntax.StatementSyntax>().DescendantNodesAndSelf()
             .OfType<VBSyntax.StatementSyntax>().Select(n => n.SpanStart).ToList();
     }
+
+    public static string GenerateUniqueVariableName(HashSet<string> generatedNames, string variableNameBase)
+    {
+        string uniqueName = GenerateUniqueName(variableNameBase, string.Empty, n => !generatedNames.Contains(n));
+        generatedNames.Add(uniqueName);
+        return uniqueName;
+    }
 }

--- a/Tests/CSharp/StatementTests/LoopStatementTests.cs
+++ b/Tests/CSharp/StatementTests/LoopStatementTests.cs
@@ -687,18 +687,18 @@ internal partial class TestClass
             For j = 1 To 3
                 Dim c As Integer
                 c  +=1
-                Console.WriteLine(""c1={0}"", c)
+                Console.WriteLine(""c={0}"", c)
             Next
             For j = 1 To 3
                 Dim c As Integer
                 c +=1
-                Console.WriteLine(""c2={0}"", c)
+                Console.WriteLine(""c1={0}"", c)
             Next
             Dim k=1
             Do while k <= 3
                 Dim c As Integer
                 c +=1
-                Console.WriteLine(""c3={0}"", c)
+                Console.WriteLine(""c2={0}"", c)
                 k+=1
             Loop
         i += 1
@@ -712,33 +712,71 @@ internal partial class TestClass
     {
         int i = 1;
         var b = default(int);
+        var c = default(int);
         var c1 = default(int);
         var c2 = default(int);
-        var c3 = default(int);
         do
         {
             b += 1;
             Console.WriteLine(""b={0}"", b);
             for (int j = 1; j <= 3; j++)
             {
-                c1 += 1;
-                Console.WriteLine(""c1={0}"", c1);
+                c += 1;
+                Console.WriteLine(""c={0}"", c);
             }
             for (int j = 1; j <= 3; j++)
             {
-                c2 += 1;
-                Console.WriteLine(""c2={0}"", c2);
+                c1 += 1;
+                Console.WriteLine(""c1={0}"", c1);
             }
             int k = 1;
             while (k <= 3)
             {
-                c3 += 1;
-                Console.WriteLine(""c3={0}"", c3);
+                c2 += 1;
+                Console.WriteLine(""c2={0}"", c2);
                 k += 1;
             }
             i += 1;
         }
         while (i <= 3);
+    }
+}");
+    }
+
+    [Fact]
+    public async Task ForWithVariableDeclarationIssue1000Async()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod()
+        For i = 1 To 2
+            Dim b As Boolean
+            Console.WriteLine(b)
+            b = True
+        Next
+        For i = 1 To 2
+            Dim b As Boolean
+            Console.WriteLine(b)
+            b = True
+        Next
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        var b = default(bool);
+        for (int i = 1; i <= 2; i++)
+        {
+            Console.WriteLine(b);
+            b = true;
+        }
+        var b1 = default(bool);
+        for (int i = 1; i <= 2; i++)
+        {
+            Console.WriteLine(b1);
+            b1 = true;
+        }
     }
 }");
     }

--- a/Tests/CSharp/StatementTests/LoopStatementTests.cs
+++ b/Tests/CSharp/StatementTests/LoopStatementTests.cs
@@ -742,4 +742,36 @@ internal partial class TestClass
     }
 }");
     }
+
+    [Fact]
+    public async Task ForWithVariableDeclarationIssue998Async()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class TestClass
+    Private Sub TestMethod(someCondition As Boolean)
+        For j = 1 To 2
+            If someCondition Then
+                Dim b As Boolean
+                Console.WriteLine(b)
+                b = True
+            End If
+        Next
+    End Sub
+End Class", @"using System;
+
+internal partial class TestClass
+{
+    private void TestMethod(bool someCondition)
+    {
+        var b = default(bool);
+        for (int j = 1; j <= 2; j++)
+        {
+            if (someCondition)
+            {
+                Console.WriteLine(b);
+                b = true;
+            }
+        }
+    }
+}");
+    }
 }


### PR DESCRIPTION
### Problem
See PR #902 for the explanation of the root issue. Issues #998 and #1000 are bugs in #902 in two specific cases.

### Solution
The fix for the two issues is in the same location `PerScopeState.CreateLocalsAsync()`
* For #998
Renaming the original variable with a unique ID as we go up the tree should only be done (and is only needed) in the nested loops case.
* For #1000 
Renaming the original variable in case of conflict was only done in the nested loops case, but a conflict can also happen in the non-nested case (see test).
A side effect of the fix is that the renaming occurs only in case of conflict (see modified test for the nested loops case).
* I have tried to merge the nested and non-nested code paths, but currently I don't think it is possible.