### PR TITLE
VB -> C#: private partial methods do not compile

### DIFF
--- a/CodeConverter/Util/ISymbolExtensions.cs
+++ b/CodeConverter/Util/ISymbolExtensions.cs
@@ -75,12 +75,12 @@ internal static class ISymbolExtensions
 
     public static bool CanHaveMethodBody(this ISymbol declaredSymbol)
     {
-        return !(declaredSymbol is IMethodSymbol ms) || ms.PartialImplementationPart == null && !ms.IsExtern;
+        return !(declaredSymbol is IMethodSymbol ms) || (!ms.IsPartialDefinition && (ms.PartialImplementationPart == null && !ms.IsExtern));
     }
 
     public static bool IsPartialMethodDefinition(this ISymbol declaredSymbol)
     {
-        return declaredSymbol is IMethodSymbol ms && ms.PartialImplementationPart != null;
+        return declaredSymbol is IMethodSymbol ms && (ms.PartialImplementationPart != null || ms.IsPartialDefinition);
     }
 
     public static bool IsPartialClassDefinition(this ISymbol declaredSymbol)

--- a/Tests/CSharp/SpecialConversionTests.cs
+++ b/Tests/CSharp/SpecialConversionTests.cs
@@ -402,4 +402,11 @@ public partial class C
     }
 }");
     }
+
+    [Fact]
+    public async Task Issue1097_PartialMethodAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Partial Private Sub DummyMethod()
+    End Sub", @"partial void DummyMethod();");
+    }
 }


### PR DESCRIPTION
- Added unit test to SpecialConversionTests (not MethodStatementTests  as there is no statements) -ISymbolExtensions.cs
  - CanHaveMethodBody & IsPartialMethodDefinition
  - Added check for IsPartialDefinition

#1097

### Problem
Partial method declarations are including a body, which makes them partial method IMPLEMENTATIONS without declarations and so the resulting conversion does not compile

### Solution
* Changed the code as little as possible, I think it fits in with the existing code, could be broken up into multiple (shorter) lines, and negative pattern matching could probably be used, but didn't want to change too much.
* Change to IsPartialMethodDefinition is unnecessary for this, not sure it should be included or not.
* There is a test for problem, but there's not a test for the other end of it (i.e. that it correctly converts partial implementations, but I didn't have a problem with those).
* [x ] At least one test covering the code changed

