### PR TITLE
Fix conversion of backing fields of overridable properties

### DIFF
--- a/CodeConverter/CSharp/CommonConversions.cs
+++ b/CodeConverter/CSharp/CommonConversions.cs
@@ -294,6 +294,9 @@ internal class CommonConversions
                     text = "value";
                 } else if (normalizedText.StartsWith("_", StringComparison.OrdinalIgnoreCase) && idSymbol is IFieldSymbol propertyFieldSymbol && propertyFieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Property) == true) {
                     text = propertyFieldSymbol.AssociatedSymbol.Name;
+                    if (propertyFieldSymbol.AssociatedSymbol.IsVirtual && !propertyFieldSymbol.AssociatedSymbol.IsAbstract) {
+                        text = "MyClass" + text;
+                    }
                 } else if (normalizedText.EndsWith("Event", StringComparison.OrdinalIgnoreCase) && idSymbol is IFieldSymbol eventFieldSymbol && eventFieldSymbol.AssociatedSymbol?.IsKind(SymbolKind.Event) == true) {
                     text = eventFieldSymbol.AssociatedSymbol.Name;
                 } else if (WinformsConversions.MayNeedToInlinePropertyAccess(id.Parent, idSymbol) && _typeContext.HandledEventsAnalysis.ShouldGeneratePropertyFor(idSymbol.Name)) {

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -336,7 +336,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
 
     public override async Task<CSharpSyntaxNode> VisitClassBlock(VBSyntax.ClassBlockSyntax node)
     {
-        _accessorDeclarationNodeConverter.AccessedThroughMyClass = GetMyClassAccessedNames(node);
+        _accessorDeclarationNodeConverter.AccessedThroughMyClass = GetMyClassAccessedNames(node, _semanticModel);
         var classStatement = node.ClassStatement;
         var attributes = await CommonConversions.ConvertAttributesAsync(classStatement.AttributeLists);
         var (parameters, constraints) = await SplitTypeParametersAsync(classStatement.TypeParameterList);
@@ -689,12 +689,23 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         return CS.SyntaxFactory.Block(await statements.SelectManyAsync(async s => (IEnumerable<StatementSyntax>) await s.Accept(methodBodyVisitor)));
     }
 
-    private static HashSet<string> GetMyClassAccessedNames(VBSyntax.ClassBlockSyntax classBlock)
+    private static HashSet<string> GetMyClassAccessedNames(VBSyntax.ClassBlockSyntax classBlock, SemanticModel semanticModel)
     {
         var memberAccesses = classBlock.DescendantNodes().OfType<VBSyntax.MemberAccessExpressionSyntax>();
         var accessedTextNames = new HashSet<string>(memberAccesses
             .Where(mae => mae.Expression is VBSyntax.MyClassExpressionSyntax)
             .Select(mae => mae.Name.Identifier.Text), StringComparer.OrdinalIgnoreCase);
+
+        var identifierNames = classBlock.DescendantNodes().OfType<VBSyntax.IdentifierNameSyntax>().Where(id => id.Identifier.Text.StartsWith("_", StringComparison.OrdinalIgnoreCase));
+        foreach (var id in identifierNames)
+        {
+            var symbolInfo = semanticModel.GetSymbolInfo(id);
+            if (symbolInfo.Symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol != null && fieldSymbol.AssociatedSymbol.IsVirtual && !fieldSymbol.AssociatedSymbol.IsAbstract)
+            {
+                accessedTextNames.Add(fieldSymbol.AssociatedSymbol.Name);
+            }
+        }
+
         return accessedTextNames;
     }
 

--- a/CodeConverter/CSharp/DeclarationNodeVisitor.cs
+++ b/CodeConverter/CSharp/DeclarationNodeVisitor.cs
@@ -700,7 +700,7 @@ internal class DeclarationNodeVisitor : VBasic.VisualBasicSyntaxVisitor<Task<CSh
         foreach (var id in identifierNames)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(id);
-            if (symbolInfo.Symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol != null && fieldSymbol.AssociatedSymbol.IsVirtual && !fieldSymbol.AssociatedSymbol.IsAbstract)
+            if (symbolInfo.Symbol is IFieldSymbol fieldSymbol && fieldSymbol.AssociatedSymbol != null && fieldSymbol.AssociatedSymbol.IsVirtual && !fieldSymbol.AssociatedSymbol.IsAbstract && !id.Identifier.Text.StartsWith("MyClass", StringComparison.OrdinalIgnoreCase))
             {
                 accessedTextNames.Add(fieldSymbol.AssociatedSymbol.Name);
             }

--- a/Tests/VB/MemberTests.cs
+++ b/Tests/VB/MemberTests.cs
@@ -1495,4 +1495,49 @@ CS0246: The type or namespace name 'IEnumerable<>' could not be found (are you m
 End Class");
     }
 
+
+    [Fact]
+    public async Task TestMyClassPropertyAccess()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"
+Class Foo
+    Overridable Property Prop As Integer = 5
+
+    Sub Test()
+        _Prop = 10 ' This should convert to MyClassProp = 10 not to Prop = 10
+        Dim isCorrect = MyClass.Prop = 10 ' After conversion this will return 5instead of 10 because we wrote to Child.Prop
+    End Sub
+End Class
+Class Child
+    Inherits Foo
+    Overrides Property Prop As Integer = 20
+End Class", @"
+internal partial class Foo
+{
+    public int MyClassProp { get; set; } = 5;
+
+    public virtual int Prop
+    {
+        get
+        {
+            return MyClassProp;
+        }
+
+        set
+        {
+            MyClassProp = value;
+        }
+    }
+
+    public void Test()
+    {
+        MyClassProp = 10; // This should convert to MyClassProp = 10 not to Prop = 10
+        bool isCorrect = MyClassProp == 10; // After conversion this will return 5instead of 10 because we wrote to Child.Prop
+    }
+}
+internal partial class Child : Foo
+{
+    public override int Prop { get; set; } = 20;
+}");
+    }
 }


### PR DESCRIPTION
This PR addresses issue #827, ensuring that accessing the backing field of an overridable property is correctly translated to accessing `MyClass[PropertyName]`. It also properly identifies these accesses using semantic analysis to trigger the generation of the `MyClass[PropertyName]` delegating auto-property. Added corresponding unit tests in `MemberTests.cs` to guarantee behavior.

---
*PR created automatically by Jules for task [2635451807914525187](https://jules.google.com/task/2635451807914525187) started by @GrahamTheCoder*