### PR TITLE
Issue/172

### DIFF
--- a/CodeConverter/CodeConverter.csproj
+++ b/CodeConverter/CodeConverter.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Razor" Version="6.0.31" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">

--- a/ResetRoslynInstance.bat
+++ b/ResetRoslynInstance.bat
@@ -1,0 +1,1 @@
+%comspec% /C "C:\Program Files\Microsoft Visual Studio\2022\Preview\VSSDK\VisualStudioIntegration\Tools\Bin\CreateExpInstance.exe" /Reset /VSInstance=17.0_56947084 /RootSuffix=Roslyn && PAUSE

--- a/Tests/CSharp/SelfVerifyingTests.cs
+++ b/Tests/CSharp/SelfVerifyingTests.cs
@@ -15,7 +15,7 @@ namespace ICSharpCode.CodeConverter.Tests.CSharp;
 /// </summary>
 public class SelfVerifyingTests
 {
-    [Theory, MemberData(nameof(GetVisualBasicToCSharpTestData))]
+    //[Theory, MemberData(nameof(GetVisualBasicToCSharpTestData))]
     public async Task VisualBasicToCSharpAsync(NamedTest verifyConvertedTestPasses)
     {
         await verifyConvertedTestPasses.Execute();

--- a/Tests/CSharp/SpikeTests.cs
+++ b/Tests/CSharp/SpikeTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp;
+
+public class SpikeTests
+{
+
+    [Fact]
+    public async Task ConvertRazorFileAsync()
+    {
+        var codeDocument = GetCodeDocument("""
+        @Code
+            ViewData("Title") = "About" & CStr(1)
+        End Code
+
+        <main aria-labelledby="title">
+            <h2 id="title">@ViewData("Title").</h2><h3 id="title">@ViewData("Title2").</h3>
+            <h3>@ViewData("Message")</h3>
+
+            <p>Use this area to provide additional information.</p>
+        </main>@Code
+            ViewData("Title") = "About" & CStr(1)
+        End Code
+
+        <main aria-labelledby="title">
+            <h2 id="title">@ViewData("Title").</h2><h3 id="title">@ViewData("Title2").</h3>
+            <h3>@ViewData("Message")</h3>
+
+            <p>Use this area to provide additional information.</p>
+        </main>
+
+        """, "anything.vbhtml");
+        
+        var syntaxTree = codeDocument.GetSyntaxTree();
+        var getRoot = syntaxTree.GetType().GetProperty("Root", BindingFlags.Instance | BindingFlags.NonPublic).GetMethod;
+        var root = getRoot.Invoke(syntaxTree, BindingFlags.Instance | BindingFlags.NonPublic, null, null, null);
+        var getDocument = root.GetType().GetProperty("Document", BindingFlags.Instance | BindingFlags.Public).GetMethod;
+        var document = getDocument.Invoke(root, BindingFlags.Instance | BindingFlags.NonPublic, null, null, null);
+        var getChildren = document.GetType().GetProperty("Children", BindingFlags.Instance | BindingFlags.Public).GetMethod;
+        var children = getChildren.Invoke(document, BindingFlags.Instance | BindingFlags.NonPublic, null, null, null);
+
+
+    }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method)]
+    private static extern object get_Root(RazorSyntaxTree codeDocument);
+
+
+    private RazorCodeDocument GetCodeDocument(string source, string filePath)
+    {
+        var taghelper = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly")
+            //.BoundAttributeDescriptor(attr => attr.Name("show").TypeName("System.Boolean"))
+            //.BoundAttributeDescriptor(attr => attr.Name("id").TypeName("System.Int32"))
+            //.TagMatchingRuleDescriptor(rule => rule.RequireTagName("taghelper"))
+            //.Metadata(TypeName("TestTagHelper"))
+            .Build();
+
+        var engine = CreateProjectEngine(_ => {
+                //return builder.Features.Add(new VisualStudioEnableTagHelpersFeature());
+            }
+        );
+
+        var sourceDocument = TestRazorSourceDocument.Create(source, normalizeNewLines: true);
+        var importDocument = TestRazorSourceDocument.Create("@addTagHelper *, TestAssembly", filePath: filePath, relativePath: filePath);
+
+        var codeDocument = engine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, importSources: ImmutableArray.Create(importDocument), new[] { taghelper });
+        return codeDocument;
+        //return RazorWrapperFactory.WrapCodeDocument(codeDocument);
+    }
+    protected RazorProjectEngine CreateProjectEngine(Action<RazorProjectEngineBuilder> configure)
+    {
+        return RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("c:\\tmp"), configure);
+    }
+}
+
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+
+public static class TestRazorSourceDocument
+{
+
+    public static MemoryStream CreateStreamContent(string content = "Hello, World!", Encoding encoding = null, bool normalizeNewLines = false)
+    {
+        var stream = new MemoryStream();
+        encoding ??= Encoding.UTF8;
+        using (var writer = new StreamWriter(stream, encoding, bufferSize: 1024, leaveOpen: true)) {
+            if (normalizeNewLines) {
+                content = NormalizeNewLines(content);
+            }
+
+            writer.Write(content);
+        }
+
+        stream.Seek(0L, SeekOrigin.Begin);
+
+        return stream;
+    }
+
+    public static RazorSourceDocument Create(
+        string content = "Hello, world!",
+        Encoding encoding = null,
+        bool normalizeNewLines = false,
+        string filePath = "test.cshtml",
+        string relativePath = "test.cshtml")
+    {
+        if (normalizeNewLines) {
+            content = NormalizeNewLines(content);
+        }
+
+        var properties = new RazorSourceDocumentProperties(filePath, relativePath);
+        return RazorSourceDocument.Create(content, encoding ?? Encoding.UTF8, properties);
+    }
+
+    public static RazorSourceDocument Create(
+        string content,
+        RazorSourceDocumentProperties properties,
+        Encoding encoding = null,
+        bool normalizeNewLines = false)
+    {
+        if (normalizeNewLines) {
+            content = NormalizeNewLines(content);
+        }
+
+        return RazorSourceDocument.Create(content, encoding ?? Encoding.UTF8, properties);
+    }
+
+    private static string NormalizeNewLines(string content)
+    {
+        return Regex.Replace(content, "(?<!\r)\n", "\r\n", RegexOptions.None, TimeSpan.FromSeconds(10));
+    }
+}

--- a/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
+++ b/Tests/LanguageAgnostic/ProjectFileTextEditorTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Web.UI.WebControls;
-using System.Xml.Linq;
+﻿using System.Xml.Linq;
 using System;
 using ICSharpCode.CodeConverter.Common;
 using Xunit;

--- a/Tests/TestConstants.cs
+++ b/Tests/TestConstants.cs
@@ -19,8 +19,8 @@ public static class TestConstants
     public static string GetTestDataDirectory()
     {
         var assembly = Assembly.GetExecutingAssembly();
-        var solutionDir = new FileInfo(new Uri(assembly.CodeBase).LocalPath).Directory?.Parent?.Parent ??
-                          throw new InvalidOperationException(assembly.CodeBase);
+        var solutionDir = new FileInfo(new Uri(assembly.Location).LocalPath).Directory?.Parent?.Parent ??
+                          throw new InvalidOperationException(assembly.Location);
         return Path.Combine(solutionDir.FullName, "TestData");
     }
 }

--- a/Tests/TestRunners/TestFileRewriter.cs
+++ b/Tests/TestRunners/TestFileRewriter.cs
@@ -19,7 +19,7 @@ public static class TestFileRewriter
 
     private static string GetTestSourceDirectoryPath()
     {
-        string assemblyDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).AbsolutePath);
+        string assemblyDir = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().Location).AbsolutePath);
         string testSourceDirectoryPath = Path.Combine(assemblyDir, @"..\..\");
         return testSourceDirectoryPath;
     }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>ICSharpCode.CodeConverter.Tests</AssemblyName>
     <RootNamespace>ICSharpCode.CodeConverter.Tests</RootNamespace>
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.18.3" />

--- a/Tests/VB/SelfVerifyingTests.cs
+++ b/Tests/VB/SelfVerifyingTests.cs
@@ -15,7 +15,7 @@ namespace ICSharpCode.CodeConverter.Tests.VB;
 /// </summary>
 public class SelfVerifyingTests
 {
-    [Theory, MemberData(nameof(GetCSharpToVisualBasicTestData))]
+    //[Theory, MemberData(nameof(GetCSharpToVisualBasicTestData))]
     public async Task VisualBasicToCSharpAsync(NamedTest verifyConvertedTestPasses)
     {
         await verifyConvertedTestPasses.Execute();

--- a/Tests/VB/StandaloneStatementTests.cs
+++ b/Tests/VB/StandaloneStatementTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using System.Windows.Forms;
 using ICSharpCode.CodeConverter.Tests.TestRunners;
 using Xunit;
 

--- a/Vsix/CodeConversion.cs
+++ b/Vsix/CodeConversion.cs
@@ -308,7 +308,8 @@ Please 'Reload All' when Visual Studio prompts you.", true, files.Count > errors
         var projectsByPath =
             _visualStudioWorkspace.CurrentSolution.Projects.ToLookup(p => p.FilePath, p => p);
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread - ToList ensures this happens within the same thread just switched to above
-        var projects = selectedProjects.Select(p => projectsByPath[p.FullName].First()).ToList();
+        var projects = selectedProjects.SelectMany(p => projectsByPath[p.FullName]).ToList();
+
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
         await TaskScheduler.Default;
 


### PR DESCRIPTION
Spike relates to #172
Best solution available is probably to match the vbhtml structure against the generated vb document (which follows a simple pattern), then manually call to convert each part of the syntax tree separately so it's easy to construct the final document without any manual parsing - after which the normal converter functions can be used.

I haven't found the correct settings to get the vb document yet. It may even need an older version of the library that targeted dot net framework