### PR TITLE
Cast to dynamic when the accessed member can't be found but the surro…

### DIFF
--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -44,6 +44,43 @@ internal partial class TestClass
     }
 
     [Fact]
+    public async Task DynamicTestAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Public Class C
+    Public Function IsPointWithinBoundaryBox(ByVal dblLat As Double, dblLon As Double, ByVal boundbox As Object) As Boolean
+        If boundbox IsNot Nothing Then
+            Dim boolInLatBounds As Boolean = (dblLat <= boundbox.north) And (dblLat >= boundbox.south) 'Less then highest (northmost) lat, AND more than lowest (southmost) lat
+            Dim boolInLonBounds As Boolean = (dblLon >= boundbox.west) And (dblLon <= boundbox.east) 'More than lowest (westmost) lat, AND less than highest (eastmost) lon
+            Return boolInLatBounds And boolInLonBounds
+        Else
+            'Throw New Exception(""boundbox is null."")
+        End If
+        Return False
+    End Function
+End Class
+", @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+public partial class C
+{
+    public bool IsPointWithinBoundaryBox(double dblLat, double dblLon, object boundbox)
+    {
+        if (boundbox is not null)
+        {
+            bool boolInLatBounds = Conversions.ToBoolean(Operators.AndObject(Operators.ConditionalCompareObjectLessEqual(dblLat, ((dynamic)boundbox).north, false), Operators.ConditionalCompareObjectGreaterEqual(dblLat, ((dynamic)boundbox).south, false))); // Less then highest (northmost) lat, AND more than lowest (southmost) lat
+            bool boolInLonBounds = Conversions.ToBoolean(Operators.AndObject(Operators.ConditionalCompareObjectGreaterEqual(dblLon, ((dynamic)boundbox).west, false), Operators.ConditionalCompareObjectLessEqual(dblLon, ((dynamic)boundbox).east, false))); // More than lowest (westmost) lat, AND less than highest (eastmost) lon
+            return boolInLatBounds & boolInLonBounds;
+        }
+        else
+        {
+            // Throw New Exception(""boundbox is null."")
+        }
+        return false;
+    }
+}");
+    }
+
+    [Fact]
     public async Task ConversionOfNotUsesParensIfNeededAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"Class TestClass

--- a/Tests/CSharp/StandaloneStatementTests.cs
+++ b/Tests/CSharp/StandaloneStatementTests.cs
@@ -135,12 +135,12 @@ Next", @"{
     var cmccIds = new List<int>();
     foreach (var scr in _sponsorPayment.SponsorClaimRevisions)
     {
-        foreach (var claim in (IEnumerable)scr.Claims)
+        foreach (var claim in (IEnumerable)((dynamic)scr).Claims)
         {
-            if (claim.ClaimSummary is ClaimSummary)
+            if (((dynamic)claim).ClaimSummary is ClaimSummary)
             {
                 {
-                    var withBlock = (ClaimSummary)claim.ClaimSummary;
+                    var withBlock = (ClaimSummary)((dynamic)claim).ClaimSummary;
                     cmccIds.AddRange(withBlock.UnpaidClaimMealCountCalculationsIds);
                 }
             }
@@ -151,9 +151,8 @@ Next", @"{
 2 source compilation errors:
 BC30451: '_sponsorPayment' is not declared. It may be inaccessible due to its protection level.
 BC30002: Type 'ClaimSummary' is not defined.
-3 target compilation errors:
+2 target compilation errors:
 CS0103: The name '_sponsorPayment' does not exist in the current context
-CS1061: 'object' does not contain a definition for 'ClaimSummary' and no accessible extension method 'ClaimSummary' accepting a first argument of type 'object' could be found (are you missing a using directive or an assembly reference?)
 CS0246: The type or namespace name 'ClaimSummary' could not be found (are you missing a using directive or an assembly reference?)");
     }
 }


### PR DESCRIPTION
Fixes #786

I'm worried this may be a bit too broad and spam dynamic casts everywhere in large real codebases with some slight reference issues for example.