### PR TITLE
Differentiate between statics in setters and getters

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1544,6 +1544,10 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
 
         var sym = GetSymbolInfoInDocument<ISymbol>(node);
         if (sym is ILocalSymbol) {
+            if (sym.IsStatic && sym.ContainingSymbol is IMethodSymbol m && m.AssociatedSymbol is IPropertySymbol) {
+                qualifiedIdentifier = qualifiedIdentifier.WithParentPropertyAccessorKind(m.MethodKind.ToString());
+            }
+            
             var vbMethodBlock = node.Ancestors().OfType<VBasic.Syntax.MethodBlockBaseSyntax>().FirstOrDefault();
             if (vbMethodBlock != null &&
                 vbMethodBlock.MustReturn() &&

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1545,7 +1545,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         var sym = GetSymbolInfoInDocument<ISymbol>(node);
         if (sym is ILocalSymbol) {
             if (sym.IsStatic && sym.ContainingSymbol is IMethodSymbol m && m.AssociatedSymbol is IPropertySymbol) {
-                qualifiedIdentifier = qualifiedIdentifier.WithParentPropertyAccessorKind(m.MethodKind.ToString());
+                qualifiedIdentifier = qualifiedIdentifier.WithParentPropertyAccessorKind(m.MethodKind);
             }
             
             var vbMethodBlock = node.Ancestors().OfType<VBasic.Syntax.MethodBlockBaseSyntax>().FirstOrDefault();

--- a/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
+++ b/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
@@ -22,5 +22,5 @@ internal class HoistedFieldFromVbStaticVariable : IHoistedNode
     }
 
     public string FieldName => OriginalMethodName != null ? $"_{OriginalMethodName}_{OriginalVariableName}" : $"_{OriginalVariableName}";
-    public string PrefixedOriginalVariableName => PerScopeState.GetPrefixedName(OriginalParentAccessorKind.ToString(), OriginalVariableName);
+    public string PrefixedOriginalVariableName => PerScopeState.GetPrefixedName(OriginalParentAccessorKind == MethodKind.Ordinary ? "" : OriginalParentAccessorKind.ToString(), OriginalVariableName);
 }

--- a/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
+++ b/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
@@ -6,12 +6,12 @@ internal class HoistedFieldFromVbStaticVariable : IHoistedNode
 {
     public string OriginalMethodName { get; }
     public string OriginalVariableName { get; }
-    public string OriginalParentAccessorKind { get; }
+    public MethodKind OriginalParentAccessorKind { get; }
     public ExpressionSyntax Initializer { get; }
     public TypeSyntax Type { get; }
     public bool IsStatic { get; }
 
-    public HoistedFieldFromVbStaticVariable(string originalMethodName, string originalVariableName, string originalParentAccessorKind, ExpressionSyntax initializer, TypeSyntax type, bool isStatic)
+    public HoistedFieldFromVbStaticVariable(string originalMethodName, string originalVariableName, MethodKind originalParentAccessorKind, ExpressionSyntax initializer, TypeSyntax type, bool isStatic)
     {
         OriginalMethodName = originalMethodName;
         OriginalVariableName = originalVariableName;
@@ -22,5 +22,5 @@ internal class HoistedFieldFromVbStaticVariable : IHoistedNode
     }
 
     public string FieldName => OriginalMethodName != null ? $"_{OriginalMethodName}_{OriginalVariableName}" : $"_{OriginalVariableName}";
-    public string PrefixedOriginalVariableName => PerScopeState.GetPrefixedName(OriginalParentAccessorKind, OriginalVariableName);
+    public string PrefixedOriginalVariableName => PerScopeState.GetPrefixedName(OriginalParentAccessorKind.ToString(), OriginalVariableName);
 }

--- a/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
+++ b/CodeConverter/CSharp/HoistedFieldFromVbStaticVariable.cs
@@ -6,18 +6,21 @@ internal class HoistedFieldFromVbStaticVariable : IHoistedNode
 {
     public string OriginalMethodName { get; }
     public string OriginalVariableName { get; }
+    public string OriginalParentAccessorKind { get; }
     public ExpressionSyntax Initializer { get; }
     public TypeSyntax Type { get; }
     public bool IsStatic { get; }
 
-    public HoistedFieldFromVbStaticVariable(string originalMethodName, string originalVariableName, ExpressionSyntax initializer, TypeSyntax type, bool isStatic)
+    public HoistedFieldFromVbStaticVariable(string originalMethodName, string originalVariableName, string originalParentAccessorKind, ExpressionSyntax initializer, TypeSyntax type, bool isStatic)
     {
         OriginalMethodName = originalMethodName;
         OriginalVariableName = originalVariableName;
+        OriginalParentAccessorKind = originalParentAccessorKind;
         Initializer = initializer;
         Type = type;
         IsStatic = isStatic;
     }
 
     public string FieldName => OriginalMethodName != null ? $"_{OriginalMethodName}_{OriginalVariableName}" : $"_{OriginalVariableName}";
+    public string PrefixedOriginalVariableName => PerScopeState.GetPrefixedName(OriginalParentAccessorKind, OriginalVariableName);
 }

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -110,7 +110,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     string methodName;
                     SyntaxTokenList methodModifiers;
 
-                    string parentAccessorKind = null;
+                    MethodKind parentAccessorKind = MethodKind.Ordinary;
                     if (_methodNode is VBSyntax.MethodBlockSyntax methodBlock) {
                         var methodStatement = methodBlock.BlockStatement as VBSyntax.MethodStatementSyntax;
                         methodModifiers = methodStatement.Modifiers;
@@ -121,7 +121,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     } else if (_methodNode is VBSyntax.AccessorBlockSyntax accessorBlock) {
                         var propertyBlock = accessorBlock.Parent as VBSyntax.PropertyBlockSyntax;
                         methodName = propertyBlock.PropertyStatement.Identifier.Text;
-                        parentAccessorKind = accessorBlock.IsKind(VBasic.SyntaxKind.GetAccessorBlock) ? "PropertyGet" : "PropertySet";
+                        parentAccessorKind = accessorBlock.IsKind(VBasic.SyntaxKind.GetAccessorBlock) ? MethodKind.PropertyGet : MethodKind.PropertySet;
                         methodModifiers = propertyBlock.PropertyStatement.Modifiers;
                     } else {
                         throw new NotImplementedException(_methodNode.GetType() + " not implemented!");

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -110,6 +110,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     string methodName;
                     SyntaxTokenList methodModifiers;
 
+                    string parentAccessorKind = null;
                     if (_methodNode is VBSyntax.MethodBlockSyntax methodBlock) {
                         var methodStatement = methodBlock.BlockStatement as VBSyntax.MethodStatementSyntax;
                         methodModifiers = methodStatement.Modifiers;
@@ -120,13 +121,14 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     } else if (_methodNode is VBSyntax.AccessorBlockSyntax accessorBlock) {
                         var propertyBlock = accessorBlock.Parent as VBSyntax.PropertyBlockSyntax;
                         methodName = propertyBlock.PropertyStatement.Identifier.Text;
+                        parentAccessorKind = accessorBlock.IsKind(VBasic.SyntaxKind.GetAccessorBlock) ? "PropertyGet" : "PropertySet";
                         methodModifiers = propertyBlock.PropertyStatement.Modifiers;
                     } else {
                         throw new NotImplementedException(_methodNode.GetType() + " not implemented!");
                     }
 
                     var isVbShared = methodModifiers.Any(a => a.IsKind(VBasic.SyntaxKind.SharedKeyword));
-                    _perScopeState.HoistToTopLevel(new HoistedFieldFromVbStaticVariable(methodName, variable.Identifier.Text, initializeValue, decl.Declaration.Type, isVbShared));
+                    _perScopeState.HoistToTopLevel(new HoistedFieldFromVbStaticVariable(methodName, variable.Identifier.Text, parentAccessorKind, initializeValue, decl.Declaration.Type, isVbShared));
                 }
             } else {
                 var shouldPullVariablesBeforeLoop = _perScopeState.IsInsideLoop() && declarator.Initializer is null && declarator.AsClause is not VBSyntax.AsNewClauseSyntax;

--- a/CodeConverter/CSharp/PerScopeState.cs
+++ b/CodeConverter/CSharp/PerScopeState.cs
@@ -169,7 +169,7 @@ internal class PerScopeState
                 modifiers.Add(CS.SyntaxFactory.Token(SyntaxKind.StaticKeyword));
             }
             var fieldDecl = CS.SyntaxFactory.FieldDeclaration(CS.SyntaxFactory.List<AttributeListSyntax>(), CS.SyntaxFactory.TokenList(modifiers), decl);
-            if (!string.IsNullOrEmpty(field.OriginalParentAccessorKind)) {
+            if (field.OriginalParentAccessorKind != MethodKind.Ordinary) {
                 fieldDecl = fieldDecl.WithParentPropertyAccessorKind(field.OriginalParentAccessorKind);
             }
             declarations.Add(fieldDecl);

--- a/CodeConverter/Common/AnnotationConstants.cs
+++ b/CodeConverter/Common/AnnotationConstants.cs
@@ -12,6 +12,7 @@ internal static class AnnotationConstants
     public const string SourceEndLineAnnotationKind = "CodeConverter.SourceEndLine";
     public const string LeadingTriviaAlreadyMappedAnnotation = nameof(CodeConverter) + "." + nameof(LeadingTriviaAlreadyMappedAnnotation);
     public const string TrailingTriviaAlreadyMappedAnnotation = nameof(CodeConverter) + "." + nameof(TrailingTriviaAlreadyMappedAnnotation);
+    public const string ParentPropertyAccessorKindAnnotation = nameof(CodeConverter) + "." + nameof(ParentPropertyAccessorKindAnnotation);
 
     private static string AsString(LinePosition position)
     {
@@ -39,5 +40,10 @@ internal static class AnnotationConstants
     public static SyntaxAnnotation SourceEndLine(FileLinePositionSpan origLinespan)
     {
         return new SyntaxAnnotation(SourceEndLineAnnotationKind, origLinespan.EndLinePosition.Line.ToString(CultureInfo.InvariantCulture));
+    }
+
+    public static SyntaxAnnotation ParentPropertyAccessorKind(string accessorKind)
+    {
+        return new SyntaxAnnotation(ParentPropertyAccessorKindAnnotation, accessorKind);
     }
 }

--- a/CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -173,6 +173,11 @@ internal static class SyntaxNodeExtensions
         return node.WithoutAnnotations(AnnotationConstants.SourceStartLineAnnotationKind).WithoutAnnotations(AnnotationConstants.SourceEndLineAnnotationKind);
     }
 
+    public static T WithParentPropertyAccessorKind<T>(this T node, string accessorKind) where T : SyntaxNode
+    {
+        return node.WithAdditionalAnnotations(AnnotationConstants.ParentPropertyAccessorKind(accessorKind));
+    }
+
     private static bool IsBlockParent(SyntaxNode converted, SyntaxToken lastCsConvertedToken)
     {
         return lastCsConvertedToken.Parent == converted || lastCsConvertedToken.Parent is BlockSyntax b && b.Parent == converted;

--- a/CodeConverter/Util/SyntaxNodeExtensions.cs
+++ b/CodeConverter/Util/SyntaxNodeExtensions.cs
@@ -173,9 +173,9 @@ internal static class SyntaxNodeExtensions
         return node.WithoutAnnotations(AnnotationConstants.SourceStartLineAnnotationKind).WithoutAnnotations(AnnotationConstants.SourceEndLineAnnotationKind);
     }
 
-    public static T WithParentPropertyAccessorKind<T>(this T node, string accessorKind) where T : SyntaxNode
+    public static T WithParentPropertyAccessorKind<T>(this T node, MethodKind accessorKind) where T : SyntaxNode
     {
-        return node.WithAdditionalAnnotations(AnnotationConstants.ParentPropertyAccessorKind(accessorKind));
+        return node.WithAdditionalAnnotations(AnnotationConstants.ParentPropertyAccessorKind(accessorKind.ToString()));
     }
 
     private static bool IsBlockParent(SyntaxNode converted, SyntaxToken lastCsConvertedToken)

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -673,6 +673,45 @@ internal partial class SurroundingClass
     }
 
     [Fact]
+    public async Task StaticLocalsInPropertyGetterAndSetterAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Public Property Prop As String
+    Get
+        Static b As Boolean
+        b = True
+    End Get
+
+    Set(ByVal s As String)
+        Static b As Boolean
+        b = False
+    End Set
+End Property
+", @"
+internal partial class SurroundingClass
+{
+    private bool _Prop_b;
+    private bool _Prop_b1;
+
+    public string Prop
+    {
+        get
+        {
+            _Prop_b = true;
+            return default;
+        }
+
+        set
+        {
+            _Prop_b1 = false;
+        }
+    }
+
+}");
+    }
+
+    [Fact]
     public async Task TestReadOnlyAndWriteOnlyParametrizedPropertyAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
### Problem
#1054: Statics with same name in getter and setter cause a CONVERSION ERROR

### Solution
* _Any comments on the approach taken, its consistency with surrounding code, etc._
  The solution is basically to store accessor kind in every `IdentifierNameSyntax` of a static, and to use that value later when doing the renaming.
* _Which part of this PR is most in need of attention/improvement?_
  Currently, it creates `_Prop_b` and `_Prop_b1`, which is fine, but it would be nicer to get `_Prop_Get_b` and `_Prop_Set_b` instead. This is easy to achieve if *every* static from a property would get that infix. It's a bit more cumbersome if only those with duplicate name would get one.
* [x] At least one test covering the code changed

