### PR TITLE
Always use `RefConversion.PreAssigment` for `const`s

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1836,6 +1836,9 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             if (symbolInfo is IPropertySymbol propertySymbol) {
                 return propertySymbol.IsReadOnly ? RefConversion.PreAssigment : RefConversion.PreAndPostAssignment;
             }
+            else if (symbolInfo is IFieldSymbol { IsConst: true } || symbolInfo is ILocalSymbol { IsConst: true }) {
+                return RefConversion.PreAssigment;
+            }
 
             if (DeclaredInUsing(symbolInfo)) return RefConversion.PreAssigment;
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1836,7 +1836,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             if (symbolInfo is IPropertySymbol propertySymbol) {
                 return propertySymbol.IsReadOnly ? RefConversion.PreAssigment : RefConversion.PreAndPostAssignment;
             }
-            else if (symbolInfo is IFieldSymbol { IsConst: true } || symbolInfo is ILocalSymbol { IsConst: true }) {
+            else if (symbolInfo is IFieldSymbol { IsConst: true } or ILocalSymbol { IsConst: true }) {
                 return RefConversion.PreAssigment;
             }
 

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -4049,4 +4049,38 @@ internal partial class StaticLocalConvertedToField
     }
 }");
     }
+
+    [Fact]
+    public async Task TestRefConstArgumentAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class RefConstArgument
+    Const a As String = ""a""
+    Sub S()
+        Const b As String = ""b""
+        MO(a)
+        MS(b)
+    End Sub
+    Sub MO(ByRef s As Object) : End Sub
+    Sub MS(ByRef s As String) : End Sub
+End Class", @"
+internal partial class RefConstArgument
+{
+    private const string a = ""a"";
+    public void S()
+    {
+        const string b = ""b"";
+        object args = a;
+        MO(ref args);
+        string args1 = b;
+        MS(ref args1);
+    }
+    public void MO(ref object s)
+    {
+    }
+    public void MS(ref string s)
+    {
+    }
+}");
+    }
 }


### PR DESCRIPTION
### Problem
#1106: ByRef temporary variable is assigned back into a constant

### Solution
* Only a minor change in `GetRefConversion`
* [x] At least one test covering the code changed

