### PR TITLE
Add regression test for issue #1091: interface DefaultMember Value access

### DIFF
--- a/Tests/CSharp/MemberTests/DefaultMemberAttributeTests.cs
+++ b/Tests/CSharp/MemberTests/DefaultMemberAttributeTests.cs
@@ -51,4 +51,43 @@ public partial class LoosingProperties
 }
 ");
     }
+
+    /// <summary>
+    /// Regression test for https://github.com/icsharpcode/CodeConverter/issues/1091
+    /// When an interface has [DefaultMember(""Value"")] and VB code explicitly accesses .Value,
+    /// the converter must NOT strip the .Value member access in the C# output.
+    /// </summary>
+    [Fact]
+    public async Task Issue1091_ExplicitAccessToDefaultMemberPropertyIsPreservedAsync()
+    {
+        await TestConversionVisualBasicToCSharpAsync(
+            @"
+<System.Reflection.DefaultMember(""Value"")>
+Public Interface IWithDefaultValue
+    Property Value As Object
+End Interface
+
+Public Module Module1
+    Sub Test(p As IWithDefaultValue)
+        Dim v = p.Value
+        p.Value = v
+    End Sub
+End Module", @"using System.Reflection;
+
+[DefaultMember(""Value"")]
+public partial interface IWithDefaultValue
+{
+    object Value { get; set; }
+}
+
+public static partial class Module1
+{
+    public static void Test(IWithDefaultValue p)
+    {
+        var v = p.Value;
+        p.Value = v;
+    }
+}
+");
+    }
 }


### PR DESCRIPTION
Fixes  #1091 (or actually adds a test for it already having been fixed)

When an interface or type has [DefaultMember("Value")] and VB code explicitly accesses .Value, the converter was incorrectly stripping the member access, producing `p` instead of `p.Value`.

The fix (already in commit 924785a) adds `&& p.Parameters.Any()` to the `isDefaultProperty` check in ConvertMemberAccessExpressionAsync. This ensures only truly indexed (parameterized) default properties are stripped, while parameterless default members like Value retain their explicit access.

This commit adds a regression test covering the exact scenario from issue #1091: an interface with <DefaultMember("Value")> where VB code explicitly reads and writes the .Value property.

https://claude.ai/code/session_01AkwUvu3XuCdj3D4axoX4UX
