### PR TITLE
take parameter attributes into account in `CreateOptionalRefArg`

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -20,7 +20,6 @@ namespace ICSharpCode.CodeConverter.CSharp;
 
 internal class CommonConversions
 {
-    public ITypeSymbol System_Linq_Expressions_Expression_T { get; }
     private static readonly Type ExtensionAttributeType = typeof(ExtensionAttribute);
     public Document Document { get; }
     public SemanticModel SemanticModel { get; }
@@ -49,8 +48,10 @@ internal class CommonConversions
         _typeContext = typeContext;
         VisualBasicEqualityComparison = visualBasicEqualityComparison;
         WinformsConversions = new WinformsConversions(typeContext);
-        System_Linq_Expressions_Expression_T = semanticModel.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+        KnownTypes = new KnownNamedTypes(semanticModel);
     }
+
+    public KnownNamedTypes KnownTypes { get; }
 
     public record VariablePair(CSSyntax.VariableDeclaratorSyntax CsVar, VBSyntax.ModifiedIdentifierSyntax VbVar);
     public record VariablesDeclaration(CSSyntax.VariableDeclarationSyntax Decl, ITypeSymbol Type, List<VariablePair> Variables);
@@ -756,5 +757,5 @@ internal class CommonConversions
         return false;
     }
 
-    private bool IsLinqDelegateExpression(ITypeSymbol convertedType) => System_Linq_Expressions_Expression_T?.Equals(convertedType?.OriginalDefinition, SymbolEqualityComparer.Default) == true;
+    private bool IsLinqDelegateExpression(ITypeSymbol convertedType) =>KnownTypes.System_Linq_Expressions_Expression_T?.Equals(convertedType?.OriginalDefinition, SymbolEqualityComparer.Default) == true;
 }

--- a/CodeConverter/CSharp/KnownNamedTypes.cs
+++ b/CodeConverter/CSharp/KnownNamedTypes.cs
@@ -1,0 +1,22 @@
+﻿namespace ICSharpCode.CodeConverter.CSharp;
+
+internal class KnownNamedTypes
+{
+    public KnownNamedTypes(SemanticModel semanticModel)
+    {
+        Boolean = semanticModel.Compilation.GetTypeByMetadataName("System.Boolean");
+        String = semanticModel.Compilation.GetTypeByMetadataName("System.String");
+        DefaultParameterValueAttribute = semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.InteropServices.DefaultParameterValueAttribute");
+        OptionalAttribute = semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.InteropServices.OptionalAttribute");
+        System_Linq_Expressions_Expression_T = semanticModel.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+        VbCompilerStringType = semanticModel.Compilation.GetTypeByMetadataName("Microsoft.VisualBasic.CompilerServices.StringType");
+    }
+
+    public INamedTypeSymbol System_Linq_Expressions_Expression_T { get; set; }
+
+    public INamedTypeSymbol Boolean { get; }
+    public INamedTypeSymbol String { get; }
+    public INamedTypeSymbol DefaultParameterValueAttribute { get; }
+    public INamedTypeSymbol OptionalAttribute { get; }
+    public INamedTypeSymbol VbCompilerStringType { get; }
+}

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -24,7 +24,6 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
     private readonly HashSet<string> _extraUsingDirectives;
     private readonly HandledEventsAnalysis _handledEventsAnalysis;
     private readonly HashSet<string> _generatedNames = new();
-    private readonly INamedTypeSymbol _vbBooleanTypeSymbol;
     private readonly HashSet<ILocalSymbol> _localsToInlineInLoop;
     private readonly PerScopeState _perScopeState;
 
@@ -65,7 +64,6 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
         _perScopeState = typeContext.PerScopeState;
         var byRefParameterVisitor = new PerScopeStateVisitorDecorator(this, _perScopeState, semanticModel, _generatedNames);
         CommentConvertingVisitor = new CommentConvertingMethodBodyVisitor(byRefParameterVisitor);
-        _vbBooleanTypeSymbol = _semanticModel.Compilation.GetTypeByMetadataName("System.Boolean");
         _localsToInlineInLoop = localsToInlineInLoop;
     }
 
@@ -520,7 +518,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
     public override async Task<SyntaxList<StatementSyntax>> VisitSingleLineIfStatement(VBSyntax.SingleLineIfStatementSyntax node)
     {
         var condition = await node.Condition.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-        condition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Condition, condition, forceTargetType: _vbBooleanTypeSymbol);
+        condition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.Condition, condition, forceTargetType: CommonConversions.KnownTypes.Boolean);
         var block = SyntaxFactory.Block(await ConvertStatementsAsync(node.Statements));
         ElseClauseSyntax elseClause = null;
 
@@ -534,7 +532,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
     public override async Task<SyntaxList<StatementSyntax>> VisitMultiLineIfBlock(VBSyntax.MultiLineIfBlockSyntax node)
     {
         var condition = await node.IfStatement.Condition.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-        condition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.IfStatement.Condition, condition, forceTargetType: _vbBooleanTypeSymbol);
+        condition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(node.IfStatement.Condition, condition, forceTargetType: CommonConversions.KnownTypes.Boolean);
         var block = SyntaxFactory.Block(await ConvertStatementsAsync(node.Statements));
 
         var elseClause = await ConvertElseClauseAsync(node.ElseBlock);
@@ -553,7 +551,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
     {
         var elseBlock = SyntaxFactory.Block(await ConvertStatementsAsync(elseIf.Statements));
         var elseIfCondition = await elseIf.ElseIfStatement.Condition.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-        elseIfCondition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(elseIf.ElseIfStatement.Condition, elseIfCondition, forceTargetType: _vbBooleanTypeSymbol);
+        elseIfCondition = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(elseIf.ElseIfStatement.Condition, elseIfCondition, forceTargetType: CommonConversions.KnownTypes.Boolean);
         return (elseIfCondition, elseBlock);
     }
 

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -4049,4 +4049,52 @@ internal partial class StaticLocalConvertedToField
     }
 }");
     }
+
+    [Fact]
+    public async Task TestMissingByRefArgumentWithNoExplicitDefaultValueAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Imports System.Runtime.InteropServices
+
+Class MissingByRefArgumentWithNoExplicitDefaultValue
+    Sub S()
+        ByRefNoDefault()
+        OptionalByRefNoDefault()
+        OptionalByRefWithDefault()
+    End Sub
+
+    Private Sub ByRefNoDefault(ByRef str1 As String) : End Sub
+    Private Sub OptionalByRefNoDefault(<[Optional]> ByRef str2 As String) : End Sub
+    Private Sub OptionalByRefWithDefault(<[Optional], DefaultParameterValue(""a"")> ByRef str3 As String) : End Sub
+End Class", @"using System.Runtime.InteropServices;
+
+internal partial class MissingByRefArgumentWithNoExplicitDefaultValue
+{
+    public void S()
+    {
+        ByRefNoDefault();
+        string argstr2 = default;
+        OptionalByRefNoDefault(str2: ref argstr2);
+        string argstr3 = ""a"";
+        OptionalByRefWithDefault(str3: ref argstr3);
+    }
+
+    private void ByRefNoDefault(ref string str1)
+    {
+    }
+    private void OptionalByRefNoDefault([Optional] ref string str2)
+    {
+    }
+    private void OptionalByRefWithDefault([Optional][DefaultParameterValue(""a"")] ref string str3)
+    {
+    }
+}
+3 source compilation errors:
+BC30455: Argument not specified for parameter 'str1' of 'Private Sub ByRefNoDefault(ByRef str1 As String)'.
+BC30455: Argument not specified for parameter 'str2' of 'Private Sub OptionalByRefNoDefault(ByRef str2 As String)'.
+BC30455: Argument not specified for parameter 'str3' of 'Private Sub OptionalByRefWithDefault(ByRef str3 As String)'.
+1 target compilation errors:
+CS7036: There is no argument given that corresponds to the required formal parameter 'str1' of 'MissingByRefArgumentWithNoExplicitDefaultValue.ByRefNoDefault(ref string)'
+");
+    }
 }


### PR DESCRIPTION
### Problem
#1048: Interop method invocations with OptionalAttribute aren't converted

### Solution
* *Any comments on the approach taken, its consistency with surrounding code, etc.*
  I decided to leave compiler errors in code, so that `BC30455: Argument not specified for parameter...` becomes `CS7036: There is no argument given that corresponds to the required formal parameter...`.
* *Which part of this PR is most in need of attention/improvement?*
  1. I couldn't quite achieve above goal: VB.NET doesn't respect the `Optional` parameter (because it doesn't need to, I guess), so we have 3 compiler errors in the VB.NET code instead of 1 should we reference a C# assembly. This means the output generated looses some compiler errors -- I'm not quite sure if that's ok. We'd need to setup two different projects to have a proper test, which I'm not too keen on doing because of the problems with #1116.
  2. For parameters without `DefaultParameterValueAttribute`, I use `default` as initializer. I think this is ok...
  3. I'm using `_semanticModel.Compilation.GetTypeByMetadataName("System.Runtime.InteropServices.DefaultParameterValueAttribute");` to get the attribute class (to keep it consistent with other places). If it fails to find one, I'm assuming it's not present -- which isn't necessarily true, I think, if at all possible. Alternative would be something like this:
   ```cs
    //var attributeData = p.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.IncludeNullability.Equals(a.AttributeClass, defaultParameterValueAttribute));
    var attributeData = p.GetAttributes().FirstOrDefault(a => a.AttributeClass.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.Runtime.InteropServices.DefaultParameterValueAttribute");
    ```
    This is IMO marginally safer, removes a call to `GetTypeByMetadataName`, but is maybe uglier.
* [x] At least one test covering the code changed

