### PR TITLE
Fix issue #1003

### DIFF
--- a/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
+++ b/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
@@ -1,4 +1,7 @@
-﻿using ICSharpCode.CodeConverter.Common;
+﻿using System.Web.UI.WebControls;
+using System.Xml.Linq;
+using System;
+using ICSharpCode.CodeConverter.Common;
 using Xunit;
 
 namespace ICSharpCode.CodeConverter.Tests.LanguageAgnostic;
@@ -8,43 +11,57 @@ public class ProjectFileTextEditorTests
     [Fact]
     public void TogglesExistingValue()
     {
-        var convertedProjFile = ProjectFileTextEditor.WithUpdatedDefaultItemExcludes(
-            @"
+        var convertedProjFile = WithUpdatedDefaultItemExcludes(
+            @"<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**;$(ProjectDir)**\*.cs</DefaultItemExcludes>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-  </PropertyGroup>", "cs", "vb");
+  </PropertyGroup>
+</Project>", "cs", "vb");
 
-        Assert.Equal(Utils.HomogenizeEol(@"
+        Assert.Equal(Utils.HomogenizeEol(@"<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**;$(ProjectDir)**\*.vb</DefaultItemExcludes>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-  </PropertyGroup>"),
+  </PropertyGroup>
+</Project>"),
             Utils.HomogenizeEol(convertedProjFile));
     }
 
     [Fact]
     public void InsertsIfNotPresent()
     {
-        var convertedProjFile = ProjectFileTextEditor.WithUpdatedDefaultItemExcludes(
-            @"
+        var convertedProjFile = WithUpdatedDefaultItemExcludes(
+            @"<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-  </PropertyGroup>", "cs", "vb");
+  </PropertyGroup>
+</Project>", "cs", "vb");
 
-        Assert.Equal(Utils.HomogenizeEol(@"
+        Assert.Equal(Utils.HomogenizeEol(@"<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.vb</DefaultItemExcludes>
   </PropertyGroup>
   <PropertyGroup>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-  </PropertyGroup>"),
+  </PropertyGroup>
+</Project>"),
             Utils.HomogenizeEol(convertedProjFile));
+    }
+
+    private static string WithUpdatedDefaultItemExcludes(string inputProjFile, string extensionNotToExclude, string extensionToExclude)
+    {
+        var xmlDoc = XDocument.Parse(inputProjFile);
+        XNamespace xmlNs = xmlDoc.Root.GetDefaultNamespace();
+
+        ProjectFileTextEditor.WithUpdatedDefaultItemExcludes(xmlDoc, xmlNs, extensionNotToExclude, extensionToExclude);
+
+        return xmlDoc.Declaration != null ? xmlDoc.Declaration + Environment.NewLine + xmlDoc : xmlDoc.ToString();
     }
 }

--- a/Tests/LanguageAgnostic/SolutionFileTextEditorTests.cs
+++ b/Tests/LanguageAgnostic/SolutionFileTextEditorTests.cs
@@ -507,6 +507,8 @@ public class SolutionFileTextEditorTests : IDisposable
             ? (Action<string>) (stringToAppend => referenceBuilder.AppendLine(stringToAppend))
             : stringToAppend => referenceBuilder.Append(stringToAppend);
 
+        builderAppendMethod("<Project>");
+
         foreach ((string projTypeGuid, string projName, string relativeProjPath, string projRefGuid) in projRefTuples)
         {
             var referenceStringToAppend = $@"Project(""{{{projTypeGuid}}}"") = ""{projName}"","
@@ -521,6 +523,8 @@ EndProject";
             builderAppendMethod(referenceStringToAppend);
         }
 
+        builderAppendMethod("</Project>");
+
         var referenceString = referenceBuilder.ToString();
 
         return Utils.HomogenizeEol(referenceString);
@@ -533,11 +537,15 @@ EndProject";
             ? (Action<string>) (stringToAppend => referenceBuilder.AppendLine(stringToAppend))
             : stringToAppend => referenceBuilder.Append(stringToAppend);
 
+        builderAppendMethod("<Project>");
+
         foreach (var relativeProjPath in relProjPaths)
         {
             var referenceStringToAppend = $@"<ProjectReference Include=""{relativeProjPath}"" />";
             builderAppendMethod(referenceStringToAppend);
         }
+
+        builderAppendMethod("</Project>");
 
         var referenceString = referenceBuilder.ToString();
 

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/CSharpNetStandardLib/CSharpNetStandardLib.vbproj
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/CSharpNetStandardLib/CSharpNetStandardLib.vbproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OptionInfer>On</OptionInfer>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.cs</DefaultItemExcludes>
   </PropertyGroup>
-
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/NetCore/NetCore.vbproj
+++ b/Tests/TestData/MultiFileCharacterization/CSToVBResults/ConvertWholeSolution/NetCore/NetCore.vbproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OptionInfer>On</OptionInfer>
     <OutputType>Exe</OutputType>
     <TargetFramework>net472</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.cs</DefaultItemExcludes>
   </PropertyGroup>
-
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertVbLibraryOnly/VbLibrary/VbLibrary.csproj
@@ -22,21 +22,19 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>bin\Debug\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>bin\Release\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/VisualBasicConsoleApp.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp1/VisualBasicConsoleApp.csproj
@@ -21,21 +21,19 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>bin\Debug\ConsoleApp1.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>bin\Release\ConsoleApp1.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp4/ConsoleApp4.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/ConsoleApp4/ConsoleApp4.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ConsoleApp4</RootNamespace>
@@ -7,5 +6,4 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.vb</DefaultItemExcludes>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/Prefix.VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/Prefix.VbLibrary/Prefix.VbLibrary.csproj
@@ -19,20 +19,18 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>bin\Debug\Prefix.VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>bin\Release\Prefix.VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbLibrary/VbLibrary.csproj
@@ -22,21 +22,19 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>bin\Debug\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>bin\Release\VbLibrary.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/VbNetStandardLib.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/VbNetStandardLib/VbNetStandardLib.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <RootNamespace>VbNetStandardLib</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(ProjectDir)**\*.vb</DefaultItemExcludes>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
     <EmbeddedResource Update="Folder2Res.resx">
@@ -25,7 +23,6 @@
       <LastGenOutput>RootResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Folder2Res.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -43,5 +40,4 @@
       <DependentUpon>RootResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
 </Project>

--- a/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WindowsAppVb.csproj
+++ b/Tests/TestData/MultiFileCharacterization/VBToCSResults/ConvertWholeSolution/WindowsAppVb/WindowsAppVb.csproj
@@ -21,21 +21,19 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <OutputPath>bin\Debug\</OutputPath>
     <DocumentationFile>bin\Debug\WindowsAppVb.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <DefineDebug>false</DefineDebug>
-    <DefineTrace>true</DefineTrace>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DocumentationFile>bin\Release\WindowsAppVb.xml</DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <OptionExplicit>On</OptionExplicit>

--- a/Tests/TestRunners/MultiFileTestFixture.cs
+++ b/Tests/TestRunners/MultiFileTestFixture.cs
@@ -113,8 +113,13 @@ public sealed class MultiFileTestFixture : ICollectionFixture<MultiFileTestFixtu
         var conversionResult = conversionResults[convertedFilePath];
         var actualText = conversionResult.ConvertedCode ?? "" + conversionResult.GetExceptionsAsString() ?? "";
 
-        OurAssert.EqualIgnoringNewlines(expectedText, actualText);
-        Assert.Equal(GetEncoding(expectedFile.FullName), GetEncoding(conversionResult));
+        try {
+            OurAssert.EqualIgnoringNewlines(expectedText + OurAssert.LineSplitter, actualText + OurAssert.LineSplitter);
+            Assert.Equal(GetEncoding(expectedFile.FullName), GetEncoding(conversionResult));
+        } catch (Exception e) {
+            var relativeFile = PathConverter.GetRelativePath(TestConstants.GetTestDataDirectory(), expectedFile.FullName);
+            throw new Exception($"Converted file does not match expected file {relativeFile}" + Environment.NewLine, e);
+        }
     }
 
     private Encoding GetEncoding(ConversionResult conversionResult)


### PR DESCRIPTION
See issue #1003

### Problem
For the VB to CS project file conversion, `<DefineDebug>` and `<DefineTrace>` should be converted to `<DefineConstants>`.

### Solution
* I've used `XDocument` to parse and edit the XML (this is already used elsewhere in the codebase, e.g. to parse the resource files).
* I've also done a similar job in the neighborhood for consistency and to simplify the code (especially in the case of the `<DocumentationFile>` conversion).
* The main change in external behavior (aside from fixing the issue) is that the `XDocument` step can cause minor changes in formatting (this can be seen in the updated test files), but I don't think this is an issue (they are new files generated by the converter, not existing files).
* I've done a small change in `MultiFileTestFixture` to ouput the expected file path in case of failure.
* The code is already covered quite well by the tests, I've updated the relevant test cases.