### PR TITLE
VB -> C#: Brackets needed around ternary expression

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -523,6 +523,10 @@ internal class CommonConversions
             && convertedExpression.SkipIntoParens() is CSSyntax.BinaryExpressionSyntax bExp && bExp.IsKind(CSSyntaxKind.SubtractExpression))
             return bExp.Left;
 
+        if (convertedExpression is CSSyntax.ConditionalExpressionSyntax ce) {
+            convertedExpression = SyntaxFactory.ParenthesizedExpression(convertedExpression);
+        }
+
         return SyntaxFactory.BinaryExpression(
             CSSyntaxKind.SubtractExpression,
             convertedExpression, SyntaxFactory.Token(CSSyntaxKind.PlusToken), SyntaxFactory.LiteralExpression(CSSyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)));

--- a/Tests/CSharp/ExpressionTests/AccessExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/AccessExpressionTests.cs
@@ -210,6 +210,26 @@ public partial class A
     }
 
     [Fact]
+    public async Task TernaryArrayIndexerAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Public Class A
+    Public Sub Test()
+        Dim i as integer = 0
+        Dim a(If(i = 1, 2, 3)) as string
+    End Sub
+End Class", @"
+public partial class A
+{
+    public void Test()
+    {
+        int i = 0;
+        var a = new string[(i == 1 ? 2 : 3) + 1];
+    }
+}");
+    }
+
+
+    [Fact]
     public async Task ElementAtOrDefaultIndexingAsync()
     {
         await TestConversionVisualBasicToCSharpAsync(@"Imports System.Linq


### PR DESCRIPTION
- Added unit test to AccessExpressionTest.cs
- CommonConversions.cs
  - use SyntaxFactory.ParenthesizedExpression to ParenthesizedExpression the converted expression if it is a ConditionalExpressionSyntax
- Ran all test, no change in existing test, new test passes after initially failing.


Link to issue(s) this covers

#1170

### Problem
C# ternary expression do not inherently have a termination, unlike VB ternary.  When converted without parameterization, IncreaseArrayUpperBoundExpressionAsync adds 1 to the false result.

### Solution
* Is mutating convertedExpression acceptable, or should it be it's own return?
* [X] All existing test continue to pass
* [x] There is now a test for this scenario.

