### PR TITLE
generate `unchecked((int)0x91234567)` instead of `int.MinValue + 0x11234567`

### DIFF
--- a/CodeConverter/Common/DocumentExtensions.cs
+++ b/CodeConverter/Common/DocumentExtensions.cs
@@ -50,7 +50,9 @@ internal static class DocumentExtensions
 
     private static bool CsWouldBeSimplifiedIncorrectly(SyntaxNode n)
     {
-        return false;
+        //"private int value = unchecked((int)0x80000010);" is simplified to "private int value = unchecked(0x80000010);"
+        // which causes CS0266: "Cannot implicitly convert type 'uint' to 'int'"
+        return (n is CSSyntax.CastExpressionSyntax && n.Parent is CSSyntax.CheckedExpressionSyntax);
     }
 
     public static async Task<Document> WithExpandedRootAsync(this Document document, CancellationToken cancellationToken)

--- a/CodeConverter/Common/DocumentExtensions.cs
+++ b/CodeConverter/Common/DocumentExtensions.cs
@@ -52,7 +52,7 @@ internal static class DocumentExtensions
     {
         //"private int value = unchecked((int)0x80000010);" is simplified to "private int value = unchecked(0x80000010);"
         // which causes CS0266: "Cannot implicitly convert type 'uint' to 'int'"
-        return (n is CSSyntax.CastExpressionSyntax && n.Parent is CSSyntax.CheckedExpressionSyntax);
+        return (n is CSSyntax.CastExpressionSyntax { Parent : CSSyntax.CheckedExpressionSyntax });
     }
 
     public static async Task<Document> WithExpandedRootAsync(this Document document, CancellationToken cancellationToken)

--- a/Tests/CSharp/SpecialConversionTests.cs
+++ b/Tests/CSharp/SpecialConversionTests.cs
@@ -154,8 +154,8 @@ internal partial class Test
 End Class", @"
 internal partial class Test754
 {
-    private int value = int.MinValue + 0x00000000;
-    private int value2 = int.MinValue + 0x71234567;
+    private int value = unchecked((int)0x80000000);
+    private int value2 = unchecked((int)0xF1234567);
 }");
     }
 


### PR DESCRIPTION
### Problem
#1064
For `&H80040E19` we get `int.MinValue + 0x00040E19`. With this PR, we'd get `unchecked((int)0x80040E19)` instead, thus preserving the hex literal value.

### Solution
Corresponding code in LiteralConversion.cs was adjusted.

Additionally, I had to change `CsWouldBeSimplifiedIncorrectly` to return true for `CastExpressionSyntax` with `Parent` that's a `CheckedExpressionSyntax`, because otherwise it would've caused CS0266: "Cannot implicitly convert type 'uint' to 'int'".
Note this rule is a bit too aggressive:
```cs
int i = unchecked(0x80040E19); //we prevent error CS0266 here
uint u = unchecked(0x80040E19); //but we also prevent this from happening
```
(and many more cases with different types)

I'm reasonable sure it doesn't matter though: this PR introduces the very first call to `SyntaxFactory.CheckedExpression`.

