### PR TITLE
Don't write back into a method call when it's ByRef argument

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1884,14 +1884,14 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
         RefConversion GetRefConversion(VBSyntax.ExpressionSyntax expression)
         {
             var symbolInfo = GetSymbolInfoInDocument<ISymbol>(expression);
-            if (symbolInfo is IPropertySymbol propertySymbol
-            // a property in VB.NET code can be ReturnsByRef if it's defined in a C# assembly the VB.NET code references
-            && !propertySymbol.ReturnsByRef && !propertySymbol.ReturnsByRefReadonly) {
+            if (symbolInfo is IPropertySymbol { ReturnsByRef: false, ReturnsByRefReadonly: false } propertySymbol) {
+                // a property in VB.NET code can be ReturnsByRef if it's defined in a C# assembly the VB.NET code references
                 return propertySymbol.IsReadOnly ? RefConversion.PreAssigment : RefConversion.PreAndPostAssignment;
             }
             else if (symbolInfo is IFieldSymbol { IsConst: true } or ILocalSymbol { IsConst: true }) {
                 return RefConversion.PreAssigment;
-            } else if (symbolInfo is IMethodSymbol) {
+            } else if (symbolInfo is IMethodSymbol { ReturnsByRef: false, ReturnsByRefReadonly: false }) {
+                // a method in VB.NET code can be ReturnsByRef if it's defined in a C# assembly the VB.NET code references
                 return RefConversion.PreAssigment;
             }
 

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -1891,6 +1891,8 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
             }
             else if (symbolInfo is IFieldSymbol { IsConst: true } or ILocalSymbol { IsConst: true }) {
                 return RefConversion.PreAssigment;
+            } else if (symbolInfo is IMethodSymbol) {
+                return RefConversion.PreAssigment;
             }
 
             if (DeclaredInUsing(symbolInfo)) return RefConversion.PreAssigment;

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -4128,6 +4128,30 @@ internal partial class RefConstArgument
     }
 
     [Fact]
+    public async Task TestRefFunctionCallNoParenthesesArgumentAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class RefFunctionCallArgument
+    Sub S(ByRef o As Object)
+        S(GetI)
+    End Sub
+    Function GetI() As Integer : End Function
+End Class", @"
+internal partial class RefFunctionCallArgument
+{
+    public void S(ref object o)
+    {
+        object argo = GetI();
+        S(ref argo);
+    }
+    public int GetI()
+    {
+        return default;
+    }
+}");
+    }
+
+    [Fact]
     public async Task TestMissingByRefArgumentWithNoExplicitDefaultValueAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(


### PR DESCRIPTION
### Problem
ByRef argument w/o parentheses is treated like a writable variable, even if it's a method:

```vb
Sub S(ByRef i as Object)
    M(GetI)
End Sub
Function GetI() As Integer : End Function
```
becomes
```cs
public bool M(ref object i)
{
    object argi1 = GetI();
    M(ref argi1);
    GetI() = argi1; //compiler error
}

public int GetI()
{
    return default;
}
```

### Solution
* _Any comments on the approach taken, its consistency with surrounding code, etc._
  The adjustment itself is very minor: return `RefConversion.PreAssigment` from `GetRefConversion` when the symbol is an `IMethodSymbol`.
* _Which part of this PR is most in need of attention/improvement?_
  I've excluded `ReturnsByRef == false && ReturnsByRefReadonly == false`, same as with properties. This generates code like this atm:
   ```cs
   object argi2 = byrefThis.RefProp;
   M(ref argi2);
   byrefThis.RefProp = Conversions.ToInteger(argi2);

   object argi3 = byrefThis.GetRefVal();
   M(ref argi3);
   byrefThis.GetRefVal() = Conversions.ToInteger(argi3);
   ```
   I haven't added any tests for this though, because of the whole problematic with solution tests involving C# ref returns from VB.NET.

   Also, this code isn't necessarily correct if the property or method involved has side effects. It should use a temporary ref variable, something like this:
   ```cs
   ref int tmp = ref byrefThis.GetRefVal();
   object argi3 = tmp;
   M(ref argi3);
   tmp = (int)(argi3);
   ```
   Unless there is an easy way to do that, I'd say it's out of scope of this PR.
* [x] At least one test covering the code changed

