### PR TITLE
Set the DefaultThreadCurrentUICulture to a specific culture, asserted error language consistency

### DIFF
--- a/Tests/TestRunners/ConverterTestBase.cs
+++ b/Tests/TestRunners/ConverterTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.VisualBasic;
 using Xunit;
 using Xunit.Sdk;
+using System.Globalization;
 
 namespace ICSharpCode.CodeConverter.Tests.TestRunners;
 
@@ -28,6 +29,7 @@ public class ConverterTestBase
 
     public ConverterTestBase(string rootNamespace = null)
     {
+        CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
         _rootNamespace = rootNamespace;
         var options = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
             .WithOptionExplicit(true)


### PR DESCRIPTION
### Problem
#1145 

### Solution
By setting DefaultThreadCurrentUICulture to CultureInfo.InvariantCulture, in the base class of the unit tests, it ensure that the asserted build error text and actual error text will be in the same language



