### PR TITLE
Fix: Incorrectly converted conditional array bounds

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -522,9 +522,9 @@ internal class CommonConversions
             && convertedExpression.SkipIntoParens() is CSSyntax.BinaryExpressionSyntax bExp && bExp.IsKind(CSSyntaxKind.SubtractExpression))
             return bExp.Left;
 
-        return SyntaxFactory.BinaryExpression(
-            CSSyntaxKind.SubtractExpression,
-            convertedExpression, SyntaxFactory.Token(CSSyntaxKind.PlusToken), SyntaxFactory.LiteralExpression(CSSyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)));
+        return SyntaxFactory.BinaryExpression(CSSyntaxKind.AddExpression,
+            SyntaxFactory.ParenthesizedExpression(convertedExpression),
+            SyntaxFactory.LiteralExpression(CSSyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)));
     }
 
     public async Task<SyntaxList<CSSyntax.AttributeListSyntax>> ConvertAttributesAsync(SyntaxList<VBSyntax.AttributeListSyntax> attributeListSyntaxs)

--- a/Tests/CSharp/StatementTests/ArrayStatementTests.cs
+++ b/Tests/CSharp/StatementTests/ArrayStatementTests.cs
@@ -529,4 +529,24 @@ public partial class SplitArrayDeclarations
     }
 }");
     }
+
+    [Fact]
+    public async Task ConditionalArrayBoundsAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"Class TestClass
+    Private Sub TestMethod()
+        dim i as integer = 0
+        dim a(If(i = 1, 2, 3)) as string
+    End Sub
+End Class", @"
+internal partial class TestClass
+{
+    private void TestMethod()
+    {
+        int i = 0;
+        var a = new string[(i == 1 ? 2 : 3) + 1];
+    }
+}");
+    }
 }


### PR DESCRIPTION
### Explanation

This bug has already been fixed, I'm just opening this draft PR as an example of how to prompt [Jules ](https://jules.google.com/task) to successfully fix such a bug

### Agent comment


Jules:
> This commit fixes a bug where conditional array bounds were converted incorrectly due to operator precedence issues. The expression is now wrapped in parentheses to ensure the addition is performed on the result of the conditional expression.
> A test case has been added to verify the fix.

### Problem

Fixes https://github.com/icsharpcode/CodeConverter/issues/1170


### Prompt used

```
Add an appropriate test for this bug report, then try to fix it. You probably won't be able to build the whole solution or run the tests due to your environment. So think carefully about the code structure and fix, and make a best effort
```

Followed by the issue description, in this case
```
The below yields the issue when pasted into the online converter.

dim i as integer = 0
dim a(If(i = 1, 2, 3)) as string
Converts to:

int i = 0;
var a = new string[i == 1 ? 2 : 3 + 1];
Instead of:

int i = 0;
var a = new string[(i == 1 ? 2 : 3) + 1];
So it looks like the problem is in the addition of 1 for C# array extents.
```


