### PR TITLE
Fixed conversion of large uint/ulong/long hex literals

### DIFF
--- a/CodeConverter/CSharp/LiteralConversions.cs
+++ b/CodeConverter/CSharp/LiteralConversions.cs
@@ -59,9 +59,9 @@ internal static class LiteralConversions
                 return SyntaxFactory.LiteralExpression(CSSyntaxKind.CharacterLiteralExpression, SyntaxFactory.Literal(c));
             case DateTime dt:
             {
-                    var valueToOutput = dt.Date.Equals(dt) ? dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    return SyntaxFactory.ParseExpression("DateTime.Parse(\"" + valueToOutput + "\")");
-                }
+                var valueToOutput = dt.Date.Equals(dt) ? dt.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) : dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                return SyntaxFactory.ParseExpression("DateTime.Parse(\"" + valueToOutput + "\")");
+            }
             default:
                 throw new ArgumentOutOfRangeException(nameof(value), value, null);
         }

--- a/Tests/CSharp/SpecialConversionTests.cs
+++ b/Tests/CSharp/SpecialConversionTests.cs
@@ -220,6 +220,25 @@ public partial class Issue483
     }
 
     [Fact]
+    public async Task Issue1147_LargeNumericHexAndBinaryLiteralsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+Public Class Issue1147
+    Private Const LargeUInt As UInteger = &HFFFFFFFEUI
+    Private Const LargeULong As ULong = &HFFFFFFFFFFFFFFFEUL       
+    Private Const LargeLong As Long = &HFFFFFFFFFFFFFFFEL
+End Class", @"
+public partial class Issue1147
+{
+    private const uint LargeUInt = 0xFFFFFFFEU;
+    private const ulong LargeULong = 0xFFFFFFFFFFFFFFFEUL;
+    private const long LargeLong = 0xFFFFFFFFFFFFFFFEL;
+}");
+    }
+
+
+    [Fact]
     public async Task TestConstCharacterConversionsAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"Imports System.Data

--- a/Tests/CSharp/SpecialConversionTests.cs
+++ b/Tests/CSharp/SpecialConversionTests.cs
@@ -220,20 +220,22 @@ public partial class Issue483
     }
 
     [Fact]
-    public async Task Issue1147_LargeNumericHexAndBinaryLiteralsAsync()
+    public async Task Issue1147_LargeNumericHexLiteralsAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(
             @"
 Public Class Issue1147
     Private Const LargeUInt As UInteger = &HFFFFFFFEUI
-    Private Const LargeULong As ULong = &HFFFFFFFFFFFFFFFEUL       
+    Private Const LargeULong As ULong = &HFFFFFFFFFFFFFFFEUL
+    Private Const LargeInt As Integer = &HFFFFFFFE
     Private Const LargeLong As Long = &HFFFFFFFFFFFFFFFEL
 End Class", @"
 public partial class Issue1147
 {
     private const uint LargeUInt = 0xFFFFFFFEU;
     private const ulong LargeULong = 0xFFFFFFFFFFFFFFFEUL;
-    private const long LargeLong = 0xFFFFFFFFFFFFFFFEL;
+    private const int LargeInt = unchecked((int)0xFFFFFFFE);
+    private const long LargeLong = unchecked((long)0xFFFFFFFFFFFFFFFE);
 }");
     }
 


### PR DESCRIPTION
### Problem
https://github.com/icsharpcode/CodeConverter/issues/1147 (Edit: Issue is duplicate of reopened https://github.com/icsharpcode/CodeConverter/issues/754)

Hex literals of numeric types uint, ulong and long with larger values than int.MaxValue failed to convert as there was a special case for int hex literals, where the numeric value is parsed to an int causing a wrong conversion.


### Solution
Restricting this special case (8 digit hex literal) to values of type int only.

https://github.com/icsharpcode/CodeConverter/issues/1115 resolved issue https://github.com/icsharpcode/CodeConverter/issues/1064 for integer values but long hex literals (16 digit hex literal) seem to have the same issue:

0xFFFFFFFFFFFFFFFEL is interpreted as uint64 instead of int64.

So this PR also applies the same solution to convert

`
Private Const LargeLong As Long = &HFFFFFFFFFFFFFFFEL
`
to
`
private const long LargeLong = unchecked((long)0xFFFFFFFFFFFFFFFE);
`

