### PR TITLE
Specifically use 1.0.6 action that is using node 16

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Update project version
-      uses: roryprimrose/set-vs-sdk-project-version@v1
+      uses: roryprimrose/set-vs-sdk-project-version@v1.0.6
       with:
         projectFilter: 'Directory.Build.props'
         version: ${{ env.BuildVersion }}.${{ github.run_number }}


### PR DESCRIPTION
https://github.com/roryprimrose/set-vs-sdk-project-version/issues/20 @v1 does not roll up automatically to latest revision.