### PR TITLE
convert `Select Case [object]` using `Operators.ConditionalCompareObject...`

### DIFF
--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 using Microsoft.VisualBasic;
 using Microsoft.VisualBasic.CompilerServices;
+using ComparisonKind = ICSharpCode.CodeConverter.CSharp.VisualBasicEqualityComparison.ComparisonKind;
 
 namespace ICSharpCode.CodeConverter.CSharp;
 
@@ -916,7 +917,7 @@ internal class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSha
                 omitConversion = true; // Already handled within for the appropriate types (rhs can become int in comparison)
                 break;
             case VisualBasicEqualityComparison.RequiredType.Object:
-                return _visualBasicEqualityComparison.GetFullExpressionForVbObjectComparison(lhs, rhs, node.IsKind(VBasic.SyntaxKind.NotEqualsExpression));
+                return _visualBasicEqualityComparison.GetFullExpressionForVbObjectComparison(lhs, rhs, ComparisonKind.Equals, node.IsKind(VBasic.SyntaxKind.NotEqualsExpression));
         }
 
         var lhsTypeIgnoringNullable = lhsTypeInfo.Type.GetNullableUnderlyingType() ?? lhsTypeInfo.Type;

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -786,8 +786,6 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     labels.Add(SyntaxFactory.DefaultSwitchLabel());
                 } else if (c is VBSyntax.RelationalCaseClauseSyntax relational) {
 
-                    var varName = CommonConversions.CsEscapedIdentifier(GetUniqueVariableNameInScope(node, "case"));
-                    ExpressionSyntax csLeft = ValidSyntaxFactory.IdentifierName(varName);
                     var operatorKind = VBasic.VisualBasicExtensions.Kind(relational);
                     var csRelationalValue = await relational.Value.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
                     CasePatternSwitchLabelSyntax caseSwitchLabelSyntax;
@@ -795,6 +793,8 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                         caseSwitchLabelSyntax = WrapInCasePatternSwitchLabelSyntax(node, relational.Value, csRelationalValue, false, operatorKind);
                     }
                     else {
+                        var varName = CommonConversions.CsEscapedIdentifier(GetUniqueVariableNameInScope(node, "case"));
+                        ExpressionSyntax csLeft = ValidSyntaxFactory.IdentifierName(varName);
                         csRelationalValue = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(relational.Value, csRelationalValue);
                         var binaryExp = SyntaxFactory.BinaryExpression(operatorKind.ConvertToken(), csLeft, csRelationalValue);
                         caseSwitchLabelSyntax = VarWhen(varName, binaryExp);

--- a/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
+++ b/CodeConverter/CSharp/MethodBodyExecutableStatementVisitor.cs
@@ -7,6 +7,7 @@ using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using Microsoft.CodeAnalysis.Text;
 using ICSharpCode.CodeConverter.Util.FromRoslyn;
 using ICSharpCode.CodeConverter.VB;
+using ComparisonKind = ICSharpCode.CodeConverter.CSharp.VisualBasicEqualityComparison.ComparisonKind;
 
 namespace ICSharpCode.CodeConverter.CSharp;
 
@@ -744,7 +745,8 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
         var csSwitchExpr = await vbExpr.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
         csSwitchExpr = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(vbExpr, csSwitchExpr);
         var switchExprTypeInfo = _semanticModel.GetTypeInfo(vbExpr);
-        var isStringComparison = switchExprTypeInfo.ConvertedType?.SpecialType == SpecialType.System_String || switchExprTypeInfo.ConvertedType?.IsArrayOf(SpecialType.System_Char) == true;
+        var isObjectComparison = switchExprTypeInfo.ConvertedType.SpecialType == SpecialType.System_Object;
+        var isStringComparison = !isObjectComparison && switchExprTypeInfo.ConvertedType?.SpecialType == SpecialType.System_String || switchExprTypeInfo.ConvertedType?.IsArrayOf(SpecialType.System_Char) == true;
         var caseInsensitiveStringComparison = vbEquality.OptionCompareTextCaseInsensitive &&
                                               isStringComparison;
         if (isStringComparison) {
@@ -772,9 +774,11 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     var isBooleanCase = caseTypeInfo.Type?.SpecialType == SpecialType.System_Boolean;
                     bool enumRelated = IsEnumOrNullableEnum(switchExprTypeInfo.ConvertedType) || IsEnumOrNullableEnum(caseTypeInfo.Type);
                     bool convertingEnum = IsEnumOrNullableEnum(switchExprTypeInfo.ConvertedType) ^ IsEnumOrNullableEnum(caseTypeInfo.Type);
-                    var csExpressionToUse = !isBooleanCase && (convertingEnum || !enumRelated && correctTypeExpressionSyntax.IsConst) ? correctTypeExpressionSyntax.Expr : originalExpressionSyntax;
+                    var csExpressionToUse = !isObjectComparison && !isBooleanCase && (convertingEnum || !enumRelated && correctTypeExpressionSyntax.IsConst)
+                        ? correctTypeExpressionSyntax.Expr
+                        : originalExpressionSyntax;
 
-                    var caseSwitchLabelSyntax = !wrapForStringComparison && correctTypeExpressionSyntax.IsConst && notAlreadyUsed
+                    var caseSwitchLabelSyntax = !isObjectComparison && !wrapForStringComparison && correctTypeExpressionSyntax.IsConst && notAlreadyUsed
                         ? (SwitchLabelSyntax)SyntaxFactory.CaseSwitchLabel(csExpressionToUse)
                         : WrapInCasePatternSwitchLabelSyntax(node, s.Value, csExpressionToUse, isBooleanCase);
                     labels.Add(caseSwitchLabelSyntax);
@@ -786,18 +790,37 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
                     ExpressionSyntax csLeft = ValidSyntaxFactory.IdentifierName(varName);
                     var operatorKind = VBasic.VisualBasicExtensions.Kind(relational);
                     var csRelationalValue = await relational.Value.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-                    csRelationalValue = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(relational.Value, csRelationalValue);
-                    var binaryExp = SyntaxFactory.BinaryExpression(operatorKind.ConvertToken(), csLeft, csRelationalValue);
-                    labels.Add(VarWhen(varName, binaryExp));
+                    CasePatternSwitchLabelSyntax caseSwitchLabelSyntax;
+                    if (isObjectComparison) {
+                        caseSwitchLabelSyntax = WrapInCasePatternSwitchLabelSyntax(node, relational.Value, csRelationalValue, false, operatorKind);
+                    }
+                    else {
+                        csRelationalValue = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(relational.Value, csRelationalValue);
+                        var binaryExp = SyntaxFactory.BinaryExpression(operatorKind.ConvertToken(), csLeft, csRelationalValue);
+                        caseSwitchLabelSyntax = VarWhen(varName, binaryExp);
+                    }
+                    labels.Add(caseSwitchLabelSyntax);
                 } else if (c is VBSyntax.RangeCaseClauseSyntax range) {
                     var varName = CommonConversions.CsEscapedIdentifier(GetUniqueVariableNameInScope(node, "case"));
-                    ExpressionSyntax csLeft = ValidSyntaxFactory.IdentifierName(varName);
+                    ExpressionSyntax csCaseVar = ValidSyntaxFactory.IdentifierName(varName);
                     var lowerBound = await range.LowerBound.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-                    lowerBound = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(range.LowerBound, lowerBound);
-                    var lowerBoundCheck = SyntaxFactory.BinaryExpression(SyntaxKind.LessThanOrEqualExpression, lowerBound, csLeft);
+                    ExpressionSyntax lowerBoundCheck;
+                    if (isObjectComparison) {
+                        var caseTypeInfo = _semanticModel.GetTypeInfo(range.LowerBound);
+                        lowerBoundCheck = ComparisonAdjustedForStringComparison(node, range.LowerBound, caseTypeInfo, lowerBound, csCaseVar, switchExprTypeInfo, ComparisonKind.LessThanOrEqual);
+                    } else {
+                        lowerBound = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(range.LowerBound, lowerBound);
+                        lowerBoundCheck = SyntaxFactory.BinaryExpression(SyntaxKind.LessThanOrEqualExpression, lowerBound, csCaseVar);
+                    }
                     var upperBound = await range.UpperBound.AcceptAsync<ExpressionSyntax>(_expressionVisitor);
-                    upperBound = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(range.UpperBound, upperBound);
-                    var upperBoundCheck = SyntaxFactory.BinaryExpression(SyntaxKind.LessThanOrEqualExpression, csLeft, upperBound);
+                    ExpressionSyntax upperBoundCheck;
+                    if (isObjectComparison) {
+                        var caseTypeInfo = _semanticModel.GetTypeInfo(range.UpperBound);
+                        upperBoundCheck = ComparisonAdjustedForStringComparison(node, range.UpperBound, switchExprTypeInfo, csCaseVar, upperBound, caseTypeInfo, ComparisonKind.LessThanOrEqual);
+                    } else {
+                        upperBound = CommonConversions.TypeConversionAnalyzer.AddExplicitConversion(range.UpperBound, upperBound);
+                        upperBoundCheck = SyntaxFactory.BinaryExpression(SyntaxKind.LessThanOrEqualExpression, csCaseVar, upperBound);
+                    }
                     var withinBounds = SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, lowerBoundCheck, upperBoundCheck);
                     labels.Add(VarWhen(varName, withinBounds));
                 } else {
@@ -916,7 +939,7 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
         return symbol.MatchesKind(SymbolKind.Parameter, SymbolKind.Local) && await CommonConversions.Document.Project.Solution.IsNeverWrittenAsync(symbol, allowedLocation);
     }
 
-    private CasePatternSwitchLabelSyntax WrapInCasePatternSwitchLabelSyntax(VBSyntax.SelectBlockSyntax node, VBSyntax.ExpressionSyntax vbCase, ExpressionSyntax expression, bool treatAsBoolean = false)
+    private CasePatternSwitchLabelSyntax WrapInCasePatternSwitchLabelSyntax(VBSyntax.SelectBlockSyntax node, VBSyntax.ExpressionSyntax vbCase, ExpressionSyntax expression, bool treatAsBoolean = false, VBasic.SyntaxKind caseClauseKind = VBasic.SyntaxKind.CaseEqualsClause)
     {
         var typeInfo = _semanticModel.GetTypeInfo(node.SelectStatement.Expression);
 
@@ -930,27 +953,47 @@ internal class MethodBodyExecutableStatementVisitor : VBasic.VisualBasicSyntaxVi
             patternMatch = ValidSyntaxFactory.VarPattern(varName);
             ExpressionSyntax csLeft = ValidSyntaxFactory.IdentifierName(varName), csRight = expression;
             var caseTypeInfo = _semanticModel.GetTypeInfo(vbCase);
-            expression = EqualsAdjustedForStringComparison(node, vbCase, typeInfo, csLeft, csRight, caseTypeInfo);
+            expression = ComparisonAdjustedForStringComparison(node, vbCase, typeInfo, csLeft, csRight, caseTypeInfo, GetComparisonKind(caseClauseKind));
         }
 
         var colonToken = SyntaxFactory.Token(SyntaxKind.ColonToken);
         return SyntaxFactory.CasePatternSwitchLabel(patternMatch, SyntaxFactory.WhenClause(expression), colonToken);
     }
 
-    private ExpressionSyntax EqualsAdjustedForStringComparison(VBSyntax.SelectBlockSyntax node, VBSyntax.ExpressionSyntax vbCase, TypeInfo lhsTypeInfo, ExpressionSyntax csLeft, ExpressionSyntax csRight, TypeInfo rhsTypeInfo)
+    private ComparisonKind GetComparisonKind(VBasic.SyntaxKind caseClauseKind) => caseClauseKind switch {
+        VBasic.SyntaxKind.CaseLessThanClause => ComparisonKind.LessThan,
+        VBasic.SyntaxKind.CaseLessThanOrEqualClause => ComparisonKind.LessThanOrEqual,
+        VBasic.SyntaxKind.CaseEqualsClause => ComparisonKind.Equals,
+        VBasic.SyntaxKind.CaseNotEqualsClause => ComparisonKind.NotEquals,
+        VBasic.SyntaxKind.CaseGreaterThanOrEqualClause => ComparisonKind.GreaterThanOrEqual,
+        VBasic.SyntaxKind.CaseGreaterThanClause => ComparisonKind.GreaterThan,
+        _ => throw new ArgumentOutOfRangeException(nameof(caseClauseKind), caseClauseKind, null)
+    };
+
+    private ExpressionSyntax ComparisonAdjustedForStringComparison(VBSyntax.SelectBlockSyntax node, VBSyntax.ExpressionSyntax vbCase, TypeInfo lhsTypeInfo, ExpressionSyntax csLeft, ExpressionSyntax csRight, TypeInfo rhsTypeInfo, ComparisonKind comparisonKind)
     {
         var vbEquality = CommonConversions.VisualBasicEqualityComparison;
         switch (_visualBasicEqualityComparison.GetObjectEqualityType(lhsTypeInfo, rhsTypeInfo)) {
             case VisualBasicEqualityComparison.RequiredType.Object:
-                return vbEquality.GetFullExpressionForVbObjectComparison(csLeft, csRight);
+                return vbEquality.GetFullExpressionForVbObjectComparison(csLeft, csRight, comparisonKind);
             case VisualBasicEqualityComparison.RequiredType.StringOnly:
                 // We know lhs isn't null, because we always coalesce it in the switch expression
                 (csLeft, csRight) = vbEquality
                     .AdjustForVbStringComparison(node.SelectStatement.Expression, csLeft, lhsTypeInfo, true, vbCase, csRight, rhsTypeInfo, false);
                 break;
         }
-        return SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, csLeft, csRight);
+        return SyntaxFactory.BinaryExpression(GetSyntaxKind(comparisonKind), csLeft, csRight);
     }
+
+    private CS.SyntaxKind GetSyntaxKind(ComparisonKind comparisonKind) => comparisonKind switch {
+        ComparisonKind.LessThan => CS.SyntaxKind.LessThanExpression,
+        ComparisonKind.LessThanOrEqual => CS.SyntaxKind.LessThanOrEqualExpression,
+        ComparisonKind.Equals => CS.SyntaxKind.EqualsExpression,
+        ComparisonKind.NotEquals => CS.SyntaxKind.NotEqualsExpression,
+        ComparisonKind.GreaterThanOrEqual => CS.SyntaxKind.GreaterThanOrEqualExpression,
+        ComparisonKind.GreaterThan => CS.SyntaxKind.GreaterThanExpression,
+        _ => throw new ArgumentOutOfRangeException(nameof(comparisonKind), comparisonKind, null)
+    };
 
     public override async Task<SyntaxList<StatementSyntax>> VisitWithBlock(VBSyntax.WithBlockSyntax node)
     {

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -2297,6 +2297,73 @@ public partial class Test
     }
 
     [Fact]
+    public async Task SelectCaseObjectCaseIntegerAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Public Class SelectObjectCaseIntegerTest
+    Sub S()
+        Dim o As Object
+        Dim j As Integer
+        o = 2.0
+        Select Case o
+            Case 1
+                j = 1
+            Case 2
+                j = 2
+            Case 3 To 4
+                j = 3
+            Case > 4
+                j = 4
+            Case Else
+                j = -1
+        End Select
+    End Sub
+End Class", @"using Microsoft.VisualBasic.CompilerServices; // Install-Package Microsoft.VisualBasic
+
+public partial class SelectObjectCaseIntegerTest
+{
+    public void S()
+    {
+        object o;
+        int j;
+        o = 2.0d;
+        switch (o)
+        {
+            case var @case when Operators.ConditionalCompareObjectEqual(@case, 1, false):
+                {
+                    j = 1;
+                    break;
+                }
+            case var case1 when Operators.ConditionalCompareObjectEqual(case1, 2, false):
+                {
+                    j = 2;
+                    break;
+                }
+            case var case2 when Operators.ConditionalCompareObjectLessEqual(3, case2, false) && Operators.ConditionalCompareObjectLessEqual(case2, 4, false):
+                {
+                    j = 3;
+                    break;
+                }
+            case var case4 when Operators.ConditionalCompareObjectGreater(case4, 4, false):
+                {
+                    j = 4;
+                    break;
+                }
+
+            default:
+                {
+                    j = -1;
+                    break;
+                }
+        }
+    }
+}
+1 target compilation errors:
+CS0825: The contextual keyword 'var' may only appear within a local variable declaration or in script code");
+        //BUG: Correct textual output, but requires var pattern syntax construct not available before CodeAnalysis 3
+    }
+
+    [Fact]
     public async Task TupleAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -2344,7 +2344,7 @@ public partial class SelectObjectCaseIntegerTest
                     j = 3;
                     break;
                 }
-            case var case4 when Operators.ConditionalCompareObjectGreater(case4, 4, false):
+            case var case3 when Operators.ConditionalCompareObjectGreater(case3, 4, false):
                 {
                     j = 4;
                     break;


### PR DESCRIPTION
### Problem
#1100: `Select Case [object]` can have incorrect converted code

### Solution
* _Any comments on the approach taken, its consistency with surrounding code, etc._
   `GetFullExpressionForVbObjectComparison` now has a `ComparisonKind` parameter (new enum).
   `VisitSelectBlock` now checks if expression type is object first, in which case  different code is generated.
* _Which part of this PR is most in need of attention/improvement?_
   * `ComparisonKind` has `Unknown` value, which might not be necessary - I added it in case something goes terribly wrong.
   * `ComparisonAdjustedForStringComparison()` (renamed from `EqualsAdjustedForStringComparison()`) has `return SyntaxFactory.BinaryExpression(GetSyntaxKind(comparisonKind), csLeft, csRight);` for the non-Object case. With how the code currently looks like, the `comparisonKind` will always be `Equals` here (i.e. the call to `GetSyntaxKind(comparisonKind)` is unnecessary). I've added it for completeness sake, because otherwise the method could return unexpected ExpressionSyntax should it ever be used somewhere else.
* [x] At least one test covering the code changed

