### PR TITLE
Fix Issue #1089: Don't optimize Option Compare Text empty string

### DIFF
--- a/CodeConverter/CSharp/VisualBasicEqualityComparison.cs
+++ b/CodeConverter/CSharp/VisualBasicEqualityComparison.cs
@@ -179,6 +179,12 @@ internal class VisualBasicEqualityComparison
     public bool TryConvertToNullOrEmptyCheck(VBSyntax.BinaryExpressionSyntax node, ExpressionSyntax lhs,
         ExpressionSyntax rhs, out CSharpSyntaxNode? visitBinaryExpression)
     {
+        if (OptionCompareTextCaseInsensitive)
+        {
+            visitBinaryExpression = null;
+            return false;
+        }
+
         bool lhsEmpty = IsNothingOrEmpty(node.Left);
         bool rhsEmpty = IsNothingOrEmpty(node.Right);
 

--- a/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/StringExpressionTests.cs
@@ -208,11 +208,11 @@ public partial class Class1
         {
             throw new Exception();
         }
-        if (string.IsNullOrEmpty(s1))
+        if (CultureInfo.CurrentCulture.CompareInfo.Compare(s1 ?? """", """", CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth) == 0)
         {
             // 
         }
-        if (string.IsNullOrEmpty(s1))
+        if (CultureInfo.CurrentCulture.CompareInfo.Compare(s1 ?? """", """", CompareOptions.IgnoreCase | CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth) == 0)
         {
             // 
         }


### PR DESCRIPTION
Fix Issue #1089: Don't optimize Option Compare Text empty string checks to string.IsNullOrEmpty()

Under Option Compare Text, Visual Basic evaluates certain invisible character strings as equal to `""`. Optimizing this down to `string.IsNullOrEmpty` in C# breaks correct behavior because C# considers these strings non-empty. This commit skips the null/empty optimization when `OptionCompareTextCaseInsensitive` is true, causing it to fall back to `CultureInfo.CurrentCulture.CompareInfo.Compare` logic.