### PR TITLE
Build against net8 too

### DIFF
--- a/CodeConv/CodeConv.csproj
+++ b/CodeConv/CodeConv.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
https://github.com/icsharpcode/CodeConverter/issues/1215

Not everyone is allowed to install the latest version of dotnet. Let's try to build against the previous version until it goes out of support in 9 months' time.

According to the passing automated tests, VS2022 is sufficient to work with this.