### PR TITLE
Fix Object Initializers Referencing Other Properties (#1080)

### DIFF
--- a/CodeConverter/CSharp/NameExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/NameExpressionNodeVisitor.cs
@@ -87,8 +87,8 @@ internal class NameExpressionNodeVisitor
             if (IsSubPartOfConditionalAccess(node)) {
                 return isDefaultProperty ? SyntaxFactory.ElementBindingExpression()
                     : await AdjustForImplicitInvocationAsync(node, SyntaxFactory.MemberBindingExpression(simpleNameSyntax));
-            } else if (node.IsParentKind(VBasic.SyntaxKind.NamedFieldInitializer)) {
-                return ValidSyntaxFactory.IdentifierName(_tempNameForAnonymousScope[node.Name.Identifier.Text].Peek().TempName);
+            } else if (node.IsParentKind(VBasic.SyntaxKind.NamedFieldInitializer) && _tempNameForAnonymousScope.TryGetValue(node.Name.Identifier.Text, out var stack) && stack.Any()) {
+                return ValidSyntaxFactory.IdentifierName(stack.Peek().TempName);
             }
             left = _withBlockLhs.Peek();
         }

--- a/Tests/VB/ExpressionTests.cs
+++ b/Tests/VB/ExpressionTests.cs
@@ -588,6 +588,57 @@ End Class");
     }
 
     [Fact]
+    public async Task ObjectInitializerExpressionReferencingOtherPropertyAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Imports System.Drawing
+
+Public Class VisualBasicClass
+    Public Sub M()
+        Dim Shape = New Point() With {
+            .X = 1,
+            .Y = .X
+        }
+    End Sub
+End Class", @"using System.Drawing;
+
+public partial class VisualBasicClass
+{
+    public void M()
+    {
+        Point @init = new Point();
+        var Shape = (@init.X = 1, @init.Y = @init.X, @init).@init;
+    }
+}");
+    }
+
+    [Fact]
+    public async Task AdvancedObjectInitializerExpressionReferencingOtherPropertyAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Imports System.Drawing
+
+Public Class VisualBasicClass
+    Public Sub M()
+        Dim Shape = New Rectangle() With {
+            .X = 1,
+            .Y = .X + 10,
+            .Width = .X + .Y,
+            .Height = System.Math.Max(.Width, .Y)
+        }
+    End Sub
+End Class", @"using System;
+using System.Drawing;
+
+public partial class VisualBasicClass
+{
+    public void M()
+    {
+        Rectangle @init = new Rectangle();
+        var Shape = (@init.X = 1, @init.Y = @init.X + 10, @init.Width = @init.X + @init.Y, @init.Height = Math.Max(@init.Width, @init.Y), @init).@init;
+    }
+}");
+    }
+
+    [Fact]
     public async Task ObjectInitializerExpression3Async()
     {
         await TestConversionCSharpToVisualBasicAsync(@"using System.Collections.Generic;


### PR DESCRIPTION
Fixes #1080 where VB.NET object initializers referencing other properties (e.g. `New Point() With { .X = 1, .Y = .X }`) caused a `KeyNotFoundException` during conversion to C# because the code incorrectly assumed any `NamedFieldInitializer` belonged to an anonymous type and tried to look up its temporary initialization variable in `_tempNameForAnonymousScope`.
The fix introduces a safe lookup via `TryGetValue`, falling back to `_withBlockLhs.Peek()` for regular object initializers. Two unit tests reproducing the issue and testing an advanced case are included.

---
*PR created automatically by Jules for task [6482098657889880382](https://jules.google.com/task/6482098657889880382) started by @GrahamTheCoder*