### PR TITLE
Fix #1012: multiline lambda with single statement conversion

### DIFF
--- a/CodeConverter/CSharp/LambdaConverter.cs
+++ b/CodeConverter/CSharp/LambdaConverter.cs
@@ -79,8 +79,17 @@ internal class LambdaConverter
             convertedStatements = convertedStatements.Select(l => l.WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)).ToList();
             block = SyntaxFactory.Block(convertedStatements);
         } else if (singleStatement.TryUnpackSingleExpressionFromStatement(out expressionBody)) {
-            arrow = SyntaxFactory.ArrowExpressionClause(expressionBody);
+            if (vbNode is VBasic.Syntax.MultiLineLambdaExpressionSyntax && singleStatement is not ExpressionStatementSyntax && singleStatement is not ReturnStatementSyntax) {
+                singleStatement = singleStatement.WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+                block = SyntaxFactory.Block(singleStatement);
+                expressionBody = null;
+            } else {
+                arrow = SyntaxFactory.ArrowExpressionClause(expressionBody);
+            }
         } else {
+            if (vbNode is VBasic.Syntax.MultiLineLambdaExpressionSyntax) {
+                singleStatement = singleStatement.WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed);
+            }
             block = SyntaxFactory.Block(singleStatement);
         }
 

--- a/Tests/CSharp/ExpressionTests/LambdaTests.cs
+++ b/Tests/CSharp/ExpressionTests/LambdaTests.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using ICSharpCode.CodeConverter.Tests.TestRunners;
+using Xunit;
+
+namespace ICSharpCode.CodeConverter.Tests.CSharp.ExpressionTests;
+
+public class LambdaTests : ConverterTestBase
+{
+    [Fact]
+    public async Task Issue1012_MultiLineLambdaWithSingleStatement()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Threading.Tasks
+
+Public Class ConversionTest3
+    Private Class MyEntity
+        Property EntityId As Integer
+        Property Name As String
+    End Class
+    Private Sub BugRepro()
+
+        Dim entities As New List(Of MyEntity)
+
+        Parallel.For(1, 3, Sub(i As Integer)
+                               Dim result As String = (From e In entities
+                                                       Where e.EntityId = 123
+                                                       Select e.Name).Single
+                           End Sub)
+    End Sub
+End Class", @"using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+public partial class ConversionTest3
+{
+    private partial class MyEntity
+    {
+        public int EntityId { get; set; }
+        public string Name { get; set; }
+    }
+    private void BugRepro()
+    {
+
+        var entities = new List<MyEntity>();
+
+        Parallel.For(1, 3, (i) =>
+        {
+            string result = (from e in entities
+                             where e.EntityId == 123
+                             select e.Name).Single();
+        });
+    }
+}");
+    }
+}


### PR DESCRIPTION
Fix conversion of single-statement multiline lambda to block syntax

Fixes #1012 by ensuring that when a VB.NET MultiLineLambdaExpressionSyntax
contains a single statement that is not an ExpressionStatementSyntax or
ReturnStatementSyntax (such as a local declaration statement with a
multiline LINQ query), it is converted to a block-bodied lambda in C#
rather than an arrow expression clause.

Also adds a corresponding characterization test.

---
*PR created automatically by Jules for task [3073073241984481523](https://jules.google.com/task/3073073241984481523) started by @GrahamTheCoder*