### PR TITLE
Issue 1154 wrong nested types conversion

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -229,7 +229,9 @@ internal class CommonConversions
 
         return syntax.ReplaceNodes(syntax.DescendantNodes().OfType<CSSyntax.IdentifierNameSyntax>(), (oldNode, _) =>
         {
-            var originalName = originalNames.FirstOrDefault(on => string.Equals(on, oldNode.ToString(), StringComparison.OrdinalIgnoreCase));
+            string oldNodeStr = oldNode.ToString();
+            var originalName = originalNames.FirstOrDefault(on => string.Equals(on, oldNodeStr, StringComparison.Ordinal)) ??
+                               originalNames.FirstOrDefault(on => string.Equals(on, oldNodeStr, StringComparison.OrdinalIgnoreCase));
             return originalName != null ? ValidSyntaxFactory.IdentifierName(originalName) : oldNode;
         });
     }

--- a/Tests/CSharp/CaseSensitivityTests.cs
+++ b/Tests/CSharp/CaseSensitivityTests.cs
@@ -107,25 +107,25 @@ End Namespace
 ",
             @"
 using System;
-              
+
 namespace Issue1154
 {
-    [CaseSensitive1.Casesensitive1.TestDummyAttribute]
+    [CaseSensitive1.Casesensitive1.TestDummy]
     public partial class UpperLowerCase
     {
     }
-              
-    [Casesensitive2.CaseSensitive2.TestDummyAttribute]
+
+    [Casesensitive2.CaseSensitive2.TestDummy]
     public partial class LowerUpperCase
     {
     }
-              
+
     [CaseSensitive3.CaseSensitive3.TestDummy]
     public partial class SameCase
     {
     }
 }
-              
+
 namespace CaseSensitive1
 {
     public partial class Casesensitive1
@@ -135,7 +135,7 @@ namespace CaseSensitive1
         }
     }
 }
-              
+
 namespace Casesensitive2
 {
     public partial class CaseSensitive2
@@ -145,7 +145,7 @@ namespace Casesensitive2
         }
     }
 }
-              
+
 namespace CaseSensitive3
 {
     public partial class CaseSensitive3

--- a/Tests/CSharp/CaseSensitivityTests.cs
+++ b/Tests/CSharp/CaseSensitivityTests.cs
@@ -61,6 +61,103 @@ public partial class VBIsCaseInsensitive
 }");
     }
 
+    [Fact]
+    public async Task Issue1154_NamespaceAndClassSameNameDifferentCaseAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Imports System
+
+Namespace Issue1154
+    <CaseSensitive1.Casesensitive1.TestDummy>
+    Public Class UpperLowerCase
+    End Class
+
+    <Casesensitive2.CaseSensitive2.TestDummy>
+    Public Class LowerUpperCase
+    End Class
+
+    <CaseSensitive3.CaseSensitive3.TestDummy>
+    Public Class SameCase
+    End Class
+End Namespace
+
+Namespace CaseSensitive1
+    Public Class Casesensitive1
+        Public Class TestDummyAttribute
+            Inherits Attribute
+        End Class
+    End Class
+End Namespace
+
+Namespace Casesensitive2
+    Public Class CaseSensitive2
+        Public Class TestDummyAttribute
+            Inherits Attribute
+        End Class
+    End Class
+End Namespace
+
+Namespace CaseSensitive3
+    Public Class CaseSensitive3
+        Public Class TestDummyAttribute
+            Inherits Attribute
+        End Class
+    End Class
+End Namespace
+",
+            @"
+using System;
+              
+namespace Issue1154
+{
+    [CaseSensitive1.Casesensitive1.TestDummyAttribute]
+    public partial class UpperLowerCase
+    {
+    }
+              
+    [Casesensitive2.CaseSensitive2.TestDummyAttribute]
+    public partial class LowerUpperCase
+    {
+    }
+              
+    [CaseSensitive3.CaseSensitive3.TestDummy]
+    public partial class SameCase
+    {
+    }
+}
+              
+namespace CaseSensitive1
+{
+    public partial class Casesensitive1
+    {
+        public partial class TestDummyAttribute : Attribute
+        {
+        }
+    }
+}
+              
+namespace Casesensitive2
+{
+    public partial class CaseSensitive2
+    {
+        public partial class TestDummyAttribute : Attribute
+        {
+        }
+    }
+}
+              
+namespace CaseSensitive3
+{
+    public partial class CaseSensitive3
+    {
+        public partial class TestDummyAttribute : Attribute
+        {
+        }
+    }
+}
+");
+    }
+
 
 
 }


### PR DESCRIPTION
### Problem
https://github.com/icsharpcode/CodeConverter/issues/1154

Namespaces and types can have the same name with a different casing:
```vbnet
Namespace CaseSensitive1
    Public Class Casesensitive1
        Public Class TestDummyAttribute
            Inherits Attribute
        End Class
    End Class
End Namespace

Namespace Issue1154
    <CaseSensitive1.Casesensitive1.TestDummy>
    Public Class UpperLowerCase
    End Class
End Namespace
```
The vbnode-to-csharpnode replacement searches node names with "StringComparison.OrdinalIgnoreCase".
Due to this way of comparison, the type name will be replaced with the namespace name.

### Solution
Performing the node name search with "StringComparison.Ordinal" first. If no match is found retry with "StringComparison.OrdinalIgnoreCase". IgnoreCase is needed as 100's of tests fail when just doing Ordinal comparison.

It is not optimal that the search is done twice now for a lot of declarations, just to handle this edge case, but checking for duplicates with different casing is probably even slower, as the collections are usually very short.