### PR TITLE
Fix LINQ extension methods conversion to C#

### DIFF
--- a/CodeConverter/CSharp/VbNameExpander.cs
+++ b/CodeConverter/CSharp/VbNameExpander.cs
@@ -65,7 +65,7 @@ internal class VbNameExpander : ISyntaxExpander
             semanticModel.GetOperation(node) is IMemberReferenceOperation { Instance: { Syntax: ExpressionSyntax promotedInstance }, Member: {} member }) {
             return MemberAccess(promotedInstance, SyntaxFactory.IdentifierName(member.Name));
         }
-        return IsOriginalSymbolGenericMethod(semanticModel, node) ? node : Simplifier.Expand(node, semanticModel, workspace);
+        return IsOriginalSymbolGenericOrExtensionMethod(semanticModel, node) ? node : Simplifier.Expand(node, semanticModel, workspace);
     }
 
     private static bool IsReducedExtensionInExtendedTypeOrDerivedType(SyntaxNode node, ISymbol symbol, SemanticModel semanticModel)
@@ -136,8 +136,15 @@ internal class VbNameExpander : ISyntaxExpander
     /// Roslyn bug - accidentally expands anonymous types to just "Global."
     /// Since the C# reducer also doesn't seem to reduce generic extension methods, it's best to avoid those too, so let's just avoid all generic methods
     /// </summary>
-    private static bool IsOriginalSymbolGenericMethod(SemanticModel semanticModel, SyntaxNode node) =>
-        semanticModel.GetSymbolInfo(node).Symbol.IsGenericMethod();
+    private static bool IsOriginalSymbolGenericOrExtensionMethod(SemanticModel semanticModel, SyntaxNode node)
+    {
+        var symbolInfo = semanticModel.GetSymbolInfo(node);
+        var symbol = symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.FirstOrDefault();
+        if (symbol?.IsGenericMethod() == true) return true;
+        if (symbol is IMethodSymbol ms && (ms.MethodKind == MethodKind.ReducedExtension || ms.IsExtensionMethod)) return true;
+        return false;
+    }
+
 
     private static bool IsQualifiableInstanceReference(ISymbol symbol) =>
         symbol?.IsStatic == false && (symbol.IsKind(SymbolKind.Method) || symbol.IsKind(SymbolKind.Field) ||

--- a/Tests/CSharp/ExpressionTests/LinqExtensionMethodReproTests.cs
+++ b/Tests/CSharp/ExpressionTests/LinqExtensionMethodReproTests.cs
@@ -1,0 +1,53 @@
+using System.Threading.Tasks;
+using Xunit;
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp.ExpressionTests;
+
+public class LinqExtensionMethodReproTests : ConverterTestBase
+{
+    [Fact]
+    public async Task TestLinqExtensionMethods()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Imports System.Linq
+
+Public Class TestClass
+    Public Shared Sub Test()
+        Dim intCol = New Integer() {1, 2, 3}
+        Dim intCol2 = New Integer() {1, 2, 3}
+
+        Dim intColQuery = intCol.Select(Function(x) x)
+        Dim intColCopy = intCol.Select(Function(x) x).ToArray()
+        Dim intSum = intCol.Select(Function(x) x).Sum(Function(x) x)
+        Dim intMax = intCol.Select(Function(x) x).Max(Function(x) x)
+        Dim intCnt = intCol.Select(Function(x) x).Count(Function(x) x > 1)
+
+        Dim intSum2 = intCol.Select(Function(x) x).Sum()
+        Dim intMax2 = intCol.OrderBy(Function(x) x).Max()
+        Dim intCnt2 = intCol.Select(Function(x) x).Count()
+        Dim intSum3 = intCol.Zip(intCol2, Function(x, y) x + y).Sum()
+    End Sub
+End Class", @"using System;
+using System.Linq;
+
+public partial class TestClass
+{
+    public static void Test()
+    {
+        int[] intCol = new int[] { 1, 2, 3 };
+        int[] intCol2 = new int[] { 1, 2, 3 };
+
+        var intColQuery = intCol.Select(x => x);
+        int[] intColCopy = intCol.Select(x => x).ToArray();
+        int intSum = intCol.Select(x => x).Sum(x => x);
+        int intMax = intCol.Select(x => x).Max(x => x);
+        int intCnt = intCol.Select(x => x).Count(x => x > 1);
+
+        int intSum2 = intCol.Select(x => x).Sum();
+        int intMax2 = intCol.OrderBy(x => x).Max();
+        int intCnt2 = intCol.Select(x => x).Count();
+        int intSum3 = intCol.Zip(intCol2, (x, y) => x + y).Sum();
+    }
+}");
+    }
+}


### PR DESCRIPTION
Fixes issue where LINQ extension methods are incorrectly replaced with static `Enumerable` methods when converted from VB to C# (Issue #1149). This occurred because non-generic extension methods (like `Sum` or `Max` on `int` enumerables) were mistakenly bypassing a guard clause and expanding into full static method invocations during the VB syntax expansion step. The C# simplifier was subsequently failing to reduce them back.

By updating the `VbNameExpander` guard clause to cover all extension methods and reduced extension methods, the idiomatic fluent syntax is successfully preserved. 

Included unit test verified against numeric collections `Select().Sum()`, `OrderBy().Max()`, `Select().Count()`, etc.

---
*PR created automatically by Jules for task [17340425955327495994](https://jules.google.com/task/17340425955327495994) started by @GrahamTheCoder*

--

Updates `VbNameExpander` to correctly bypass syntax expansion for all extension methods (both generic and reduced, such as `.Sum()` over numeric collections). Previously, non-generic extension methods were expanded to static calls (e.g. `Enumerable.Sum(...)`), which the C# simplifier phase couldn't contract back to fluent syntax, leading to erroneous or uncompilable C# output.

Renames `IsOriginalSymbolGenericMethod` to `IsOriginalSymbolGenericOrExtensionMethod` to reflect its behavior of handling `IsExtensionMethod` and `MethodKind.ReducedExtension`.

Includes a new reproducing unit test `LinqExtensionMethodReproTests` to ensure continued functionality.


