### PR TITLE
AddressOf does not wrap compatible signatures in lambdas anymore

### DIFF
--- a/CodeConverter/Util/FromRoslyn/IMethodSymbolExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/IMethodSymbolExtensions.cs
@@ -23,7 +23,7 @@ internal static class IMethodSymbolExtensions
             return false;
         }
 
-        if (!method.ReturnType.InheritsFromOrEquals(invoke.ReturnType)) {
+        if (!method.ReturnType.InheritsFromOrEquals(invoke.ReturnType, true)) {
             return false;
         }
 

--- a/CodeConverter/Util/FromRoslyn/IMethodSymbolExtensions.cs
+++ b/CodeConverter/Util/FromRoslyn/IMethodSymbolExtensions.cs
@@ -28,7 +28,7 @@ internal static class IMethodSymbolExtensions
         }
 
         for (var i = 0; i < method.Parameters.Length; i++) {
-            if (!invoke.Parameters[i].Type.InheritsFromOrEquals(method.Parameters[i].Type)) {
+            if (!invoke.Parameters[i].Type.InheritsFromOrEquals(method.Parameters[i].Type, true)) {
                 return false;
             }
         }

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -1451,6 +1451,7 @@ Public Class Issue1148
     Public Shared FuncBaseClass As Func(Of TestBaseObjClass) = AddressOf FunctionReturningClass
     Public Shared FuncInterface As Func(Of ITestObj) = AddressOf FunctionReturningClass
     Public Shared FuncInterfaceParam As Func(Of ITestObj, ITestObj) = AddressOf CastObj
+    Public Shared FuncClassParam As Func(Of TestObjClass, ITestObj) = AddressOf CastObj
 
     Public Shared Function FunctionReturningClass() As TestObjClass
         Return New TestObjClass()
@@ -1481,6 +1482,7 @@ public partial class Issue1148
     public static Func<TestBaseObjClass> FuncBaseClass = FunctionReturningClass;
     public static Func<ITestObj> FuncInterface = FunctionReturningClass;
     public static Func<ITestObj, ITestObj> FuncInterfaceParam = CastObj;
+    public static Func<TestObjClass, ITestObj> FuncClassParam = CastObj;
 
     public static TestObjClass FunctionReturningClass()
     {

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -1441,6 +1441,74 @@ internal partial class TestClass
     }
 
     [Fact]
+    public async Task Issue1148_AddressOfSignatureCompatibilityAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Imports System
+
+Public Class Issue1148
+    Public Shared FuncClass As Func(Of TestObjClass) = AddressOf FunctionReturningClass
+    Public Shared FuncBaseClass As Func(Of TestBaseObjClass) = AddressOf FunctionReturningClass
+    Public Shared FuncInterface As Func(Of ITestObj) = AddressOf FunctionReturningClass
+    Public Shared FuncInterfaceParam As Func(Of ITestObj, ITestObj) = AddressOf CastObj
+
+    Public Shared Function FunctionReturningClass() As TestObjClass
+        Return New TestObjClass()
+    End Function
+
+    Public Shared Function CastObj(obj As ITestObj) As TestObjClass
+        Return CType(obj, TestObjClass)
+    End Function
+
+End Class
+
+Public Class TestObjClass
+    Inherits TestBaseObjClass
+    Implements ITestObj
+End Class
+
+Public Class TestBaseObjClass
+End Class
+
+Public Interface ITestObj
+End Interface
+", @"
+using System;
+
+public partial class Issue1148
+{
+    public static Func<TestObjClass> FuncClass = FunctionReturningClass;
+    public static Func<TestBaseObjClass> FuncBaseClass = FunctionReturningClass;
+    public static Func<ITestObj> FuncInterface = FunctionReturningClass;
+    public static Func<ITestObj, ITestObj> FuncInterfaceParam = CastObj;
+
+    public static TestObjClass FunctionReturningClass()
+    {
+        return new TestObjClass();
+    }
+
+    public static TestObjClass CastObj(ITestObj obj)
+    {
+        return (TestObjClass)obj;
+    }
+
+}
+
+public partial class TestObjClass : TestBaseObjClass, ITestObj
+{
+}
+
+public partial class TestBaseObjClass
+{
+}
+
+public partial interface ITestObj
+{
+}
+");
+    }
+
+    [Fact]
     public async Task LambdaImmediatelyExecutedAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"Public Class Issue869


### PR DESCRIPTION
https://github.com/icsharpcode/CodeConverter/issues/1148

### Problem
AddressOf delegates are wrapped in lambdas when delegate signatures are not equal but still compatible.
This behaviour is implemented correctly for base and derived classes but not for interfaces.

### Solution
Using InheritsFromOrEquals overload with the option to include interfaces for delegates that widen the return type to an interface that is implemented by the type or narrow the input parameters types to classes implementing the interface.

