### PR TITLE
Fix Issue 886: VB -> C# wrong conversion of optional struct or decimal ref parameter

### DIFF
--- a/CodeConverter/CSharp/ArgumentConverter.cs
+++ b/CodeConverter/CSharp/ArgumentConverter.cs
@@ -226,10 +226,18 @@ internal class ArgumentConverter
         var type = CommonConversions.GetTypeSyntax(p.Type);
         CSSyntax.ExpressionSyntax initializer;
         if (p.HasExplicitDefaultValue) {
-            initializer = CommonConversions.Literal(p.ExplicitDefaultValue);
+            if (p.ExplicitDefaultValue == null && p.Type.IsValueType && p.Type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T) {
+                initializer = CS.SyntaxFactory.DefaultExpression(type);
+            } else {
+                initializer = CommonConversions.Literal(p.ExplicitDefaultValue);
+            }
         } else if (HasOptionalAttribute(p)) {
             if (TryGetDefaultParameterValueAttributeValue(p, out var defaultValue)) {
-                initializer = CommonConversions.Literal(defaultValue);
+                if (defaultValue == null && p.Type.IsValueType && p.Type.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T) {
+                    initializer = CS.SyntaxFactory.DefaultExpression(type);
+                } else {
+                    initializer = CommonConversions.Literal(defaultValue);
+                }
             } else {
                 initializer = CS.SyntaxFactory.DefaultExpression(type);
             }

--- a/CodeConverter/CSharp/ExpressionNodeVisitor.cs
+++ b/CodeConverter/CSharp/ExpressionNodeVisitor.cs
@@ -471,7 +471,22 @@ internal partial class ExpressionNodeVisitor : VBasic.VisualBasicSyntaxVisitor<T
                     CS.SyntaxFactory.Attribute(ValidSyntaxFactory.IdentifierName("Optional")),
                 };
                 if (!node.Default.Value.IsKind(VBasic.SyntaxKind.NothingLiteralExpression)) {
-                    optionalAttributes.Add(CS.SyntaxFactory.Attribute(ValidSyntaxFactory.IdentifierName("DefaultParameterValue"), arg));
+                    if (vbSymbol?.Type?.SpecialType == SpecialType.System_Decimal && defaultExpression is CSSyntax.LiteralExpressionSyntax literalExpr) {
+                        var literalValue = literalExpr.Token.Value;
+                        if (literalValue is decimal decimalVal) {
+                            var isInteger = decimalVal == Math.Round(decimalVal);
+                            var newLiteral = isInteger ? CommonConversions.Literal((int)decimalVal) : CommonConversions.Literal((double)decimalVal);
+                            arg = CommonConversions.CreateAttributeArgumentList(CS.SyntaxFactory.AttributeArgument(newLiteral));
+                        }
+                    }
+
+                    if (vbSymbol?.Type?.TypeKind == TypeKind.Struct && vbSymbol?.Type?.SpecialType == SpecialType.None) {
+                        arg = null;
+                    }
+
+                    if (arg != null) {
+                        optionalAttributes.Add(CS.SyntaxFactory.Attribute(ValidSyntaxFactory.IdentifierName("DefaultParameterValue"), arg));
+                    }
                 }
                 attributes.Insert(0,
                     CS.SyntaxFactory.AttributeList(CS.SyntaxFactory.SeparatedList(optionalAttributes)));

--- a/Tests/CSharp/MemberTests/MemberTests.cs
+++ b/Tests/CSharp/MemberTests/MemberTests.cs
@@ -1576,4 +1576,43 @@ BC30455: Argument not specified for parameter 'str3' of 'Private Sub OptionalByR
 CS7036: There is no argument given that corresponds to the required parameter 'str1' of 'MissingByRefArgumentWithNoExplicitDefaultValue.ByRefNoDefault(ref string)'
 ");
     }
+    [Fact]
+    public async Task OptionalByRefParameterAsync886()
+    {
+        await TestConversionVisualBasicToCSharpAsync(@"Class Issue886
+    Private Shared Sub OptionalParams()
+        FunctionWithOptionalParams()
+    End Sub
+
+    Private Shared Sub FunctionWithOptionalParams(Optional ByRef structParam As TestStruct = Nothing, Optional ByRef decimalParam As Decimal = 0)
+        structParam = New TestStruct
+        decimalParam = 0
+    End Sub
+
+    Friend Structure TestStruct
+        Friend A As Boolean
+    End Structure
+End Class", @"using System.Runtime.InteropServices;
+
+internal partial class Issue886
+{
+    private static void OptionalParams()
+    {
+        TestStruct argstructParam = default;
+        decimal argdecimalParam = 0m;
+        FunctionWithOptionalParams(structParam: ref argstructParam, decimalParam: ref argdecimalParam);
+    }
+
+    private static void FunctionWithOptionalParams([Optional] ref TestStruct structParam, [Optional, DefaultParameterValue(0)] ref decimal decimalParam)
+    {
+        structParam = new TestStruct();
+        decimalParam = 0m;
+    }
+
+    internal partial struct TestStruct
+    {
+        internal bool A;
+    }
+}");
+    }
 }


### PR DESCRIPTION
This PR fixes an issue where converting `Optional ByRef` VB.NET parameters initialized with `Nothing` for custom structures or numeric `Decimal` defaults emitted C# code that fails to compile due to C# compiler limitations with `[DefaultParameterValue]`.

Changes:
1. `ExpressionNodeVisitor.cs`: For `[DefaultParameterValue]`, `decimal` parameter primitive defaults now properly emit an equivalent constant `int` or `double` valid attribute expression, without the decimal `m` suffix which is disallowed. For generic structs (`TypeKind.Struct` and `SpecialType.None`), no `DefaultParameterValue` attribute will be generated as custom structs with non-null defaults fail natively on C#.
2. `ArgumentConverter.cs`: Whenever default parameters expand for variable definitions around callers (`ref` arguments), non-nullable structs initialized to `null` instead will yield their expected `default` initialization.
3. Added the expected unit test `OptionalByRefParameterAsync886` and verified it passes correctly alongside all project suites.

---
*PR created automatically by Jules for task [15338263271799288852](https://jules.google.com/task/15338263271799288852) started by @GrahamTheCoder*