### PR TITLE
Convert explicitely omitted ByRef arguments into temporary variables

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1739,6 +1739,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             if (arg.IsOmitted) {
                 if (invocationSymbol != null && !invocationHasOverloads) {
                     forceNamedParameters = true;
+                    processedParameters.Remove(parameterSymbol?.Name);
                     return null; //Prefer to skip omitted and use named parameters when the symbol has only one overload
                 }
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1731,18 +1731,22 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         {
             var argName = arg is VBSyntax.SimpleArgumentSyntax { IsNamed: true } namedArg ? namedArg.NameColonEquals.Name.Identifier.Text : null;
             var parameterSymbol = invocationSymbol?.GetParameters().GetArgument(argName, argIndex);
+            var convertedArg = await ConvertArgForParameter(arg, parameterSymbol);
 
-            if (parameterSymbol != null) {
+            if (convertedArg is not null && parameterSymbol is not null) {
                 processedParameters.Add(parameterSymbol.Name);
             }
 
+            return convertedArg;
+        }
+
+        async Task<ArgumentSyntax> ConvertArgForParameter(VBSyntax.ArgumentSyntax arg, IParameterSymbol parameterSymbol)
+        {
             if (arg.IsOmitted) {
                 if (invocationSymbol != null && !invocationHasOverloads) {
                     forceNamedParameters = true;
-                    processedParameters.Remove(parameterSymbol?.Name);
                     return null; //Prefer to skip omitted and use named parameters when the symbol has only one overload
                 }
-
                 return ConvertOmittedArgument(parameterSymbol);
             }
 

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -4049,4 +4049,47 @@ internal partial class StaticLocalConvertedToField
     }
 }");
     }
+
+    [Fact]
+    public async Task TestOmittedArgumentsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class OmittedArguments
+    Sub M(Optional a As String = ""a"", ByRef Optional b As String = ""b"")
+        Dim s As String = """"
+
+        M() 'omitted implicitely
+        M(,) 'omitted explicitely
+
+        M(s) 'omitted implicitely
+        M(s,) 'omitted explicitely
+
+        M(a:=s) 'omitted implicitely
+        M(a:=s, ) 'omitted explicitely
+    End Sub
+End Class", @"using System.Runtime.InteropServices;
+
+internal partial class OmittedArguments
+{
+    public void M([Optional, DefaultParameterValue(""a"")] string a, [Optional, DefaultParameterValue(""b"")] ref string b)
+    {
+        string s = """";
+
+        string argb = ""b"";
+        M(b: ref argb); // omitted implicitely
+        string argb1 = ""b"";
+        M(b: ref argb1); // omitted explicitely
+
+        string argb2 = ""b"";
+        M(s, b: ref argb2); // omitted implicitely
+        string argb3 = ""b"";
+        M(s, b: ref argb3); // omitted explicitely
+
+        string argb4 = ""b"";
+        M(a: s, b: ref argb4); // omitted implicitely
+        string argb5 = ""b"";
+        M(a: s, b: ref argb5); // omitted explicitely
+    }
+}");
+    }
 }

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -4058,14 +4058,14 @@ internal partial class StaticLocalConvertedToField
     Sub M(Optional a As String = ""a"", ByRef Optional b As String = ""b"")
         Dim s As String = """"
 
-        M() 'omitted implicitely
-        M(,) 'omitted explicitely
+        M() 'omitted implicitly
+        M(,) 'omitted explicitly
 
-        M(s) 'omitted implicitely
-        M(s,) 'omitted explicitely
+        M(s) 'omitted implicitly
+        M(s,) 'omitted explicitly
 
-        M(a:=s) 'omitted implicitely
-        M(a:=s, ) 'omitted explicitely
+        M(a:=s) 'omitted implicitly
+        M(a:=s, ) 'omitted explicitly
     End Sub
 End Class", @"using System.Runtime.InteropServices;
 
@@ -4076,19 +4076,19 @@ internal partial class OmittedArguments
         string s = """";
 
         string argb = ""b"";
-        M(b: ref argb); // omitted implicitely
+        M(b: ref argb); // omitted implicitly
         string argb1 = ""b"";
-        M(b: ref argb1); // omitted explicitely
+        M(b: ref argb1); // omitted explicitly
 
         string argb2 = ""b"";
-        M(s, b: ref argb2); // omitted implicitely
+        M(s, b: ref argb2); // omitted implicitly
         string argb3 = ""b"";
-        M(s, b: ref argb3); // omitted explicitely
+        M(s, b: ref argb3); // omitted explicitly
 
         string argb4 = ""b"";
-        M(a: s, b: ref argb4); // omitted implicitely
+        M(a: s, b: ref argb4); // omitted implicitly
         string argb5 = ""b"";
-        M(a: s, b: ref argb5); // omitted explicitely
+        M(a: s, b: ref argb5); // omitted explicitly
     }
 }");
     }


### PR DESCRIPTION
### Problem
#1107: OmittedArgumentSyntax isn't converted into temporary variable for ByRef parameters causing error CS7036

### Solution
* Only a minor change. I decided to have redundand call to `processedParameters.Add(parameterSymbol.Name);` in these cases (by removing the just added name), to keep the number of `if`s (and avoid nesting another one within). There are alternatives, but IMHO the tiny performance impact is ok.
* [X] At least one test covering the code changed

