### PR TITLE
Fix lambda block unpacking with comments

### DIFF
--- a/CodeConverter/CSharp/LambdaConverter.cs
+++ b/CodeConverter/CSharp/LambdaConverter.cs
@@ -75,7 +75,8 @@ internal class LambdaConverter
         BlockSyntax block = null;
         ExpressionSyntax expressionBody = null;
         ArrowExpressionClauseSyntax arrow = null;
-        if (!convertedStatements.TryUnpackSingleStatement(out StatementSyntax singleStatement)) {
+        bool hasComments = vbNode.DescendantTrivia().Any(t => t.IsKind(VBasic.SyntaxKind.CommentTrivia));
+        if (hasComments || !convertedStatements.TryUnpackSingleStatement(out StatementSyntax singleStatement)) {
             convertedStatements = convertedStatements.Select(l => l.WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed)).ToList();
             block = SyntaxFactory.Block(convertedStatements);
         } else if (singleStatement.TryUnpackSingleExpressionFromStatement(out expressionBody)) {

--- a/Tests/CSharp/ExpressionTests/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests/ExpressionTests.cs
@@ -2931,4 +2931,50 @@ public partial class CrashTest
     }
 }");
     }
+    [Fact]
+    public async Task LambdaBodyExpressionWithCommentsAsync() {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Imports System.Threading.Tasks
+Imports System.Collections.Generic
+
+Public Class ConversionTest1
+    Public Sub BugRepro()
+        Dim dt As New List(Of Integer)
+
+        Parallel.ForEach(dt, Sub(row)
+                                 If Not String.IsNullOrWhiteSpace("""") Then
+                                     'comment1
+                                     Dim test1 As Boolean = True
+                                     'comment2
+                                     Dim test2 As Boolean = True
+                                     'comment3
+                                     Dim test3 As Boolean = True
+                                 End If
+                             End Sub)
+    End Sub
+End Class
+", @"using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public partial class ConversionTest1
+{
+    public void BugRepro()
+    {
+        var dt = new List<int>();
+
+        Parallel.ForEach(dt, row =>
+        {
+            if (!string.IsNullOrWhiteSpace(""""))
+            {
+                // comment1
+                bool test1 = true;
+                // comment2
+                bool test2 = true;
+                // comment3
+                bool test3 = true;
+            }
+        });
+    }
+}", incompatibleWithAutomatedCommentTesting: true);
+    }
 }


### PR DESCRIPTION
Fixes #1013 by ensuring that lambda bodies containing comments are converted using a full BlockSyntax rather than being unpacked to an expression body or unparenthesized statement, which previously caused comments to jump outside the lambda loop in resulting C# code. Added a test matching the issue's repro without compilation errors by substituting DataTable with a simpler generic List.

---
*PR created automatically by Jules for task [17420352820605040508](https://jules.google.com/task/17420352820605040508) started by @GrahamTheCoder*