### PR TITLE
use `TokenContext` when creating modifiers for a `DeclareStatementSyntax`

### DIFF
--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -1504,7 +1504,13 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
 
         var attributeLists = (await CommonConversions.ConvertAttributesAsync(node.AttributeLists)).Add(dllImportAttributeList);
 
-        var modifiers = CommonConversions.ConvertModifiers(node, node.Modifiers).Add(SyntaxFactory.Token(CSSyntaxKind.StaticKeyword)).Add(SyntaxFactory.Token(CSSyntaxKind.ExternKeyword));
+        var tokenContext = GetMemberContext(node);
+        var modifiers = CommonConversions.ConvertModifiers(node, node.Modifiers, tokenContext);
+        if (!modifiers.Any(m => m.IsKind(CSSyntaxKind.StaticKeyword))) {
+            modifiers = modifiers.Add(SyntaxFactory.Token(CSSyntaxKind.StaticKeyword));
+        }
+        modifiers = modifiers.Add(SyntaxFactory.Token(CSSyntaxKind.ExternKeyword));
+
         var returnType = await (node.AsClause?.Type).AcceptAsync<TypeSyntax>(_triviaConvertingExpressionVisitor) ?? SyntaxFactory.PredefinedType(SyntaxFactory.Token(CSSyntaxKind.VoidKeyword));
         var parameterListSyntax = await (node.ParameterList).AcceptAsync<ParameterListSyntax>(_triviaConvertingExpressionVisitor) ??
                                   SyntaxFactory.ParameterList();

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -85,6 +85,34 @@ internal static partial class Module1
     }
 
     [Fact]
+    public async Task TestDeclareMethodVisibilityInModuleAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Module Module1
+    Declare Sub External Lib ""lib.dll"" ()
+End Module", @"using System.Runtime.InteropServices;
+
+internal static partial class Module1
+{
+    [DllImport(""lib.dll"")]
+    public static extern void External();
+}");
+    }
+
+    [Fact]
+    public async Task TestDeclareMethodVisibilityInClassAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class Class1
+    Declare Sub External Lib ""lib.dll"" ()
+End Class", @"using System.Runtime.InteropServices;
+
+internal partial class Class1
+{
+    [DllImport(""lib.dll"")]
+    public static extern void External();
+}");
+    }
+
+    [Fact]
     public async Task TestTypeInferredConstAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
### Problem
Fixes #1109
 "Default visibility on Declared members isn't adjusted"

### Solution
Get modifiers in a similar manner to how `MethodStatementSyntax` is analyzed (use `GetMemberContext(node)`).
